### PR TITLE
Input clash handling

### DIFF
--- a/.github/linters/.markdown-link.yml
+++ b/.github/linters/.markdown-link.yml
@@ -1,4 +1,0 @@
-{
-    "MD013": false
-    "MD024:" false
-}

--- a/.github/linters/.markdown-link.yml
+++ b/.github/linters/.markdown-link.yml
@@ -1,3 +1,4 @@
 {
     "MD013": false
+    "MD024:" false
 }

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -12,3 +12,4 @@
 # Rules by tags #
 #################
 no-duplicate-heading: false
+line-length: false

--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,0 +1,14 @@
+---
+###########################
+###########################
+## Markdown Linter rules ##
+###########################
+###########################
+
+# Linter rules doc:
+# - https://github.com/DavidAnson/markdownlint
+
+#################
+# Rules by tags #
+#################
+no-duplicate-heading: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ petitset = "0.1"
 strum = {version = "0.23", features = ["derive"]}
 leafwing_input_manager_macros = "0.1"
 thiserror = "1.0"
+itertools = "0.10"
 
 [dev-dependencies]
 bevy = {version = "0.6", default-features = true}

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ No more characters wandering around while your menu is open!
   - `input_map.insert(Action::Jump, KeyCode::Space)` XOR `input_map.insert(Action::Jump, C)`? Why not both?
 - Full support for arbitrary button combinations: chord your heart out.
   - `input_map.insert_chord(Action::Console, [KeyCode::LCtrl, KeyCode::Shift, KeyCode::C])`
+- Sophisticated input disambiguation with the `ClashStrategy` enum: stop triggering individual buttons when you meant to press a chord!
 - Create an arbitrary number of strongly typed disjoint action sets: decouple your camera and player state.
 - Local multiplayer support: freely bind keys to distinct entities, rather than worrying about singular global state
 - Leafwing Studio's trademark `#![forbid(missing_docs)]`

--- a/README.md
+++ b/README.md
@@ -32,6 +32,8 @@ No more characters wandering around while your menu is open!
 - Sophisticated input disambiguation with the `ClashStrategy` enum: stop triggering individual buttons when you meant to press a chord!
 - Create an arbitrary number of strongly typed disjoint action sets: decouple your camera and player state.
 - Local multiplayer support: freely bind keys to distinct entities, rather than worrying about singular global state
+- Powerful and easy-to-use input mocking API for integration testing your Bevy applications
+  - `app.send_input(KeyCode::B)` or `world.send_input(UserInput::chord([KeyCode::B, KeyCode::E, KeyCode::V, KeyCode::Y])`
 - Leafwing Studio's trademark `#![forbid(missing_docs)]`
 
 ## Limitations

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 - configure how "clashing" inputs should be handled with the `ClashStrategy` field of your `InputMap`
   - very useful for working with modifier keys
   - if two actions are triggered
+- ergonomic input mocking API at both the `App` and `World` level using the `MockInputs` trait
 
 ### Usability
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,7 @@
 - better decoupled `InputMap` and `ActionState`, providing an `InputMap::which_pressed` API and allowing `ActionState::update` to operate based on any `HashSet<A: Actionlike>` of pressed virtual buttons that you pass in
 - `InputMap` now uses a collected `InputStreams` struct in all of its methods, and input methods are now optional
 - `InputManagerPlugin` now works even if some input stream resources are missing
+- added the `input_pressed` method to `InputMap`, to check if a single input is pressed
 
 ### Bug fixes
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,10 @@
 
 ### Enhancements
 
+- configure how "clashing" inputs should be handled with the `ClashStrategy` field of your `InputMap`
+  - very useful for working with modifier keys
+  - if two actions are triggered
+
 ### Usability
 
 - better decoupled `InputMap` and `ActionState`, providing an `InputMap::which_pressed` API and allowing `ActionState::update` to operate based on any `HashSet<A: Actionlike>` of pressed virtual buttons that you pass in

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -1,0 +1,68 @@
+//! Clashes occur when two actions would be triggered by the same combination of buttons
+//! and one input is a strict subset of the other.
+//!
+//! See [`ClashStrategy`] for more details.
+
+use bevy::prelude::*;
+use leafwing_input_manager::clashing_inputs::ClashStrategy;
+use leafwing_input_manager::prelude::*;
+use strum::EnumIter;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(InputManagerPlugin::<TestAction>::default())
+        .add_startup_system(spawn_input_map)
+        .add_system(report_pressed_actions)
+        .run()
+}
+
+#[derive(Actionlike, Debug, Clone, Copy, EnumIter, PartialEq, Eq, Hash)]
+enum TestAction {
+    One,
+    Two,
+    Three,
+    OneAndTwo,
+    OneAndThree,
+    TwoAndThree,
+    OneAndTwoAndThree,
+}
+
+fn spawn_input_map(mut commands: Commands) {
+    use KeyCode::*;
+    use TestAction::*;
+
+    let mut input_map = InputMap::default();
+    // Setting the clash strategy; swap out the variant
+    // to play with different behavior!
+    //input_map.clash_strategy = ClashStrategy::PressAll;
+    input_map.clash_strategy = ClashStrategy::PrioritizeLongest;
+    //input_map.clash_strategy = ClashStrategy::UseActionOrder;
+
+    // Setting up input mappings in the obvious way
+    input_map.insert(One, Key1);
+    input_map.insert(Two, Key2);
+    input_map.insert(Three, Key3);
+
+    input_map.insert_chord(OneAndTwo, [Key1, Key2]);
+    input_map.insert_chord(OneAndThree, [Key1, Key3]);
+    input_map.insert_chord(TwoAndThree, [Key2, Key3]);
+
+    input_map.insert_chord(OneAndTwoAndThree, [Key1, Key2, Key3]);
+
+    commands.spawn_bundle(InputManagerBundle {
+        input_map,
+        ..Default::default()
+    });
+}
+
+fn report_pressed_actions(
+    query: Query<&ActionState<TestAction>, Changed<ActionState<TestAction>>>,
+) {
+    let action_state = query.single();
+    for action in TestAction::iter() {
+        if action_state.just_pressed(action) {
+            dbg!(action);
+        }
+    }
+}

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -522,6 +522,7 @@ mod tests {
             gamepad: None,
             keyboard: Some(&keyboard_input_stream),
             mouse: None,
+            associated_gamepad: None,
         };
 
         // Starting state
@@ -539,6 +540,7 @@ mod tests {
             gamepad: None,
             keyboard: Some(&keyboard_input_stream),
             mouse: None,
+            associated_gamepad: None,
         };
 
         action_state.update(input_map.which_pressed(&input_streams));
@@ -563,6 +565,7 @@ mod tests {
             gamepad: None,
             keyboard: Some(&keyboard_input_stream),
             mouse: None,
+            associated_gamepad: None,
         };
 
         action_state.update(input_map.which_pressed(&input_streams));

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -517,13 +517,7 @@ mod tests {
 
         // Input streams
         let mut keyboard_input_stream = Input::<KeyCode>::default();
-
-        let input_streams = InputStreams {
-            gamepad: None,
-            keyboard: Some(&keyboard_input_stream),
-            mouse: None,
-            associated_gamepad: None,
-        };
+        let input_streams = InputStreams::from_keyboard(&keyboard_input_stream);
 
         // Starting state
         action_state.update(input_map.which_pressed(&input_streams));
@@ -535,13 +529,7 @@ mod tests {
 
         // Pressing
         keyboard_input_stream.press(KeyCode::R);
-
-        let input_streams = InputStreams {
-            gamepad: None,
-            keyboard: Some(&keyboard_input_stream),
-            mouse: None,
-            associated_gamepad: None,
-        };
+        let input_streams = InputStreams::from_keyboard(&keyboard_input_stream);
 
         action_state.update(input_map.which_pressed(&input_streams));
 
@@ -561,12 +549,7 @@ mod tests {
 
         // Releasing
         keyboard_input_stream.release(KeyCode::R);
-        let input_streams = InputStreams {
-            gamepad: None,
-            keyboard: Some(&keyboard_input_stream),
-            mouse: None,
-            associated_gamepad: None,
-        };
+        let input_streams = InputStreams::from_keyboard(&keyboard_input_stream);
 
         action_state.update(input_map.which_pressed(&input_streams));
         assert!(!action_state.pressed(Action::Run));

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -5,8 +5,10 @@ use crate::user_input::{InputButton, UserInput};
 use crate::Actionlike;
 use bevy::input::keyboard::KeyCode;
 use bevy::utils::HashSet;
+use itertools::Itertools;
+use petitset::PetitSet;
 
-/// How should clashing inputs by handled by an [`InputMap`](crate::input_map::InputMap)?
+/// How should clashing inputs by handled by an [`InputMap`]?
 ///
 /// Inputs "clash" if and only if one [`UserInput`] is a strict subset of the other.
 /// By example:
@@ -16,6 +18,9 @@ use bevy::utils::HashSet;
 /// - `S` and `S`: does not clash
 /// - `LControl + S` and `LAlt + S`: clashes
 /// - `LControl + S`, `LAlt + S` and `LControl + LAlt + S`: clashes
+///
+/// This strategy is only used when assessing the actions and input holistically,
+/// in [`InputMap::which_pressed`], using [`InputMap::handle_clashes`].
 #[non_exhaustive]
 #[derive(Clone, PartialEq, Debug)]
 pub enum ClashStrategy {
@@ -79,43 +84,160 @@ impl Default for ClashStrategy {
 }
 
 impl UserInput {
-    /// Is `self` a strict superset of `other`?
-    pub fn contains(&self, other: &UserInput) -> bool {
-        if self == other {
-            false
-        } else {
-            !self.contained_by(other)
-        }
-    }
-
-    /// Is `self` a strict subset of `other`?
-    pub fn contained_by(&self, other: &UserInput) -> bool {
+    /// Does `self` clash with `other`?
+    pub fn clashes(&self, other: &UserInput) -> bool {
         use UserInput::*;
 
         match self {
-            Null => true,
-            Single(button) => match other {
+            Null => false,
+            Single(self_button) => match other {
                 Null => false,
                 Single(_) => false,
-                Chord(button_set) => button_set.contains(button) && button_set.len() > 1,
+                Chord(other_set) => button_chord_clash(self_button, other_set),
             },
             Chord(self_set) => match other {
                 Null => false,
-                Single(_) => false,
-                Chord(other_set) => self_set.is_subset(other_set) && self_set != other_set,
+                Single(other_button) => button_chord_clash(other_button, self_set),
+                Chord(other_set) => chord_chord_clash(self_set, other_set),
             },
         }
     }
 }
 
 impl<A: Actionlike> InputMap<A> {
-    /// Generate all possible clashing input sets
-    pub fn possible_clashes(&self) -> Vec<HashSet<UserInput>> {
-        todo!()
+    /// Resolve clashing inputs, removing action presses that have been overruled
+    pub fn handle_clashes(
+        &self,
+        pressed_actions: &mut HashSet<A>,
+        pressed_inputs: PetitSet<UserInput, 500>,
+    ) {
+        match self.clash_strategy {
+            ClashStrategy::PressAll => (),
+            ClashStrategy::PrioritizeLongest => (),
+            ClashStrategy::PrioritizeModified(_) => (),
+            ClashStrategy::UseActionOrder => (),
+        };
     }
 
-    /// Resolve clashing inputs, returning the set of virtual buttons to press
-    pub fn resolve_clashes(&self) -> HashSet<A> {
-        todo!()
+    /// Gets the set of clashing action-input pairs
+    ///
+    /// Returns both the action and [`UserInput`] for each clashing set
+    pub fn get_clashes(
+        &self,
+        pressed_actions: &HashSet<A>,
+        pressed_inputs: &PetitSet<UserInput, 500>,
+    ) -> Vec<Clash<A>> {
+        let mut clashes = Vec::default();
+
+        for action_pair in pressed_actions.iter().combinations(2) {
+            let action_a = *action_pair.iter().next().unwrap();
+            let action_b = *action_pair.iter().next().unwrap();
+
+            if let Some(clash) = self.clashes(action_a, action_b, pressed_inputs) {
+                clashes.push(clash);
+            }
+        }
+
+        clashes
     }
+
+    /// Is it possible for a pair of actions to clash given the provided input map?
+    // TODO: use this to cache
+    pub fn can_clash(&self, action_a: A, action_b: A) -> bool {
+        for input_a in self.get(action_a, None) {
+            for input_b in self.get(action_b, None) {
+                if input_a.clashes(&input_b) {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Given the `pressed_inputs`, are there any clashes between the two actions?
+    ///
+    /// Returns `Some(clash)` if they are clashing, and `None` if they are not.
+    pub fn clashes(
+        &self,
+        action_a: &A,
+        action_b: &A,
+        pressed_inputs: &PetitSet<UserInput, 500>,
+    ) -> Option<Clash<A>> {
+        let mut clash = Clash::new(action_a.clone(), action_b.clone());
+
+        for input_a in self
+            .get(*action_a, None)
+            .iter()
+            .filter(|input| pressed_inputs.contains(input))
+        {
+            for input_b in self
+                .get(*action_b, None)
+                .iter()
+                .filter(|input| pressed_inputs.contains(input))
+            {
+                if input_a.clashes(&input_b) {
+                    clash.inputs_a.push(input_a.clone());
+                    clash.inputs_b.push(input_a.clone());
+                }
+            }
+        }
+        None
+    }
+}
+
+/// A user-input clash, which stores the actions that are being clashed on,
+/// as well as the corresponding user inputs
+#[derive(Debug, Clone)]
+pub struct Clash<A: Actionlike> {
+    action_a: A,
+    action_b: A,
+    inputs_a: Vec<UserInput>,
+    inputs_b: Vec<UserInput>,
+}
+
+impl<A: Actionlike> Clash<A> {
+    /// Creates a new clash between the two actions
+    fn new(action_a: A, action_b: A) -> Self {
+        Self {
+            action_a,
+            action_b,
+            inputs_a: Vec::default(),
+            inputs_b: Vec::default(),
+        }
+    }
+
+    /// Provides references to the actions that are clashing
+    pub fn actions(&self) -> (&A, &A) {
+        (&self.action_a, &self.action_b)
+    }
+
+    /// Provides references to the inputs that are clashing
+    pub fn inputs(&self) -> (&Vec<UserInput>, &Vec<UserInput>) {
+        (&self.inputs_a, &self.inputs_b)
+    }
+}
+
+/// Does the `button` clash with the `chord`?
+fn button_chord_clash(button: &InputButton, chord: &PetitSet<InputButton, 8>) -> bool {
+    if chord.len() <= 1 {
+        return false;
+    }
+
+    chord.contains(button)
+}
+
+/// Does the `chord_a` clash with `chord_b`?
+fn chord_chord_clash(
+    chord_a: &PetitSet<InputButton, 8>,
+    chord_b: &PetitSet<InputButton, 8>,
+) -> bool {
+    if chord_a.len() <= 1 || chord_b.len() <= 1 {
+        return false;
+    }
+
+    if chord_a == chord_b {
+        return false;
+    }
+
+    chord_a.is_subset(chord_b) || chord_b.is_subset(chord_a)
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -301,7 +301,21 @@ pub fn resolve_clash<A: Actionlike>(
         }
         // Remove the clashing action wtih the fewest modifier keys
         ClashStrategy::PrioritizeModified => todo!(),
-        // Remove the clashing action that comes later in the pair
-        ClashStrategy::UseActionOrder => todo!(),
+        // Remove the clashing action that comes later in the action enum
+        ClashStrategy::UseActionOrder => {
+            let mut action_to_remove = None;
+            for action in A::iter() {
+                if action == clash.action_a {
+                    action_to_remove = Some(clash.action_b);
+                    break;
+                }
+
+                if action == clash.action_b {
+                    action_to_remove = Some(clash.action_a);
+                    break;
+                }
+            }
+            action_to_remove
+        }
     }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -464,7 +464,7 @@ mod tests {
                 &simple_clash,
                 &ClashStrategy::PrioritizeLongest,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(One)
         );
@@ -475,7 +475,7 @@ mod tests {
                 &reversed_clash,
                 &ClashStrategy::PrioritizeLongest,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(One)
         );
@@ -492,7 +492,7 @@ mod tests {
                 &chord_clash,
                 &ClashStrategy::PrioritizeLongest,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(OneAndTwo)
         );
@@ -516,7 +516,7 @@ mod tests {
                 &simple_clash,
                 &ClashStrategy::PrioritizeModified,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(One)
         );
@@ -531,7 +531,7 @@ mod tests {
                 &chord_clash,
                 &ClashStrategy::PrioritizeModified,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(CtrlOne)
         );
@@ -556,7 +556,7 @@ mod tests {
                 &simple_clash,
                 &ClashStrategy::UseActionOrder,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(CtrlOne)
         );
@@ -566,7 +566,7 @@ mod tests {
                 &reversed_clash,
                 &ClashStrategy::UseActionOrder,
                 &input_streams,
-                &HashSet::default(),
+                &input_map.modifier_buttons,
             ),
             Some(CtrlOne)
         );

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,6 +1,8 @@
 //! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
 
+use crate::input_map::InputMap;
 use crate::user_input::{InputButton, UserInput};
+use crate::Actionlike;
 use bevy::input::keyboard::KeyCode;
 use bevy::utils::HashSet;
 
@@ -20,8 +22,6 @@ pub enum ClashStrategy {
     /// All matching inputs will always be pressed
     PressAll,
     /// Only press the action that corresponds to the longest chord
-    ///
-    /// In the case of a tie, all tied actions will be pressed.
     PrioritizeLongest,
     /// If the [`UserInput`] contains a modifier key, press that action over any unmodified action.
     ///
@@ -105,5 +105,17 @@ impl UserInput {
                 Chord(other_set) => self_set.is_subset(other_set) && self_set != other_set,
             },
         }
+    }
+}
+
+impl<A: Actionlike> InputMap<A> {
+    /// Generate all possible clashing input sets
+    pub fn possible_clashes(&self) -> Vec<HashSet<UserInput>> {
+        todo!()
+    }
+
+    /// Resolve clashing inputs, returning the set of virtual buttons to press
+    pub fn resolve_clashes(&self) -> HashSet<A> {
+        todo!()
     }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -84,7 +84,7 @@ impl<A: Actionlike> InputMap<A> {
     }
 
     /// Updates the cache of possible input clashes
-    pub fn cache_possible_clashes(&mut self) {
+    pub(crate) fn cache_possible_clashes(&mut self) {
         let mut clashes = Vec::default();
 
         for action_pair in A::iter().combinations(2) {

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -26,9 +26,9 @@ pub enum ClashStrategy {
     /// If the [`UserInput`] contains a modifier key, press that action over any unmodified action.
     ///
     /// If more than one matching action uses a modifier, break ties based on number of modifiers.
-    /// If a tie persists, press all of them.
+    /// Further ties are broken using the `PrioritizeLongest` rule.
     PrioritizeModified(HashSet<InputButton>),
-    /// Use the order in which actions are defined in the enum to break ties
+    /// Use the order in which actions are defined in the enum to resolve clashing inputs
     ///
     /// Uses the iteration order returned by [IntoEnumIterator](crate::IntoEnumIterator),
     /// which is generated in order of the enum items by the `#[derive(EnumIter)]` macro.

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -48,6 +48,7 @@ impl Default for ClashStrategy {
 
 impl UserInput {
     /// Does `self` clash with `other`?
+    #[must_use]
     fn clashes(&self, other: &UserInput) -> bool {
         use UserInput::*;
 
@@ -109,6 +110,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Gets the set of clashing action-input pairs
     ///
     /// Returns both the action and [`UserInput`]s for each clashing set
+    #[must_use]
     fn get_clashes(
         &self,
         pressed_actions: &HashSet<A>,
@@ -136,6 +138,7 @@ impl<A: Actionlike> InputMap<A> {
     }
 
     /// If the pair of actions could clash, how?
+    #[must_use]
     fn possible_clash(&self, action_a: &A, action_b: &A) -> Option<Clash<A>> {
         let mut clash = Clash::new(*action_a, *action_b);
 
@@ -168,6 +171,7 @@ pub(crate) struct Clash<A: Actionlike> {
 
 impl<A: Actionlike> Clash<A> {
     /// Creates a new clash between the two actions
+    #[must_use]
     fn new(action_a: A, action_b: A) -> Self {
         Self {
             action_a,
@@ -179,6 +183,7 @@ impl<A: Actionlike> Clash<A> {
 }
 
 /// Does the `button` clash with the `chord`?
+#[must_use]
 fn button_chord_clash(button: &InputButton, chord: &PetitSet<InputButton, 8>) -> bool {
     if chord.len() <= 1 {
         return false;
@@ -188,6 +193,7 @@ fn button_chord_clash(button: &InputButton, chord: &PetitSet<InputButton, 8>) ->
 }
 
 /// Does the `chord_a` clash with `chord_b`?
+#[must_use]
 fn chord_chord_clash(
     chord_a: &PetitSet<InputButton, 8>,
     chord_b: &PetitSet<InputButton, 8>,
@@ -206,6 +212,7 @@ fn chord_chord_clash(
 /// Given the `input_streams`, does the provided clash actually occur?
 ///
 /// Returns `Some(clash)` if they are clashing, and `None` if they are not.
+#[must_use]
 fn check_clash<A: Actionlike>(clash: &Clash<A>, input_streams: &InputStreams) -> Option<Clash<A>> {
     let mut actual_clash = Clash::new(clash.action_a, clash.action_b);
 
@@ -237,6 +244,7 @@ fn check_clash<A: Actionlike>(clash: &Clash<A>, input_streams: &InputStreams) ->
 }
 
 /// Which (if any) of the actions in the [`Clash`] should be discarded?
+#[must_use]
 fn resolve_clash<A: Actionlike>(
     clash: &Clash<A>,
     clash_strategy: &ClashStrategy,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -631,6 +631,4 @@ mod tests {
             );
         }
     }
-
-    mod regression_tests {}
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -27,6 +27,8 @@ pub enum ClashStrategy {
     /// All matching inputs will always be pressed
     PressAll,
     /// Only press the action that corresponds to the longest chord
+    ///
+    /// This is the default strategy.
     PrioritizeLongest,
     /// Use the order in which actions are defined in the enum to resolve clashing inputs
     ///
@@ -37,7 +39,7 @@ pub enum ClashStrategy {
 
 impl Default for ClashStrategy {
     fn default() -> Self {
-        ClashStrategy::PressAll
+        ClashStrategy::PrioritizeLongest
     }
 }
 

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -593,4 +593,23 @@ mod tests {
 
         assert_eq!(pressed_actions, HashSet::from_iter([OneAndTwo]));
     }
+
+    #[test]
+    fn which_pressed() {
+        use bevy::prelude::*;
+        use Action::*;
+
+        let mut input_map = test_input_map();
+        input_map.clash_strategy = ClashStrategy::PrioritizeLongest;
+
+        let mut keyboard: Input<KeyCode> = Default::default();
+        keyboard.press(Key1);
+        keyboard.press(Key2);
+        keyboard.press(LControl);
+
+        assert_eq!(
+            input_map.which_pressed(&InputStreams::from_keyboard(&keyboard)),
+            HashSet::from_iter([CtrlOne, OneAndTwo])
+        );
+    }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -71,7 +71,7 @@ impl<A: Actionlike> InputMap<A> {
     pub fn handle_clashes(
         &self,
         _pressed_actions: &mut HashSet<A>,
-        _pressed_inputs: PetitSet<UserInput, 500>,
+        _pressed_inputs: HashSet<UserInput>,
     ) {
         match self.clash_strategy {
             ClashStrategy::PressAll => (),
@@ -87,7 +87,7 @@ impl<A: Actionlike> InputMap<A> {
     pub fn get_clashes(
         &self,
         pressed_actions: &HashSet<A>,
-        pressed_inputs: &PetitSet<UserInput, 500>,
+        pressed_inputs: &HashSet<UserInput>,
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
 
@@ -209,7 +209,7 @@ fn chord_chord_clash(
 /// Returns `Some(clash)` if they are clashing, and `None` if they are not.
 pub fn check_clash<A: Actionlike>(
     clash: &Clash<A>,
-    pressed_inputs: &PetitSet<UserInput, 500>,
+    pressed_inputs: &HashSet<UserInput>,
 ) -> Option<Clash<A>> {
     let mut actual_clash = Clash::new(clash.action_a, clash.action_b);
 

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -71,6 +71,13 @@ impl<A: Actionlike> InputMap<A> {
     /// Resolve clashing inputs, removing action presses that have been overruled
     pub fn handle_clashes(&self, pressed_actions: &mut HashSet<A>, input_streams: &InputStreams) {
         for clash in self.get_clashes(pressed_actions, input_streams) {
+            // Skip clashes whose actions were not pressed
+            if !pressed_actions.contains(&clash.action_a)
+                & !pressed_actions.contains(&clash.action_b)
+            {
+                continue;
+            }
+
             // Remove the action in the pair that was overruled, if any
             if let Some(culled_action) = resolve_clash(
                 &clash,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -571,4 +571,26 @@ mod tests {
             Some(CtrlOne)
         );
     }
+
+    #[test]
+    fn handle_clashes() {
+        use bevy::prelude::*;
+        use Action::*;
+
+        let mut input_map = test_input_map();
+        input_map.clash_strategy = ClashStrategy::PrioritizeLongest;
+
+        let mut keyboard: Input<KeyCode> = Default::default();
+        keyboard.press(Key1);
+        keyboard.press(Key2);
+
+        let mut pressed_actions = HashSet::from_iter([One, Two, OneAndTwo]);
+
+        input_map.handle_clashes(
+            &mut pressed_actions,
+            &InputStreams::from_keyboard(&keyboard),
+        );
+
+        assert_eq!(pressed_actions, HashSet::from_iter([OneAndTwo]));
+    }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -70,15 +70,15 @@ impl<A: Actionlike> InputMap<A> {
     /// Resolve clashing inputs, removing action presses that have been overruled
     pub fn handle_clashes(
         &self,
-        _pressed_actions: &mut HashSet<A>,
-        _pressed_inputs: HashSet<UserInput>,
+        pressed_actions: &mut HashSet<A>,
+        pressed_inputs: &HashSet<UserInput>,
     ) {
-        match self.clash_strategy {
-            ClashStrategy::PressAll => (),
-            ClashStrategy::PrioritizeLongest => (),
-            ClashStrategy::PrioritizeModified => (),
-            ClashStrategy::UseActionOrder => (),
-        };
+        for clash in self.get_clashes(pressed_actions, pressed_inputs) {
+            // Remove the action in the pair that was overruled, if any
+            if let Some(culled_action) = resolve_clash(clash, pressed_inputs) {
+                pressed_actions.remove(culled_action);
+            }
+        }
     }
 
     /// Gets the set of clashing action-input pairs
@@ -237,5 +237,23 @@ pub fn check_clash<A: Actionlike>(
         Some(actual_clash)
     } else {
         None
+    }
+}
+
+/// Which (if any) of the actions in the [`Clash`] should be discarded?
+pub fn resolve_clash<A: Actionlike>(
+    clash: Clash,
+    clash_strategy: ClashStrategy,
+    pressed_inputs: HashSet<UserInput>,
+) -> Option<A> {
+    match clash_strategy {
+        // Do nothing
+        ClashStrategy::PressAll => None,
+        // Remove the clashing action with the shorter chord
+        ClashStrategy::PrioritizeLongest => todo!(),
+        // Remove the clashing action wtih the fewest modifier keys
+        ClashStrategy::PrioritizeModified => todo!(),
+        // Remove the clashing action that comes later in the pair
+        ClashStrategy::UseActionOrder => todo!(),
     }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,0 +1,109 @@
+//! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
+
+use crate::user_input::{InputButton, UserInput};
+use bevy::input::keyboard::KeyCode;
+use bevy::utils::HashSet;
+
+/// How should clashing inputs by handled by an [`InputMap`](crate::input_map::InputMap)?
+///
+/// Inputs "clash" if and only if one [`UserInput`] is a strict subset of the other.
+/// By example:
+///
+/// - `S` and `W`: does not clash
+/// - `LControl + S` and `S`: clashes
+/// - `S` and `S`: does not clash
+/// - `LControl + S` and `LAlt + S`: clashes
+/// - `LControl + S`, `LAlt + S` and `LControl + LAlt + S`: clashes
+#[non_exhaustive]
+#[derive(Clone, PartialEq, Debug)]
+pub enum ClashStrategy {
+    /// All matching inputs will always be pressed
+    PressAll,
+    /// Only press the action that corresponds to the longest chord
+    ///
+    /// In the case of a tie, all tied actions will be pressed.
+    PrioritizeLongest,
+    /// If the [`UserInput`] contains a modifier key, press that action over any unmodified action.
+    ///
+    /// If more than one matching action uses a modifier, break ties based on number of modifiers.
+    /// If a tie persists, press all of them.
+    PrioritizeModified(HashSet<InputButton>),
+    /// Use the order in which actions are defined in the enum to break ties
+    ///
+    /// Uses the iteration order returned by [IntoEnumIterator](crate::IntoEnumIterator),
+    /// which is generated in order of the enum items by the `#[derive(EnumIter)]` macro.
+    UseActionOrder,
+}
+
+impl ClashStrategy {
+    /// Creates a `ClashStrategy::PrioritizeModified` variant with the standard keyboard modifiers
+    ///
+    /// The list added is `[LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]`
+    pub fn default_modifiers() -> ClashStrategy {
+        use KeyCode::*;
+
+        Self::custom_modifiers([LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin])
+    }
+
+    /// Creates a `ClashStrategy::PrioritizeModified` variant with a custom set of modifiers
+    ///
+    /// These do not need to all be keyboard modifiers,
+    /// although the iterator passed in must have a homogenous item type.
+    ///
+    /// # Example
+    /// ```rust
+    /// use leafwing_input_manager::user_input::InputButton;
+    /// use leafwing_input_manger::clashing_inputs::ClashStrategy;
+    ///
+    /// let clash_strategy = ClashStrategy::custom_modifiers(
+    /// 	[InputButton::Keyboard(KeyCode::LControl),
+    /// 	 InputButton::Mouse(MouseButton::Left),
+    ///      InputButton::Gamepad(GamepadButtonType::LeftTrigger),
+    /// 	]
+    /// )
+    /// ```
+    pub fn custom_modifiers(
+        modifiers: impl IntoIterator<Item = impl Into<InputButton>>,
+    ) -> ClashStrategy {
+        let hash_set: HashSet<InputButton> =
+            HashSet::from_iter(modifiers.into_iter().map(|buttonlike| buttonlike.into()));
+
+        ClashStrategy::PrioritizeModified(hash_set)
+    }
+}
+
+impl Default for ClashStrategy {
+    fn default() -> Self {
+        ClashStrategy::PressAll
+    }
+}
+
+impl UserInput {
+    /// Is `self` a strict superset of `other`?
+    pub fn contains(&self, other: &UserInput) -> bool {
+        if self == other {
+            false
+        } else {
+            !self.contained_by(other)
+        }
+    }
+
+    /// Is `self` a strict subset of `other`?
+    pub fn contained_by(&self, other: &UserInput) -> bool {
+        use UserInput::*;
+
+        match self {
+            Null => true,
+            Single(button) => match other {
+                Null => false,
+                Single(_) => false,
+                Chord(button_set) => button_set.contains(button) && button_set.len() > 1,
+            },
+            Chord(self_set) => match other {
+                Null => false,
+                Single(_) => false,
+                Chord(other_set) => self_set.is_subset(other_set) && self_set != other_set,
+            },
+        }
+    }
+}

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -217,7 +217,7 @@ fn check_clash<A: Actionlike>(clash: &Clash<A>, input_streams: &InputStreams) ->
             // If a clash was detected,
             if input_a.clashes(input_b) {
                 actual_clash.inputs_a.push(input_a.clone());
-                actual_clash.inputs_b.push(input_a.clone());
+                actual_clash.inputs_b.push(input_b.clone());
             }
         }
     }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -21,7 +21,7 @@ use petitset::PetitSet;
 /// This strategy is only used when assessing the actions and input holistically,
 /// in [`InputMap::which_pressed`], using [`InputMap::handle_clashes`].
 #[non_exhaustive]
-#[derive(Clone, PartialEq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub enum ClashStrategy {
     /// All matching inputs will always be pressed
     PressAll,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -93,9 +93,9 @@ impl<A: Actionlike> InputMap<A> {
 
         for action_pair in A::iter().combinations(2) {
             let action_a = *action_pair.get(0).unwrap();
-            let action_b = *action_pair.get(0).unwrap();
+            let action_b = *action_pair.get(1).unwrap();
 
-            if let Some(clash) = self.can_clash(&action_a, &action_b) {
+            if let Some(clash) = self.possible_clash(&action_a, &action_b) {
                 clashes.push(clash);
             }
         }
@@ -132,15 +132,15 @@ impl<A: Actionlike> InputMap<A> {
         clashes
     }
 
-    /// Is it possible for a pair of actions to clash given the provided input map?
-    fn can_clash(&self, action_a: &A, action_b: &A) -> Option<Clash<A>> {
+    /// If the pair of actions could clash, how?
+    fn possible_clash(&self, action_a: &A, action_b: &A) -> Option<Clash<A>> {
         let mut clash = Clash::new(*action_a, *action_b);
 
         for input_a in self.get(*action_a, None) {
             for input_b in self.get(*action_b, None) {
                 if input_a.clashes(&input_b) {
                     clash.inputs_a.push(input_a.clone());
-                    clash.inputs_b.push(input_a.clone());
+                    clash.inputs_b.push(input_b.clone());
                 }
             }
         }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -436,10 +436,21 @@ mod tests {
 
     #[test]
     fn clash_caching() {
-        let mut input_map = test_input_map(ClashStrategy::PressAll);
-        assert!(input_map.possible_clashes.is_empty());
+        use crate::user_input::InputMode;
 
-        input_map.cache_possible_clashes();
+        let mut input_map = test_input_map(ClashStrategy::PressAll);
+        // Possible clashes are cached upon initialization
         assert_eq!(input_map.possible_clashes.len(), 12);
+
+        // Possible clashes are cached upon binding insertion
+        input_map.insert(Action::Two, UserInput::chord([LControl, LAlt, Key1]));
+        assert_eq!(input_map.possible_clashes.len(), 15);
+
+        // Possible clashes are cached upon binding removal
+        input_map.clear_action(Action::One, None);
+        assert_eq!(input_map.possible_clashes.len(), 9);
+
+        input_map.clear_action(Action::Two, Some(InputMode::Keyboard));
+        assert_eq!(input_map.possible_clashes.len(), 4);
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -131,7 +131,7 @@ impl<A: Actionlike> InputMap<A> {
 
         // Handle clashing inputs, possibly removing some pressed actions from the list
         if self.clash_strategy != ClashStrategy::PressAll {
-            self.handle_clashes(&mut pressed_actions, &input_streams);
+            self.handle_clashes(&mut pressed_actions, input_streams);
         }
 
         pressed_actions

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -141,7 +141,10 @@ impl<A: Actionlike> InputMap<A> {
 
     /// Returns a [`HashSet`] of the virtual buttons that are currently pressed
     ///
-    /// Accounts for clashing inputs according to the [`ClashStrategy`]
+    /// Accounts for clashing inputs according to the [`ClashStrategy`].
+    ///
+    /// Remember to ensure that the clash cache is fresh by calling [`InputMap::cache_possible_clashes]
+    /// before using this method!
     pub fn which_pressed(&self, input_streams: &InputStreams) -> HashSet<A> {
         let mut pressed_actions = HashSet::default();
         let mut pressed_inputs = HashSet::default();

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -144,7 +144,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Accounts for clashing inputs according to the [`ClashStrategy`]
     pub fn which_pressed(&self, input_streams: &InputStreams) -> HashSet<A> {
         let mut pressed_actions = HashSet::default();
-        let mut pressed_inputs = PetitSet::default();
+        let mut pressed_inputs = HashSet::default();
 
         // Generate the raw action presses
         for action in A::iter() {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -143,7 +143,7 @@ impl<A: Actionlike> InputMap<A> {
     ///
     /// Accounts for clashing inputs according to the [`ClashStrategy`].
     ///
-    /// Remember to ensure that the clash cache is fresh by calling [`InputMap::cache_possible_clashes]
+    /// Remember to ensure that the clash cache is fresh by calling [`InputMap::cache_possible_clashes`]
     /// before using this method!
     pub fn which_pressed(&self, input_streams: &InputStreams) -> HashSet<A> {
         let mut pressed_actions = HashSet::default();

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -821,7 +821,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         // With no inputs, nothing should be detected
@@ -836,7 +836,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
         for action in Action::iter() {
             assert!(!input_map.pressed(action, &input_streams));
@@ -849,7 +849,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         assert!(input_map.pressed(Action::Run, &input_streams));
@@ -862,7 +862,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         assert!(input_map.pressed(Action::Run, &input_streams));
@@ -874,7 +874,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         for action in Action::iter() {
@@ -888,7 +888,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         assert!(input_map.pressed(Action::Run, &input_streams));
@@ -904,7 +904,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         assert!(input_map.pressed(Action::Run, &input_streams));
@@ -920,7 +920,7 @@ mod tests {
             gamepad: Some(&gamepad_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
-            associated_gamepad: None,
+            associated_gamepad: Some(Gamepad(42)),
         };
 
         assert!(input_map.pressed(Action::Hide, &input_streams));

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -3,7 +3,6 @@
 use crate::clashing_inputs::{Clash, ClashStrategy};
 use crate::user_input::{InputButton, InputMode, InputStreams, UserInput};
 use crate::{Actionlike, IntoEnumIterator};
-use bevy::input::keyboard::KeyCode;
 use bevy::prelude::*;
 use bevy::utils::{HashMap, HashSet};
 use core::fmt::Debug;
@@ -58,7 +57,7 @@ use petitset::PetitSet;
 /// // But you can't Hide :(
 /// input_map.clear_action(Action::Hide, None);
 ///```
-#[derive(Component, Debug, Clone)]
+#[derive(Component, Debug, Clone, PartialEq)]
 pub struct InputMap<A: Actionlike> {
     /// The raw [HashMap] of [PetitSet]s used to store the input mapping
     pub map: HashMap<A, PetitSet<UserInput, 16>>,
@@ -68,28 +67,10 @@ pub struct InputMap<A: Actionlike> {
     pub clash_strategy: ClashStrategy,
     /// A cached list of all pairs of actions that could potentially clash
     pub(crate) possible_clashes: Vec<Clash<A>>,
-    /// Buttons that act like modifier keys, for the purpose of clash resolution
-    ///
-    /// By default, these are the [`KeyCode']s
-    /// `[LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]`
-    pub modifier_buttons: HashSet<InputButton>,
-}
-
-impl<A: Actionlike> PartialEq for InputMap<A> {
-    /// [`InputMap`] equality ignores the cached `possible_clashes` field
-    fn eq(&self, other: &Self) -> bool {
-        self.map == other.map
-            && self.per_mode_cap == other.per_mode_cap
-            && self.associated_gamepad == other.associated_gamepad
-            && self.clash_strategy == other.clash_strategy
-            && self.modifier_buttons == other.modifier_buttons
-    }
 }
 
 impl<A: Actionlike> Default for InputMap<A> {
     fn default() -> Self {
-        use KeyCode::*;
-
         InputMap {
             map: HashMap::default(),
             associated_gamepad: None,
@@ -98,10 +79,6 @@ impl<A: Actionlike> Default for InputMap<A> {
             clash_strategy: ClashStrategy::PressAll,
             // Empty input maps cannot have any clashes
             possible_clashes: Vec::default(),
-            modifier_buttons: HashSet::from_iter(
-                [LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]
-                    .map(|keycode| keycode.into()),
-            ),
         }
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,7 +1,7 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
 use crate::clashing_inputs::ClashStrategy;
-use crate::user_input::{InputButton, InputMode, UserInput};
+use crate::user_input::{InputButton, InputMode, InputStreams, UserInput};
 use crate::{Actionlike, IntoEnumIterator};
 use bevy::prelude::*;
 use bevy::utils::{HashMap, HashSet};

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,7 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
-use crate::user_input::{InputButton, InputMode, InputStreams, UserInput};
+use crate::clashing_inputs::ClashStrategy;
+use crate::user_input::{InputButton, InputMode, UserInput};
 use crate::{Actionlike, IntoEnumIterator};
 use bevy::prelude::*;
 use bevy::utils::{HashMap, HashSet};
@@ -19,6 +20,11 @@ use petitset::PetitSet;
 ///
 /// In addition, you can configure the per-mode cap for each [`InputMode`] using [`InputMap::new`] or [`InputMap::set_per_mode_cap`].
 /// This can be useful if your UI can only display one or two possible keybindings for each input mode.
+///
+/// By default, pressing a single button (or combination of buttons) can cause any number of actions to be triggered.
+/// For example, pressing both `S` and `Ctrl + S` in your text editor app would both enter the letter `s` and save your file.
+/// Set the `clashing_inputs` field of this struct with the [`ClashingInputs`] enum to configure
+/// how the input map should handle these cases.
 ///
 /// # Example
 /// ```rust
@@ -55,6 +61,8 @@ use petitset::PetitSet;
 pub struct InputMap<A: Actionlike> {
     /// The raw [HashMap] of [PetitSet]s used to store the input mapping
     pub map: HashMap<A, PetitSet<UserInput, 16>>,
+    /// How should overlapping inputs be handled?
+    pub clashing_inputs: ClashStrategy,
     per_mode_cap: Option<usize>,
     associated_gamepad: Option<Gamepad>,
 }
@@ -65,6 +73,8 @@ impl<A: Actionlike> Default for InputMap<A> {
             map: HashMap::default(),
             associated_gamepad: None,
             per_mode_cap: None,
+            // This is the simplest, least surprising behavior.
+            clashing_inputs: ClashStrategy::PressAll,
         }
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -3,6 +3,7 @@
 use crate::clashing_inputs::ClashStrategy;
 use crate::user_input::{InputButton, InputMode, InputStreams, UserInput};
 use crate::{Actionlike, IntoEnumIterator};
+use bevy::input::keyboard::KeyCode;
 use bevy::prelude::*;
 use bevy::utils::{HashMap, HashSet};
 use core::fmt::Debug;
@@ -65,16 +66,27 @@ pub struct InputMap<A: Actionlike> {
     associated_gamepad: Option<Gamepad>,
     /// How should clashing (overlapping) inputs be handled?
     pub clash_strategy: ClashStrategy,
+    /// Buttons that act like modifier keys, for the purpose of clash resolution
+    ///
+    /// By default, these are the [`KeyCode']s
+    /// `[LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]`
+    pub modifier_buttons: HashSet<InputButton>,
 }
 
 impl<A: Actionlike> Default for InputMap<A> {
     fn default() -> Self {
+        use KeyCode::*;
+
         Self {
             map: HashMap::default(),
             associated_gamepad: None,
             per_mode_cap: None,
             // This is the simplest, least surprising behavior.
             clash_strategy: ClashStrategy::PressAll,
+            modifier_buttons: HashSet::from_iter(
+                [LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]
+                    .map(|keycode| keycode.into()),
+            ),
         }
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -160,7 +160,9 @@ impl<A: Actionlike> InputMap<A> {
         }
 
         // Handle clashing inputs, possibly removing some pressed actions from the list
-        self.handle_clashes(&mut pressed_actions, pressed_inputs);
+        if self.clash_strategy != ClashStrategy::PressAll {
+            self.handle_clashes(&mut pressed_actions, &pressed_inputs);
+        }
 
         pressed_actions
     }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -21,10 +21,12 @@ use petitset::PetitSet;
 /// In addition, you can configure the per-mode cap for each [`InputMode`] using [`InputMap::new`] or [`InputMap::set_per_mode_cap`].
 /// This can be useful if your UI can only display one or two possible keybindings for each input mode.
 ///
-/// By default, pressing a single button (or combination of buttons) can cause any number of actions to be triggered.
-/// For example, pressing both `S` and `Ctrl + S` in your text editor app would both enter the letter `s` and save your file.
-/// Set the `clashing_inputs` field of this struct with the [`ClashingInputs`] enum to configure
-/// how the input map should handle these cases.
+/// By default, if two actions would be triggered by a combination of buttons,
+/// and one combination is a strict subset of the other, only the larger input is registered.
+/// For example, pressing both `S` and `Ctrl + S` in your text editor app would save your file,
+/// but not enter the letters `s`.
+/// Set the `clashing_inputs` field of this struct with the [`ClashingInputs`] enum
+/// to configure this behavior.
 ///
 /// # Example
 /// ```rust
@@ -75,8 +77,8 @@ impl<A: Actionlike> Default for InputMap<A> {
             map: HashMap::default(),
             associated_gamepad: None,
             per_mode_cap: None,
-            // This is the simplest, least surprising behavior.
-            clash_strategy: ClashStrategy::PressAll,
+            // This is the most commonly useful behavior.
+            clash_strategy: ClashStrategy::PrioritizeLongest,
             // Empty input maps cannot have any clashes
             possible_clashes: Vec::default(),
         }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -129,23 +129,17 @@ impl<A: Actionlike> InputMap<A> {
 impl<A: Actionlike> InputMap<A> {
     /// Is at least one of the corresponding inputs for `action` found in the provided `input` streams?
     ///
-    /// Does not check for clashing inputs.
+    /// Accounts for clashing inputs according to the [`ClashStrategy`].
+    /// If you need to inspect many inputs at once, prefer [`InputMap::which_pressed`] instead.
     #[must_use]
     pub fn pressed(&self, action: A, input_streams: &InputStreams) -> bool {
-        if let Some(matching_inputs) = self.map.get(&action) {
-            input_streams.any_pressed(matching_inputs)
-        } else {
-            // No matches can be found if no inputs are registred for that action
-            false
-        }
+        let pressed_set = self.which_pressed(input_streams);
+        pressed_set.contains(&action)
     }
 
     /// Returns a [`HashSet`] of the virtual buttons that are currently pressed
     ///
     /// Accounts for clashing inputs according to the [`ClashStrategy`].
-    ///
-    /// Remember to ensure that the clash cache is fresh by calling [`InputMap::cache_possible_clashes`]
-    /// before using this method!
     pub fn which_pressed(&self, input_streams: &InputStreams) -> HashSet<A> {
         let mut pressed_actions = HashSet::default();
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,6 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
-use crate::clashing_inputs::ClashStrategy;
+use crate::clashing_inputs::{Clash, ClashStrategy};
 use crate::user_input::{InputButton, InputMode, InputStreams, UserInput};
 use crate::{Actionlike, IntoEnumIterator};
 use bevy::input::keyboard::KeyCode;
@@ -58,7 +58,7 @@ use petitset::PetitSet;
 /// // But you can't Hide :(
 /// input_map.clear_action(Action::Hide, None);
 ///```
-#[derive(Component, Debug, Clone, PartialEq)]
+#[derive(Component, Debug, Clone)]
 pub struct InputMap<A: Actionlike> {
     /// The raw [HashMap] of [PetitSet]s used to store the input mapping
     pub map: HashMap<A, PetitSet<UserInput, 16>>,
@@ -66,11 +66,24 @@ pub struct InputMap<A: Actionlike> {
     associated_gamepad: Option<Gamepad>,
     /// How should clashing (overlapping) inputs be handled?
     pub clash_strategy: ClashStrategy,
+    /// A cached list of all pairs of actions that could potentially clash
+    pub(crate) possible_clashes: Vec<Clash<A>>,
     /// Buttons that act like modifier keys, for the purpose of clash resolution
     ///
     /// By default, these are the [`KeyCode']s
     /// `[LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]`
     pub modifier_buttons: HashSet<InputButton>,
+}
+
+impl<A: Actionlike> PartialEq for InputMap<A> {
+    /// [`InputMap`] equality ignores the cached `possible_clashes` field
+    fn eq(&self, other: &Self) -> bool {
+        self.map == other.map
+            && self.per_mode_cap == other.per_mode_cap
+            && self.associated_gamepad == other.associated_gamepad
+            && self.clash_strategy == other.clash_strategy
+            && self.modifier_buttons == other.modifier_buttons
+    }
 }
 
 impl<A: Actionlike> Default for InputMap<A> {
@@ -83,6 +96,7 @@ impl<A: Actionlike> Default for InputMap<A> {
             per_mode_cap: None,
             // This is the simplest, least surprising behavior.
             clash_strategy: ClashStrategy::PressAll,
+            possible_clashes: Vec::default(),
             modifier_buttons: HashSet::from_iter(
                 [LAlt, RAlt, LControl, RControl, LShift, RShift, LWin, RWin]
                     .map(|keycode| keycode.into()),

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -21,16 +21,17 @@ use bevy::input::{
 /// use bevy::prelude::*;
 /// use leafwing_input_manager::MockInput;
 ///
-/// let world = World::new();
+/// let mut world = World::new();
 ///
 /// // Pay respects!
 /// world.send_input(KeyCode::F);
 /// ```
 ///
 /// ```rust
-/// /// use bevy::prelude::*;
-/// use leafwing_input_manager::MockInput;
-/// let app = App::new();
+/// use bevy::prelude::*;
+/// use leafwing_input_manager::{MockInput, user_input::UserInput};
+///
+/// let mut app = App::new();
 ///
 /// // Send inputs one at a time
 /// let B_E_V_Y = [KeyCode::B, KeyCode::E, KeyCode::V, KeyCode::Y];

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -36,7 +36,7 @@ use bevy::input::{
 /// let B_E_V_Y = [KeyCode::B, KeyCode::E, KeyCode::V, KeyCode::Y];
 ///
 /// for letter in B_E_V_Y {
-/// 	app.send_input(letter);
+///     app.send_input(letter);
 /// }
 ///
 /// // Or use chords!
@@ -105,19 +105,19 @@ impl<'a> MutableInputStreams<'a> {
             }
         };
 
-        if let Some(gamepad_input) = self.gamepad.as_deref_mut() {
+        if let Some(ref mut gamepad_input) = self.gamepad {
             for button in gamepad_buttons {
                 gamepad_input.press(button);
             }
         }
 
-        if let Some(keyboard_input) = self.keyboard.as_deref_mut() {
+        if let Some(ref mut keyboard_input) = self.keyboard {
             for button in keyboard_buttons {
                 keyboard_input.press(button);
             }
         }
 
-        if let Some(mouse_input) = self.mouse.as_deref_mut() {
+        if let Some(ref mut mouse_input) = self.mouse {
             for button in mouse_buttons {
                 mouse_input.press(button);
             }

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -67,11 +67,7 @@ impl<'a> MutableInputStreams<'a> {
     /// Send the specified `user_input` directly, using the specified gamepad
     ///
     /// Called by the methods of [`MockInput`].
-    pub fn send_user_input_to_gamepad(
-        &mut self,
-        input: impl Into<UserInput>,
-        gamepad: Option<Gamepad>,
-    ) {
+    pub fn send_user_input(&mut self, input: impl Into<UserInput>) {
         let input_to_send: UserInput = input.into();
 
         let mut gamepad_buttons: Vec<GamepadButton> = Vec::default();
@@ -83,7 +79,7 @@ impl<'a> MutableInputStreams<'a> {
             UserInput::Null => (),
             UserInput::Single(button) => match button {
                 InputButton::Gamepad(gamepad_buttontype) => {
-                    if let Some(gamepad) = gamepad {
+                    if let Some(gamepad) = self.associated_gamepad {
                         gamepad_buttons.push(GamepadButton(gamepad, gamepad_buttontype));
                     }
                 }
@@ -94,7 +90,7 @@ impl<'a> MutableInputStreams<'a> {
                 for button in button_set {
                     match button {
                         InputButton::Gamepad(gamepad_buttontype) => {
-                            if let Some(gamepad) = gamepad {
+                            if let Some(gamepad) = self.associated_gamepad {
                                 gamepad_buttons.push(GamepadButton(gamepad, gamepad_buttontype));
                             }
                         }
@@ -152,9 +148,10 @@ impl MockInput for World {
             gamepad: maybe_gamepad.as_deref_mut(),
             keyboard: maybe_keyboard.as_deref_mut(),
             mouse: maybe_mouse.as_deref_mut(),
+            associated_gamepad: gamepad,
         };
 
-        mutable_input_streams.send_user_input_to_gamepad(input, gamepad);
+        mutable_input_streams.send_user_input(input);
     }
 
     fn reset_inputs(&mut self) {

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -1,0 +1,119 @@
+//! Helpful utilities for testing input management by sending mock input events
+
+use crate::user_input::{InputButton, MutableInputStreams, UserInput};
+use bevy::app::App;
+use bevy::ecs::system::{ResMut, SystemState};
+use bevy::ecs::world::World;
+use bevy::input::{
+    gamepad::{Gamepad, GamepadButton},
+    keyboard::KeyCode,
+    mouse::MouseButton,
+    Input,
+};
+
+/// Send fake input events for testing purposes
+///
+/// In game code, you should (almost) always be setting the [`ActionState`](crate::action_state::ActionState)
+/// directly instead.
+///
+/// # Examples
+/// ```rust
+/// use bevy::prelude::*;
+/// use leafwing_input_manager::MockInput;
+/// let world = World::new();
+///
+///
+/// ```
+///
+/// ```rust
+///
+///
+/// ```
+pub trait MockInput {
+    /// Send the specified `user_input` directly
+    fn send_user_input(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>);
+}
+
+impl<'a> MockInput for MutableInputStreams<'a> {
+    fn send_user_input(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
+        let input_to_send: UserInput = input.into();
+
+        let mut gamepad_buttons: Vec<GamepadButton> = Vec::default();
+
+        let mut keyboard_buttons: Vec<KeyCode> = Vec::default();
+        let mut mouse_buttons: Vec<MouseButton> = Vec::default();
+
+        match input_to_send {
+            UserInput::Null => (),
+            UserInput::Single(button) => match button {
+                InputButton::Gamepad(gamepad_buttontype) => {
+                    if let Some(gamepad) = gamepad {
+                        gamepad_buttons.push(GamepadButton(gamepad, gamepad_buttontype));
+                    }
+                }
+                InputButton::Keyboard(keycode) => keyboard_buttons.push(keycode),
+                InputButton::Mouse(mouse_button) => mouse_buttons.push(mouse_button),
+            },
+            UserInput::Chord(button_set) => {
+                for button in button_set {
+                    match button {
+                        InputButton::Gamepad(gamepad_buttontype) => {
+                            if let Some(gamepad) = gamepad {
+                                gamepad_buttons.push(GamepadButton(gamepad, gamepad_buttontype));
+                            }
+                        }
+                        InputButton::Keyboard(keycode) => keyboard_buttons.push(keycode),
+                        InputButton::Mouse(mouse_button) => mouse_buttons.push(mouse_button),
+                    }
+                }
+            }
+        };
+
+        if let Some(gamepad_input) = self.gamepad.as_deref_mut() {
+            for button in gamepad_buttons {
+                gamepad_input.press(button);
+            }
+        }
+
+        if let Some(keyboard_input) = self.keyboard.as_deref_mut() {
+            for button in keyboard_buttons {
+                keyboard_input.press(button);
+            }
+        }
+
+        if let Some(mouse_input) = self.mouse.as_deref_mut() {
+            for button in mouse_buttons {
+                mouse_input.press(button);
+            }
+        }
+    }
+}
+
+impl MockInput for World {
+    fn send_user_input(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
+        // You can make a system with this type signature if you'd like to mock user input
+        // in a non-exclusive system
+        let mut input_system_state: SystemState<(
+            Option<ResMut<Input<GamepadButton>>>,
+            Option<ResMut<Input<KeyCode>>>,
+            Option<ResMut<Input<MouseButton>>>,
+        )> = SystemState::new(self);
+
+        let (mut maybe_gamepad, mut maybe_keyboard, mut maybe_mouse) =
+            input_system_state.get_mut(self);
+
+        let mut mutable_input_streams = MutableInputStreams {
+            gamepad: maybe_gamepad.as_deref_mut(),
+            keyboard: maybe_keyboard.as_deref_mut(),
+            mouse: maybe_mouse.as_deref_mut(),
+        };
+
+        mutable_input_streams.send_user_input(input, gamepad);
+    }
+}
+
+impl MockInput for App {
+    fn send_user_input(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
+        self.world.send_user_input(input, gamepad);
+    }
+}

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -47,12 +47,12 @@ pub trait MockInput {
     ///
     /// Gamepad input will be sent by the first registed controller found.
     /// If none are found, gamepad input will be silently skipped.
-    fn send_user_input(&mut self, input: impl Into<UserInput>);
+    fn send_input(&mut self, input: impl Into<UserInput>);
 
     /// Send the specified `user_input` directly, using the specified gamepad
     ///
     /// Provide the `Gamepad` identifier to control which gamepad you are emulating inputs from
-    fn send_user_input_to_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>);
+    fn send_input_to_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>);
 
     /// Clears all user input streams, resetting them to their default state
     ///
@@ -126,21 +126,17 @@ impl<'a> MutableInputStreams<'a> {
 }
 
 impl MockInput for World {
-    fn send_user_input(&mut self, input: impl Into<UserInput>) {
+    fn send_input(&mut self, input: impl Into<UserInput>) {
         let gamepad = if let Some(gamepads) = self.get_resource::<Gamepads>() {
             gamepads.iter().next().copied()
         } else {
             None
         };
 
-        self.send_user_input_to_gamepad(input, gamepad);
+        self.send_input_to_gamepad(input, gamepad);
     }
 
-    fn send_user_input_to_gamepad(
-        &mut self,
-        input: impl Into<UserInput>,
-        gamepad: Option<Gamepad>,
-    ) {
+    fn send_input_to_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
         // You can make a system with this type signature if you'd like to mock user input
         // in a non-exclusive system
         let mut input_system_state: SystemState<(
@@ -185,16 +181,12 @@ impl MockInput for World {
 }
 
 impl MockInput for App {
-    fn send_user_input(&mut self, input: impl Into<UserInput>) {
-        self.world.send_user_input(input);
+    fn send_input(&mut self, input: impl Into<UserInput>) {
+        self.world.send_input(input);
     }
 
-    fn send_user_input_to_gamepad(
-        &mut self,
-        input: impl Into<UserInput>,
-        gamepad: Option<Gamepad>,
-    ) {
-        self.world.send_user_input_to_gamepad(input, gamepad);
+    fn send_input_to_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
+        self.world.send_input_to_gamepad(input, gamepad);
     }
 
     fn reset_inputs(&mut self) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 
 pub mod action_state;
+pub mod clashing_inputs;
 mod display_impl;
 pub mod input_map;
 pub mod systems;
@@ -73,10 +74,11 @@ pub use strum::IntoEnumIterator;
 /// Everything you need to get started
 pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
+    pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
     pub use crate::user_input::UserInput;
-    pub use crate::IntoEnumIterator;
 
+    pub use crate::IntoEnumIterator;
     pub use crate::{Actionlike, InputManagerBundle, InputManagerPlugin};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,9 @@ pub mod action_state;
 pub mod clashing_inputs;
 mod display_impl;
 pub mod input_map;
-pub mod input_mocking;
+mod input_mocking;
+// Re-export this at the root level
+pub use input_mocking::MockInput;
 pub mod systems;
 pub mod user_input;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,7 @@ pub mod action_state;
 pub mod clashing_inputs;
 mod display_impl;
 pub mod input_map;
+pub mod input_mocking;
 pub mod systems;
 pub mod user_input;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,7 +97,6 @@ pub mod prelude {
 /// ## Systems
 /// - [`tick_action_state`](systems::tick_action_state), which resets the `pressed` and `just_pressed` fields of the [`ActionState`] each frame
 ///     - labeled [`InputManagerSystem::Reset`]
-/// - [`cache_possible_clashes`](systems::cache_possible_clashes), which updates the cached list of potentially clashing actions
 /// - [`update_action_state`](systems::update_action_state), which collects [`Input`] resources to update the [`ActionState`]
 ///     - labeled [`InputManagerSystem::Update`]
 /// - [`update_action_state_from_interaction`](systems::update_action_state_from_interaction), for triggering actions from buttons
@@ -166,12 +165,10 @@ impl<A: Actionlike, UserState: Resource + PartialEq + Clone> Plugin
                     .label(InputManagerSystem::Reset)
                     .before(InputManagerSystem::Update),
             )
-            .with_system(cache_possible_clashes::<A>.label(PrivateSystems::RebuildCache))
             .with_system(
                 update_action_state::<A>
                     .label(InputManagerSystem::Update)
-                    .after(InputSystem)
-                    .after(PrivateSystems::RebuildCache),
+                    .after(InputSystem),
             )
             .with_system(
                 update_action_state_from_interaction::<A>
@@ -247,12 +244,6 @@ pub enum InputManagerSystem {
     Reset,
     /// Gathers input data to update the [ActionState]
     Update,
-}
-
-/// This [`SystemLabel`] cannot be made pub, as users must not be able to run systems between the cache's rebuild and use
-#[derive(SystemLabel, Clone, Hash, Debug, PartialEq, Eq)]
-enum PrivateSystems {
-    RebuildCache,
 }
 
 /// This [`Bundle`] allows entities to collect and interpret inputs from across input sources

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -22,16 +22,6 @@ pub fn tick_action_state<A: Actionlike>(mut query: Query<&mut ActionState<A>>, t
     }
 }
 
-/// Refreshes the cache of possible input clashes, to enable faster resolution
-// BLOCKED: this should run atomically before update_action_state
-pub fn cache_possible_clashes<A: Actionlike>(
-    mut query: Query<&mut InputMap<A>, Changed<InputMap<A>>>,
-) {
-    for mut input_map in query.iter_mut() {
-        input_map.cache_possible_clashes();
-    }
-}
-
 /// Fetches all of the releveant [`Input`] resources to update [`ActionState`] according to the [`InputMap`]
 ///
 /// Missing resources will be ignored, and treated as if none of the corresponding inputs were pressed

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -37,13 +37,14 @@ pub fn update_action_state<A: Actionlike>(
 
     let mouse = maybe_mouse_input_stream.as_deref();
 
-    let input_streams = InputStreams {
-        gamepad,
-        keyboard,
-        mouse,
-    };
-
     for (mut action_state, input_map) in query.iter_mut() {
+        let input_streams = InputStreams {
+            gamepad,
+            keyboard,
+            mouse,
+            associated_gamepad: input_map.gamepad(),
+        };
+
         let pressed_set = input_map.which_pressed(&input_streams);
 
         action_state.update(pressed_set);

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -22,6 +22,16 @@ pub fn tick_action_state<A: Actionlike>(mut query: Query<&mut ActionState<A>>, t
     }
 }
 
+/// Refreshes the cache of possible input clashes, to enable faster resolution
+// BLOCKED: this should run atomically before update_action_state
+pub fn cache_possible_clashes<A: Actionlike>(
+    mut query: Query<&mut InputMap<A>, Changed<InputMap<A>>>,
+) {
+    for mut input_map in query.iter_mut() {
+        input_map.cache_possible_clashes();
+    }
+}
+
 /// Fetches all of the releveant [`Input`] resources to update [`ActionState`] according to the [`InputMap`]
 ///
 /// Missing resources will be ignored, and treated as if none of the corresponding inputs were pressed

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -95,6 +95,15 @@ impl UserInput {
             UserInput::Null => false,
         }
     }
+
+    /// The number of buttons in the [`UserInput`]
+    pub fn len(&self) -> u8 {
+        match self {
+            UserInput::Null => 0,
+            UserInput::Single(_) => 1,
+            UserInput::Chord(button_set) => button_set.len().try_into().unwrap(),
+        }
+    }
 }
 
 impl From<InputButton> for UserInput {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -256,3 +256,31 @@ pub struct MutableInputStreams<'a> {
     /// An optional [`MouseButton`] [`Input`] stream
     pub mouse: Option<&'a mut Input<MouseButton>>,
 }
+
+impl<'a> From<MutableInputStreams<'a>> for InputStreams<'a> {
+    fn from(mutable_streams: MutableInputStreams<'a>) -> Self {
+        let gamepad = if let Some(mutable_ref) = mutable_streams.gamepad {
+            Some(&*mutable_ref)
+        } else {
+            None
+        };
+
+        let keyboard = if let Some(mutable_ref) = mutable_streams.keyboard {
+            Some(&*mutable_ref)
+        } else {
+            None
+        };
+
+        let mouse = if let Some(mutable_ref) = mutable_streams.mouse {
+            Some(&*mutable_ref)
+        } else {
+            None
+        };
+
+        InputStreams {
+            gamepad,
+            keyboard,
+            mouse,
+        }
+    }
+}

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -106,6 +106,11 @@ impl UserInput {
         }
     }
 
+    /// Is the number of buttons in the [`UserInput`] 0?
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
     /// How many of the provided `buttons` are found in the [`UserInput`]
     pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> u8 {
         match self {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -241,3 +241,18 @@ pub struct InputStreams<'a> {
     /// An optional [`MouseButton`] [`Input`] stream
     pub mouse: Option<&'a Input<MouseButton>>,
 }
+
+/// A mutable collection of [`Input`] structs, which can be used for mocking user inputs.
+///
+/// Each of these streams is optional; if a stream does not exist, inputs sent to them will be ignored.
+///
+/// These are typically collected via a system from the [`World`](bevy::prelude::World) as resources.
+#[derive(Debug)]
+pub struct MutableInputStreams<'a> {
+    /// An optional [`GamepadButton`] [`Input`] stream
+    pub gamepad: Option<&'a mut Input<GamepadButton>>,
+    /// An optional [`KeyCode`] [`Input`] stream
+    pub keyboard: Option<&'a mut Input<KeyCode>>,
+    /// An optional [`MouseButton`] [`Input`] stream
+    pub mouse: Option<&'a mut Input<MouseButton>>,
+}

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -262,7 +262,7 @@ pub struct InputStreams<'a> {
 
 // Constructors
 impl<'a> InputStreams<'a> {
-    /// Construct [InputStreams] with only a [GamepadButton] input stream
+    /// Construct [`InputStreams`] with only a [`GamepadButton`] input stream
     pub fn from_gamepad(
         gamepad_input_stream: &'a Input<GamepadButton>,
         associated_gamepad: Gamepad,
@@ -275,7 +275,7 @@ impl<'a> InputStreams<'a> {
         }
     }
 
-    /// Construct [InputStreams] with only a [KeyCode] input stream
+    /// Construct [`InputStreams`] with only a [`KeyCode`] input stream
     pub fn from_keyboard(keyboard_input_stream: &'a Input<KeyCode>) -> Self {
         Self {
             gamepad: None,
@@ -285,7 +285,7 @@ impl<'a> InputStreams<'a> {
         }
     }
 
-    /// Construct [InputStreams] with only a [GamepadButton] input stream
+    /// Construct [`InputStreams`] with only a [`GamepadButton`] input stream
     pub fn from_mouse(mouse_input_stream: &'a Input<MouseButton>) -> Self {
         Self {
             gamepad: None,
@@ -302,7 +302,7 @@ impl<'a> InputStreams<'a> {
     pub fn input_pressed(&self, input: &UserInput) -> bool {
         match input {
             UserInput::Single(button) => self.button_pressed(*button),
-            UserInput::Chord(buttons) => self.all_buttons_pressed(&buttons),
+            UserInput::Chord(buttons) => self.all_buttons_pressed(buttons),
             UserInput::Null => false,
         }
     }
@@ -385,23 +385,11 @@ pub struct MutableInputStreams<'a> {
 
 impl<'a> From<MutableInputStreams<'a>> for InputStreams<'a> {
     fn from(mutable_streams: MutableInputStreams<'a>) -> Self {
-        let gamepad = if let Some(mutable_ref) = mutable_streams.gamepad {
-            Some(&*mutable_ref)
-        } else {
-            None
-        };
+        let gamepad = mutable_streams.gamepad.map(|mutable_ref| &*mutable_ref);
 
-        let keyboard = if let Some(mutable_ref) = mutable_streams.keyboard {
-            Some(&*mutable_ref)
-        } else {
-            None
-        };
+        let keyboard = mutable_streams.keyboard.map(|mutable_ref| &*mutable_ref);
 
-        let mouse = if let Some(mutable_ref) = mutable_streams.mouse {
-            Some(&*mutable_ref)
-        } else {
-            None
-        };
+        let mouse = mutable_streams.mouse.map(|mutable_ref| &*mutable_ref);
 
         InputStreams {
             gamepad,

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -244,6 +244,43 @@ pub struct InputStreams<'a> {
     pub associated_gamepad: Option<Gamepad>,
 }
 
+// Constructors
+impl<'a> InputStreams<'a> {
+    /// Construct [InputStreams] with only a [GamepadButton] input stream
+    pub fn from_gamepad(
+        gamepad_input_stream: &'a Input<GamepadButton>,
+        associated_gamepad: Gamepad,
+    ) -> Self {
+        Self {
+            gamepad: Some(gamepad_input_stream),
+            keyboard: None,
+            mouse: None,
+            associated_gamepad: Some(associated_gamepad),
+        }
+    }
+
+    /// Construct [InputStreams] with only a [KeyCode] input stream
+    pub fn from_keyboard(keyboard_input_stream: &'a Input<KeyCode>) -> Self {
+        Self {
+            gamepad: None,
+            keyboard: Some(keyboard_input_stream),
+            mouse: None,
+            associated_gamepad: None,
+        }
+    }
+
+    /// Construct [InputStreams] with only a [GamepadButton] input stream
+    pub fn from_mouse(mouse_input_stream: &'a Input<MouseButton>) -> Self {
+        Self {
+            gamepad: None,
+            keyboard: None,
+            mouse: Some(mouse_input_stream),
+            associated_gamepad: None,
+        }
+    }
+}
+
+// Input checking
 impl<'a> InputStreams<'a> {
     /// Is the `input` matched by the [`InputStreams`]?
     pub fn input_pressed(&self, input: &UserInput) -> bool {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -12,7 +12,7 @@ use strum::EnumIter;
 /// Some combination of user input, which may cross [`Input`] boundaries
 ///
 /// Suitable for use in an [`InputMap`]
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum UserInput {
     /// A single button
     Single(InputButton),

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -112,6 +112,22 @@ impl UserInput {
     }
 
     /// How many of the provided `buttons` are found in the [`UserInput`]
+    ///
+    /// # Example
+    /// ```rust
+    /// use bevy::input::keyboard::KeyCode::*;
+    /// use bevy::utils::HashSet;
+    /// use leafwing_input_manager::user_input::UserInput;
+    ///
+    /// let buttons = HashSet::from_iter([LControl.into(), LAlt.into()]);
+    /// let a: UserInput  = A.into();
+    /// let ctrl_a = UserInput::chord([LControl, A]);
+    /// let ctrl_alt_a = UserInput::chord([LControl, LAlt, A]);
+    ///
+    /// assert_eq!(a.n_matching(&buttons), 0);
+    /// assert_eq!(ctrl_a.n_matching(&buttons), 1);
+    /// assert_eq!(ctrl_alt_a.n_matching(&buttons), 2);
+    /// ```
     pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> u8 {
         match self {
             UserInput::Null => 0,

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -152,7 +152,7 @@ fn input_clash_handling() {
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, Two, OneAndTwo]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwo]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [One, Two, OneAndTwo]);
-    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Three inputs
     app.reset_inputs();
@@ -170,7 +170,7 @@ fn input_clash_handling() {
         ClashStrategy::PrioritizeModified,
         [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree],
     );
-    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Modifier
     app.reset_inputs();
@@ -184,9 +184,15 @@ fn input_clash_handling() {
         ClashStrategy::PressAll,
         [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree, CtrlOne],
     );
-    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
-    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [CtrlOne]);
-    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+    app.assert_input_map_actions_eq(
+        ClashStrategy::PrioritizeLongest,
+        [CtrlOne, OneAndTwoAndThree],
+    );
+    app.assert_input_map_actions_eq(
+        ClashStrategy::PrioritizeModified,
+        [CtrlOne, OneAndTwo, Two, TwoAndThree, OneAndTwoAndThree],
+    );
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Multiple modifiers
     app.reset_inputs();

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -99,6 +99,7 @@ impl ClashTestExt for App {
             gamepad: maybe_gamepad.as_deref(),
             keyboard: maybe_keyboard.as_deref(),
             mouse: maybe_mouse.as_deref(),
+            associated_gamepad: None,
         };
 
         let mut matching_input_map = InputMap::<Action>::default();

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -110,11 +110,19 @@ impl ClashTestExt for App {
             }
         }
 
+        let keyboard_input = input_streams.keyboard.unwrap();
+
         for action in Action::iter() {
             if pressed_actions.contains(&action) {
-                assert!(matching_input_map.pressed(action, &input_streams));
+                assert!(
+                    matching_input_map.pressed(action, &input_streams),
+                    "{action:?} was incorrectly not pressed for {clash_strategy:?} when `Input<KeyCode>` was \n {keyboard_input:?}."
+                );
             } else {
-                assert!(!matching_input_map.pressed(action, &input_streams));
+                assert!(
+                    !matching_input_map.pressed(action, &input_streams),
+                    "{action:?} was incorrectly pressed for {clash_strategy:?} when `Input<KeyCode>` was \n {keyboard_input:?}"
+                );
             }
         }
     }

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -93,13 +93,18 @@ impl ClashTestExt for App {
         let input_streams = InputStreams::from_keyboard(&*keyboard);
 
         let mut matching_input_map = InputMap::<Action>::default();
+        let mut found = false;
 
         for input_map in input_map_query.iter() {
             if input_map.clash_strategy == clash_strategy {
                 matching_input_map = input_map.clone();
+                found = true;
                 break;
             }
         }
+
+        // Verify that we found the right input map
+        assert!(found);
 
         let keyboard_input = input_streams.keyboard.unwrap();
 

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -1,0 +1,203 @@
+use bevy::ecs::system::SystemState;
+use bevy::prelude::*;
+use bevy::utils::HashSet;
+use leafwing_input_manager::prelude::*;
+use leafwing_input_manager::user_input::InputStreams;
+use strum::EnumIter;
+
+#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, EnumIter, Debug)]
+enum Action {
+    One,
+    Two,
+    OneAndTwo,
+    TwoAndThree,
+    OneAndTwoAndThree,
+    CtrlOne,
+    AltOne,
+    CtrlAltOne,
+}
+
+fn test_input_map(strategy: ClashStrategy) -> InputMap<Action> {
+    use Action::*;
+    use KeyCode::*;
+
+    let mut input_map = InputMap::default();
+    input_map.clash_strategy = strategy;
+
+    input_map.insert(One, Key1);
+    input_map.insert(Two, Key2);
+    input_map.insert_chord(OneAndTwo, [Key1, Key2]);
+    input_map.insert_chord(TwoAndThree, [Key2, Key3]);
+    input_map.insert_chord(OneAndTwoAndThree, [Key1, Key2, Key3]);
+    input_map.insert_chord(CtrlOne, [LControl, Key1]);
+    input_map.insert_chord(AltOne, [LAlt, Key1]);
+    input_map.insert_chord(CtrlAltOne, [LControl, LAlt, Key1]);
+
+    input_map
+}
+
+fn spawn_input_maps(mut commands: Commands) {
+    commands
+        .spawn()
+        .insert_bundle(InputManagerBundle::<Action> {
+            input_map: test_input_map(ClashStrategy::PressAll),
+            ..Default::default()
+        });
+
+    commands
+        .spawn()
+        .insert_bundle(InputManagerBundle::<Action> {
+            input_map: test_input_map(ClashStrategy::PrioritizeLongest),
+            ..Default::default()
+        });
+
+    commands
+        .spawn()
+        .insert_bundle(InputManagerBundle::<Action> {
+            input_map: test_input_map(ClashStrategy::PrioritizeModified),
+            ..Default::default()
+        });
+
+    commands
+        .spawn()
+        .insert_bundle(InputManagerBundle::<Action> {
+            input_map: test_input_map(ClashStrategy::UseActionOrder),
+            ..Default::default()
+        });
+}
+
+trait ClashTestExt {
+    /// Asserts that the set of `pressed_actions` matches the actions observed
+    /// by the entity with the corresponding varaint of the [`ClashStrategy`] enum
+    /// in its [`InputMap`] component
+    fn assert_input_map_actions_eq(
+        &mut self,
+        clash_strategy: ClashStrategy,
+        pressed_actions: impl IntoIterator<Item = Action>,
+    );
+}
+
+impl ClashTestExt for App {
+    fn assert_input_map_actions_eq(
+        &mut self,
+        clash_strategy: ClashStrategy,
+        pressed_actions: impl IntoIterator<Item = Action>,
+    ) {
+        let pressed_actions: HashSet<Action> = HashSet::from_iter(pressed_actions.into_iter());
+        // SystemState is love, SystemState is life
+        let mut input_system_state: SystemState<(
+            Query<&InputMap<Action>>,
+            Option<Res<Input<GamepadButton>>>,
+            Option<Res<Input<KeyCode>>>,
+            Option<Res<Input<MouseButton>>>,
+        )> = SystemState::new(&mut self.world);
+
+        let (input_map_query, maybe_gamepad, maybe_keyboard, maybe_mouse) =
+            input_system_state.get(&mut self.world);
+
+        let input_streams = InputStreams {
+            gamepad: maybe_gamepad.as_deref(),
+            keyboard: maybe_keyboard.as_deref(),
+            mouse: maybe_mouse.as_deref(),
+        };
+
+        let mut matching_input_map = InputMap::<Action>::default();
+
+        for input_map in input_map_query.iter() {
+            if input_map.clash_strategy == clash_strategy {
+                matching_input_map = input_map.clone();
+                break;
+            }
+        }
+
+        for action in Action::iter() {
+            if pressed_actions.contains(&action) {
+                assert!(matching_input_map.pressed(action, &input_streams));
+            } else {
+                assert!(!matching_input_map.pressed(action, &input_streams));
+            }
+        }
+    }
+}
+
+#[test]
+fn input_clash_handling() {
+    use bevy::input::InputPlugin;
+    use leafwing_input_manager::MockInput;
+    use Action::*;
+    use KeyCode::*;
+
+    let mut app = App::new();
+
+    app.add_plugins(MinimalPlugins)
+        .add_plugin(InputPlugin)
+        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_startup_system(spawn_input_maps);
+
+    // Two inputs
+    app.send_input(Key1);
+    app.send_input(Key2);
+    app.update();
+
+    app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, Two, OneAndTwo]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwo]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [One, Two, OneAndTwo]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+
+    // Three inputs
+    app.reset_inputs();
+    app.send_input(Key1);
+    app.send_input(Key2);
+    app.send_input(Key3);
+    app.update();
+
+    app.assert_input_map_actions_eq(
+        ClashStrategy::PressAll,
+        [One, Two, OneAndTwo, OneAndTwoAndThree],
+    );
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
+    app.assert_input_map_actions_eq(
+        ClashStrategy::PrioritizeModified,
+        [One, Two, OneAndTwo, OneAndTwoAndThree],
+    );
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+
+    // Modifier
+    app.reset_inputs();
+    app.send_input(Key1);
+    app.send_input(Key2);
+    app.send_input(Key3);
+    app.send_input(LControl);
+    app.update();
+
+    app.assert_input_map_actions_eq(
+        ClashStrategy::PressAll,
+        [One, Two, OneAndTwo, OneAndTwoAndThree, CtrlOne],
+    );
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [CtrlOne]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+
+    // Multiple modifiers
+    app.reset_inputs();
+    app.send_input(Key1);
+    app.send_input(LControl);
+    app.send_input(LAlt);
+    app.update();
+
+    app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, CtrlOne, AltOne, CtrlAltOne]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [CtrlAltOne]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [CtrlAltOne]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
+
+    // Action order
+    app.reset_inputs();
+    app.send_input(Key3);
+    app.send_input(Key2);
+    app.update();
+
+    app.assert_input_map_actions_eq(ClashStrategy::PressAll, [Two, TwoAndThree]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [TwoAndThree]);
+    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [Two, TwoAndThree]);
+    app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [Two]);
+}

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -93,7 +93,7 @@ impl ClashTestExt for App {
         )> = SystemState::new(&mut self.world);
 
         let (input_map_query, maybe_gamepad, maybe_keyboard, maybe_mouse) =
-            input_system_state.get(&mut self.world);
+            input_system_state.get(&self.world);
 
         let input_streams = InputStreams {
             gamepad: maybe_gamepad.as_deref(),

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -54,13 +54,6 @@ fn spawn_input_maps(mut commands: Commands) {
     commands
         .spawn()
         .insert_bundle(InputManagerBundle::<Action> {
-            input_map: test_input_map(ClashStrategy::PrioritizeModified),
-            ..Default::default()
-        });
-
-    commands
-        .spawn()
-        .insert_bundle(InputManagerBundle::<Action> {
             input_map: test_input_map(ClashStrategy::UseActionOrder),
             ..Default::default()
         });
@@ -151,7 +144,6 @@ fn input_clash_handling() {
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, Two, OneAndTwo]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwo]);
-    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [One, Two, OneAndTwo]);
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Three inputs
@@ -166,10 +158,6 @@ fn input_clash_handling() {
         [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree],
     );
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
-    app.assert_input_map_actions_eq(
-        ClashStrategy::PrioritizeModified,
-        [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree],
-    );
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Modifier
@@ -188,10 +176,6 @@ fn input_clash_handling() {
         ClashStrategy::PrioritizeLongest,
         [CtrlOne, OneAndTwoAndThree],
     );
-    app.assert_input_map_actions_eq(
-        ClashStrategy::PrioritizeModified,
-        [CtrlOne, OneAndTwo, Two, TwoAndThree, OneAndTwoAndThree],
-    );
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One, Two]);
 
     // Multiple modifiers
@@ -203,7 +187,6 @@ fn input_clash_handling() {
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, CtrlOne, AltOne, CtrlAltOne]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [CtrlAltOne]);
-    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [CtrlAltOne]);
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
 
     // Action order
@@ -214,6 +197,5 @@ fn input_clash_handling() {
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [Two, TwoAndThree]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [TwoAndThree]);
-    app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [Two, TwoAndThree]);
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [Two]);
 }

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -157,12 +157,12 @@ fn input_clash_handling() {
 
     app.assert_input_map_actions_eq(
         ClashStrategy::PressAll,
-        [One, Two, OneAndTwo, OneAndTwoAndThree],
+        [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree],
     );
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
     app.assert_input_map_actions_eq(
         ClashStrategy::PrioritizeModified,
-        [One, Two, OneAndTwo, OneAndTwoAndThree],
+        [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree],
     );
     app.assert_input_map_actions_eq(ClashStrategy::UseActionOrder, [One]);
 
@@ -176,7 +176,7 @@ fn input_clash_handling() {
 
     app.assert_input_map_actions_eq(
         ClashStrategy::PressAll,
-        [One, Two, OneAndTwo, OneAndTwoAndThree, CtrlOne],
+        [One, Two, OneAndTwo, TwoAndThree, OneAndTwoAndThree, CtrlOne],
     );
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeLongest, [OneAndTwoAndThree]);
     app.assert_input_map_actions_eq(ClashStrategy::PrioritizeModified, [CtrlOne]);

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -121,6 +121,12 @@ impl ClashTestExt for App {
                 );
             }
         }
+
+        // Verify that the holistic view is also correct
+        assert_eq!(
+            matching_input_map.which_pressed(&input_streams),
+            pressed_actions
+        );
     }
 }
 

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -85,22 +85,12 @@ impl ClashTestExt for App {
     ) {
         let pressed_actions: HashSet<Action> = HashSet::from_iter(pressed_actions.into_iter());
         // SystemState is love, SystemState is life
-        let mut input_system_state: SystemState<(
-            Query<&InputMap<Action>>,
-            Option<Res<Input<GamepadButton>>>,
-            Option<Res<Input<KeyCode>>>,
-            Option<Res<Input<MouseButton>>>,
-        )> = SystemState::new(&mut self.world);
+        let mut input_system_state: SystemState<(Query<&InputMap<Action>>, Res<Input<KeyCode>>)> =
+            SystemState::new(&mut self.world);
 
-        let (input_map_query, maybe_gamepad, maybe_keyboard, maybe_mouse) =
-            input_system_state.get(&self.world);
+        let (input_map_query, keyboard) = input_system_state.get(&self.world);
 
-        let input_streams = InputStreams {
-            gamepad: maybe_gamepad.as_deref(),
-            keyboard: maybe_keyboard.as_deref(),
-            mouse: maybe_mouse.as_deref(),
-            associated_gamepad: None,
-        };
+        let input_streams = InputStreams::from_keyboard(&*keyboard);
 
         let mut matching_input_map = InputMap::<Action>::default();
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -25,14 +25,10 @@ fn spawn_player(mut commands: Commands) {
         });
 }
 
-fn press_f(mut input: ResMut<Input<KeyCode>>) {
-    input.press(KeyCode::F);
-}
-
 #[test]
 fn action_state_change_detection() {
-    use bevy::ecs::schedule::ShouldRun;
     use bevy::input::InputPlugin;
+    use leafwing_input_manager::MockInput;
 
     let mut app = App::new();
 
@@ -40,21 +36,13 @@ fn action_state_change_detection() {
         .add_plugin(InputPlugin)
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(spawn_player)
-        .add_system(
-            press_f.with_run_criteria(|mut run_this_frame: Local<bool>| {
-                // Run this system every other frame
-                let run_next_frame = !*run_this_frame;
-                *run_this_frame = run_next_frame;
-                if run_next_frame {
-                    ShouldRun::No
-                } else {
-                    ShouldRun::Yes
-                }
-            }),
-        )
         .add_system(action_state_changed_iff_input_changed);
 
-    for _ in 0..10 {
+    for i in 0..10 {
+        if i % 2 == 0 {
+            app.send_user_input(KeyCode::F);
+        }
+
         app.update();
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -40,7 +40,7 @@ fn action_state_change_detection() {
 
     for i in 0..10 {
         if i % 2 == 0 {
-            app.send_user_input(KeyCode::F);
+            app.send_input(KeyCode::F);
         }
 
         app.update();


### PR DESCRIPTION
## Problem

Fixes #23.

In many applications, overlapping inputs are special cased, to avoid surprising results, especially with modifier keys.

If `Ctrl + V` and `Ctrl + Shift + V` only pastes without formatting, rather than doing that *and* pasting normally.

## Solution

Two inputs are said to clash if one is a strict subset of the other.

Allow users to configure their input maps to decide how they want to handle clashing inputs.

```rust
pub enum ClashStrategy {
    /// All matching inputs will always be pressed
    PressAll,
    /// Only press the action that corresponds to the longest chord
    PrioritizeLongest,
    /// If the [`UserInput`] contains a modifier key (defined at the input map level), press that action over any unmodified action.
    ///
    /// If more than one matching action uses a modifier, break ties based on number of modifiers.
    /// Further ties are broken using the `PrioritizeLongest` rule.
    PrioritizeModified,
    /// Use the order in which actions are defined in the enum to resolve clashing inputs
    ///
    /// Uses the iteration order returned by [IntoEnumIterator](crate::IntoEnumIterator),
    /// which is generated in order of the enum items by the `#[derive(EnumIter)]` macro.
    UseActionOrder,
}
```

## To do

- [x] actually handle clashes according to the selected strategy
- [x] add integration tests to verify that this works as expected
- [x] add an example demonstrating how this works