### PR TITLE
Add Bevy Gilrs to Dev Dependency Features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ itertools = "0.10"
 serde = {version = "1.0", features = ["derive"]}
 
 [dev-dependencies]
-bevy = {version = "0.7", default-features = false, features = ["bevy_sprite", "bevy_text", "bevy_ui", "bevy_render", "bevy_core_pipeline", "x11"]}
+bevy = {version = "0.7", default-features = false, features = ["bevy_gilrs", "bevy_sprite", "bevy_text", "bevy_ui", "bevy_render", "bevy_core_pipeline", "x11"]}
 bevy_egui = {version="0.13", default-features = false}
 
 [lib]


### PR DESCRIPTION
This way you can run the examples with gamepad support. It was kind of confusing to me as somebody trying to run the examples that none of the gamepad inputs were working.

A lot of people probably wouldn't know to do this themselves.