### PR TITLE
Add Support For Gamepad Axes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ and a single input can result in multiple actions being triggered, which can be 
 ## Features
 
 - Full keyboard, mouse and joystick support for button-like and axis inputs.
-- Dual gamepad axes and virtual DPad bindings that can have values intuitively read from an `AxisPair`.
+- Dual axis support for analog inputs from gamepads and joysticks
+- Bind arbitrary button inputs into virtual DPads
 - Effortlessly wire UI buttons to game state with one simple component!
   - When clicked, your button will press the appropriate action on the corresponding entity.
 - Store all your input mappings in a single `InputMap` component

--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ and a single input can result in multiple actions being triggered, which can be 
 
 ## Features
 
-- Full keyboard, mouse and joystick support for button-like inputs.
+- Full keyboard, mouse and joystick support for button-like and axis inputs.
+- Dual gamepad axes and virtual DPad bindings that can have values intuitively read from an `AxisPair`.
 - Effortlessly wire UI buttons to game state with one simple component!
   - When clicked, your button will press the appropriate action on the corresponding entity.
 - Store all your input mappings in a single `InputMap` component
@@ -33,11 +34,6 @@ and a single input can result in multiple actions being triggered, which can be 
 
 ## Limitations
 
-- The `Button` enum only includes `KeyCode`, `MouseButton` and `GamepadButtonType`.
-  - This is due to object-safety limitations on the types stored in `bevy::input::Input`
-  - Please file an issue if you would like something more exotic!
-- No built-in support for non-button input types (e.g. gestures or analog sticks).
-  - All methods on `ActionState` are `pub`: it's designed to be hooked into and extended.
 - Gamepads must be manually assigned to each input map: read from the `Gamepads` resource and use `InputMap::set_gamepad`.
 
 ## Instructions

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,16 @@
 
 ## Version 0.4
 
+### Changes
+
+- Renamed `InputButton` to `InputKind` to reflect it's ability to represent non-button inputs such as axes.
+
+### Enhancements
+
+- Added `InputKind::SingleGamepadAxis` and `InputKind::DualGamepadAxis` variants that can be used to trigger on axis inputs.
+- Added `ActionState::action_value()` and `ActionState::action_axis_pair()` that can be used to read axis and button values.
+- Added `UserInput::VirtualDPad` variant that can be used to bind directional button inputs and read them as an `AxisPair`.
+
 ### Usability
 
 - reduced required `derive_more` features

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,9 +8,10 @@
 
 ### Enhancements
 
-- Added `InputKind::SingleGamepadAxis` and `InputKind::DualGamepadAxis` variants that can be used to trigger on axis inputs.
-- Added `ActionState::action_value()` and `ActionState::action_axis_pair()` that can be used to read axis and button values.
-- Added `UserInput::VirtualDPad` variant that can be used to bind directional button inputs and read them as an `AxisPair`.
+- Added `SingleGamepadAxis` and `DualGamepadAxis` structs that can be supplied to an `InputMap` to trigger on axis inputs.
+- Added `VirtualDPad` struct that can be supplied to an `InputMap` to trigger on four direction-representing inputs.
+- Added `ActionState::action_axis_pair()` which can return an `AxisPair` to containing the analog values of a `SingleGamepadAxis`, `DualGamepadAxis`, or `VirtualDPad`.
+- Added `ActionState::action_value()` which represents the floating point value of any action: `1.0` or `0.0` for pressed or unpressed buttons, a value in the range `-1.0..=1.0` for a single axis representing its analog input, or a value in the range `0.0..=1.0` for a dual axis representing the magnitude (length) of its vector.
 
 ### Usability
 

--- a/examples/analog_stick.rs
+++ b/examples/analog_stick.rs
@@ -1,0 +1,94 @@
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        // This plugin maps inputs to an input-type agnostic action-state
+        // We need to provide it with an enum which stores the possible actions a player could take
+        .add_plugin(InputManagerPlugin::<Action>::default())
+        // The InputMap and ActionState components will be added to any entity with the Player component
+        .add_startup_system(spawn_player)
+        // Read the ActionState in your systems using queries!
+        .add_system(move_player)
+        .run();
+}
+
+// This is the list of "things in the game I want to be able to do based on input"
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+enum Action {
+    Up,
+    Down,
+    Left,
+    Right,
+}
+
+#[derive(Component)]
+struct Player;
+
+fn spawn_player(mut commands: Commands) {
+    commands
+        .spawn()
+        .insert(Player)
+        .insert_bundle(InputManagerBundle::<Action> {
+            // Stores "which actions are currently activated"
+            action_state: ActionState::default(),
+            // Describes how to convert from player inputs into those actions
+            input_map: InputMap::new([
+                (
+                    // This describes which gamepad axis must be moved how much to trigger the action
+                    GamepadAxisThreshold {
+                        axis: GamepadAxisType::LeftStickY,
+                        comparison: GamepadAxisComparison::Greater,
+                        threshold: 0.1,
+                    },
+                    Action::Up,
+                ),
+                (
+                    GamepadAxisThreshold {
+                        axis: GamepadAxisType::LeftStickY,
+                        comparison: GamepadAxisComparison::Less,
+                        threshold: -0.1,
+                    },
+                    Action::Down,
+                ),
+                (
+                    GamepadAxisThreshold {
+                        axis: GamepadAxisType::LeftStickX,
+                        comparison: GamepadAxisComparison::Less,
+                        threshold: -0.1,
+                    },
+                    Action::Left,
+                ),
+                (
+                    GamepadAxisThreshold {
+                        axis: GamepadAxisType::LeftStickX,
+                        comparison: GamepadAxisComparison::Greater,
+                        threshold: 0.1,
+                    },
+                    Action::Right,
+                ),
+            ])
+            // Listen for events on the first gamepad
+            .set_gamepad(Gamepad(0))
+            .build(),
+        });
+}
+
+// Query for the `ActionState` component in your game logic systems!
+fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
+    let action_state = query.single();
+    // Each action has a button-like state of its own that you can check
+    if action_state.pressed(Action::Up) {
+        println!("Up");
+    }
+    if action_state.pressed(Action::Down) {
+        println!("Down");
+    }
+    if action_state.pressed(Action::Left) {
+        println!("Left");
+    }
+    if action_state.pressed(Action::Right) {
+        println!("Right");
+    }
+}

--- a/examples/analog_stick.rs
+++ b/examples/analog_stick.rs
@@ -86,29 +86,30 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
         // You can also get the action value which will tell you how tilted the axis is for axis
         // inputs.
         // For analog sticks, this will be between -1.0 and 1.0.
-        let value = action_state.action_data(Action::Up).value;
+        let value = action_state.action_value(Action::Up);
         println!("Up: {}", value);
     }
     if action_state.pressed(Action::Down) {
-        let value = action_state.action_data(Action::Down).value;
+        let value = action_state.action_value(Action::Down);
         println!("Down: {}", value);
     }
     if action_state.pressed(Action::Left) {
-        let value = action_state.action_data(Action::Left).value;
+        let value = action_state.action_value(Action::Left);
         println!("Left: {}", value);
     }
     if action_state.pressed(Action::Right) {
-        let value = action_state.action_data(Action::Right).value;
+        let value = action_state.action_value(Action::Right);
         println!("Right: {}", value);
     }
     if action_state.pressed(Action::Throttle) {
-        // Note that some gamepad buttons are also tied to axes, so even though we used a
-        // GamepadbuttonType::RightTrigger2 binding to trigger the throttle action, we can get a
-        // variable value here if you have a variable right trigger on your gamepad.
+        // Note that some gamepad buttons are also tied to axes,
+        // so even though we used a GamepadbuttonType::RightTrigger2 binding to trigger the
+        // throttle action,
+        // we can get a variable value here if you have a variable right trigger on your gamepad.
         //
-        // If you don't have a variable trigger, this will just return 0.0 when not pressed and 1.0
-        // when pressed.
-        let value = action_state.action_data(Action::Throttle).value;
+        // If you don't have a variable trigger,
+        // this will just return 0.0 when not pressed and 1.0 when pressed.
+        let value = action_state.action_value(Action::Throttle);
         println!("Throttle: {}", value);
     }
 }

--- a/examples/analog_stick.rs
+++ b/examples/analog_stick.rs
@@ -7,7 +7,7 @@ fn main() {
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
         .add_plugin(InputManagerPlugin::<Action>::default())
-        // The InputMap and ActionState components will be added to any entity with the Player component
+        // Spawn an entity with Player, InputMap, and ActionState components
         .add_startup_system(spawn_player)
         // Read the ActionState in your systems using queries!
         .add_system(move_player)

--- a/examples/analog_stick.rs
+++ b/examples/analog_stick.rs
@@ -21,6 +21,7 @@ enum Action {
     Down,
     Left,
     Right,
+    Throttle,
 }
 
 #[derive(Component)]
@@ -69,6 +70,8 @@ fn spawn_player(mut commands: Commands) {
                     Action::Right,
                 ),
             ])
+            // Let's also add a gamepad button binding to the right trigger
+            .insert(GamepadButtonType::RightTrigger2, Action::Throttle)
             // Listen for events on the first gamepad
             .set_gamepad(Gamepad(0))
             .build(),
@@ -80,15 +83,32 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
     // Each action has a button-like state of its own that you can check
     if action_state.pressed(Action::Up) {
-        println!("Up");
+        // You can also get the action value which will tell you how tilted the axis is for axis
+        // inputs.
+        // For analog sticks, this will be between -1.0 and 1.0.
+        let value = action_state.action_data(Action::Up).value;
+        println!("Up: {}", value);
     }
     if action_state.pressed(Action::Down) {
-        println!("Down");
+        let value = action_state.action_data(Action::Down).value;
+        println!("Down: {}", value);
     }
     if action_state.pressed(Action::Left) {
-        println!("Left");
+        let value = action_state.action_data(Action::Left).value;
+        println!("Left: {}", value);
     }
     if action_state.pressed(Action::Right) {
-        println!("Right");
+        let value = action_state.action_data(Action::Right).value;
+        println!("Right: {}", value);
+    }
+    if action_state.pressed(Action::Throttle) {
+        // Note that some gamepad buttons are also tied to axes, so even though we used a
+        // GamepadbuttonType::RightTrigger2 binding to trigger the throttle action, we can get a
+        // variable value here if you have a variable right trigger on your gamepad.
+        //
+        // If you don't have a variable trigger, this will just return 0.0 when not pressed and 1.0
+        // when pressed.
+        let value = action_state.action_data(Action::Throttle).value;
+        println!("Throttle: {}", value);
     }
 }

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -77,7 +77,7 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     if action_state.pressed(Action::Move) {
         let axis_pair = action_state.action_axis_pair(Action::Move).unwrap();
         println!("Move:");
-        println!("   distance: {}", axis_pair.magnitude());
+        println!("   distance: {}", axis_pair.length());
         println!("          x: {}", axis_pair.x());
         println!("          y: {}", axis_pair.y());
     }

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -14,11 +14,11 @@ fn main() {
         .run();
 }
 
-// This is the list of "things in the game I want to be able to do based on input"
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Move,
     Throttle,
+    Rudder,
 }
 
 #[derive(Component)]
@@ -32,19 +32,35 @@ fn spawn_player(mut commands: Commands) {
             // Stores "which actions are currently activated"
             action_state: ActionState::default(),
             // Describes how to convert from player inputs into those actions
-            input_map: InputMap::new([(
-                // We want to trigger our move action when the left stick is moved more than 10% in
-                // any direction.
-                DualGamepadAxisThreshold {
-                    x_axis: GamepadAxisType::LeftStickX,
-                    y_axis: GamepadAxisType::LeftStickY,
-                    comparison: GamepadAxisComparison::Greater,
-                    threshold: 0.1,
-                },
-                Action::Move,
-            )])
+            input_map: InputMap::new([
+                // Configure the left stick as a dual-axis
+                (
+                    DualGamepadAxis {
+                        x_axis: GamepadAxisType::LeftStickX,
+                        y_axis: GamepadAxisType::LeftStickY,
+                        // We want to trigger our move action when the left stick is moved more than 10%
+                        // in any direction.
+                        //
+                        // Note: The Bevy `GamepadSettings` such as the axis deadzone with still apply.
+                        // If bevy filters out a gamepad event,
+                        // it will be filtered out of leafwing, too.
+                        deadzone: 0.1,
+                    },
+                    Action::Move,
+                ),
+            ])
             // Let's also add a gamepad button binding to the right trigger
             .insert(GamepadButtonType::RightTrigger2, Action::Throttle)
+            // And we'll use the x axis on the right stick as a rudder control
+            .insert(
+                SingleGamepadAxis {
+                    axis: GamepadAxisType::RightStickX,
+                    // This will trigger if the axis is moved 10% or more in either direction.
+                    negative_low: -0.1,
+                    positive_low: 0.1,
+                },
+                Action::Rudder,
+            )
             // Listen for events on the first gamepad
             .set_gamepad(Gamepad(0))
             .build(),
@@ -56,7 +72,7 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
     // Each action has a button-like state of its own that you can check
     if action_state.pressed(Action::Move) {
-        let axis_pair = action_state.action_axis_pair(Action::Move);
+        let axis_pair = action_state.action_axis_pair(Action::Move).unwrap();
         println!("Move:");
         println!("   distance: {}", axis_pair.magnitude());
         println!("          x: {}", axis_pair.x());
@@ -73,5 +89,10 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
         // this will just return 0.0 when not pressed and 1.0 when pressed.
         let value = action_state.action_value(Action::Throttle);
         println!("Throttle: {}", value);
+    }
+
+    if action_state.pressed(Action::Rudder) {
+        let value = action_state.action_value(Action::Rudder);
+        println!("Rudder: {}", value);
     }
 }

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -41,9 +41,8 @@ fn spawn_player(mut commands: Commands) {
                         // We want to trigger our move action when the left stick is moved more than 10%
                         // in any direction.
                         //
-                        // Note: The Bevy `GamepadSettings` such as the axis deadzone with still apply.
-                        // If bevy filters out a gamepad event,
-                        // it will be filtered out of leafwing, too.
+                        // Note: The Bevy `GamepadSettings` may cause input to be filtered out before
+                        // reaching leafwing.
                         x_positive_low: 0.1,
                         x_negative_low: -0.1,
                         y_positive_low: 0.1,
@@ -52,9 +51,9 @@ fn spawn_player(mut commands: Commands) {
                     Action::Move,
                 ),
             ])
-            // Let's also add a gamepad button binding to the right trigger
+            // Let's bind the right gamepad trigger to the throttle action
             .insert(GamepadButtonType::RightTrigger2, Action::Throttle)
-            // And we'll use the x axis on the right stick as a rudder control
+            // And we'll use the right stick's x axis as a rudder control
             .insert(
                 SingleGamepadAxis {
                     axis: GamepadAxisType::RightStickX,
@@ -83,13 +82,12 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     }
 
     if action_state.pressed(Action::Throttle) {
-        // Note that some gamepad buttons are also tied to axes,
-        // so even though we used a GamepadbuttonType::RightTrigger2 binding to trigger the
-        // throttle action,
-        // we can get a variable value here if you have a variable right trigger on your gamepad.
+        // Note that some gamepad buttons are also tied to axes, so even though we used a
+        // GamepadbuttonType::RightTrigger2 binding to trigger the throttle action, we can get a
+        // variable value here if you have a variable right trigger on your gamepad.
         //
-        // If you don't have a variable trigger,
-        // this will just return 0.0 when not pressed and 1.0 when pressed.
+        // If you don't have a variable trigger, this will just return 0.0 when not pressed and 1.0
+        // when pressed.
         let value = action_state.action_value(Action::Throttle);
         println!("Throttle: {}", value);
     }

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -44,7 +44,10 @@ fn spawn_player(mut commands: Commands) {
                         // Note: The Bevy `GamepadSettings` such as the axis deadzone with still apply.
                         // If bevy filters out a gamepad event,
                         // it will be filtered out of leafwing, too.
-                        deadzone: 0.1,
+                        x_positive_low: 0.1,
+                        x_negative_low: -0.1,
+                        y_positive_low: 0.1,
+                        y_negative_low: -0.1,
                     },
                     Action::Move,
                 ),

--- a/examples/binding_menu.rs
+++ b/examples/binding_menu.rs
@@ -8,7 +8,7 @@ use bevy_egui::{
     EguiContext, EguiPlugin,
 };
 use derive_more::Display;
-use leafwing_input_manager::{prelude::*, user_input::InputButton};
+use leafwing_input_manager::{prelude::*, user_input::InputKind};
 
 const UI_MARGIN: f32 = 10.0;
 
@@ -63,13 +63,15 @@ fn controls_window_system(
                         let inputs = control_settings.input.get(action);
                         for index in 0..INPUT_VARIANTS {
                             let button_text = match inputs.get_at(index) {
-                                Some(UserInput::Single(InputButton::Gamepad(gamepad_button))) => {
+                                Some(UserInput::Single(InputKind::GamepadButton(
+                                    gamepad_button,
+                                ))) => {
                                     format!("🎮 {:?}", gamepad_button)
                                 }
-                                Some(UserInput::Single(InputButton::Keyboard(keycode))) => {
+                                Some(UserInput::Single(InputKind::Keyboard(keycode))) => {
                                     format!("🖮 {:?}", keycode)
                                 }
-                                Some(UserInput::Single(InputButton::Mouse(mouse_button))) => {
+                                Some(UserInput::Single(InputKind::Mouse(mouse_button))) => {
                                     format!("🖱 {:?}", mouse_button)
                                 }
                                 _ => "Empty".to_string(),
@@ -238,7 +240,7 @@ impl ActiveBinding {
 
 struct BindingConflict {
     action: ControlAction,
-    input_button: InputButton,
+    input_button: InputKind,
 }
 
 /// Helper for collecting input
@@ -250,7 +252,7 @@ struct InputEvents<'w, 's> {
 }
 
 impl InputEvents<'_, '_> {
-    fn input_button(&mut self) -> Option<InputButton> {
+    fn input_button(&mut self) -> Option<InputKind> {
         if let Some(keyboard_input) = self.keys.iter().next() {
             if keyboard_input.state == ElementState::Released {
                 if let Some(key_code) = keyboard_input.key_code {

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -31,7 +31,7 @@ fn spawn_player(mut commands: Commands) {
             action_state: ActionState::default(),
             // Describes how to convert from player inputs into those actions
             input_map: InputMap::new([(
-                UserInput::VirtualDPad {
+                VirtualDPad {
                     up: KeyCode::W.into(),
                     down: KeyCode::S.into(),
                     left: KeyCode::A.into(),
@@ -50,7 +50,7 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     if action_state.pressed(Action::Move) {
         let axis_pair = action_state.action_axis_pair(Action::Move).unwrap();
         println!("Move:");
-        println!("   distance: {}", axis_pair.magnitude());
+        println!("   distance: {}", axis_pair.length());
         println!("          x: {}", axis_pair.x());
         println!("          y: {}", axis_pair.y());
     }

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -14,7 +14,6 @@ fn main() {
         .run();
 }
 
-// This is the list of "things in the game I want to be able to do based on input"
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Move,
@@ -49,7 +48,7 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
     // Each action has a button-like state of its own that you can check
     if action_state.pressed(Action::Move) {
-        let axis_pair = action_state.action_axis_pair(Action::Move);
+        let axis_pair = action_state.action_axis_pair(Action::Move).unwrap();
         println!("Move:");
         println!("   distance: {}", axis_pair.magnitude());
         println!("          x: {}", axis_pair.x());

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -29,7 +29,7 @@ fn spawn_player(mut commands: Commands) {
         .insert_bundle(InputManagerBundle::<Action> {
             // Stores "which actions are currently activated"
             action_state: ActionState::default(),
-            // Describes how to convert from player inputs into those actions
+            // Map some arbitrary keys into a virtual direction pad that triggers our move action
             input_map: InputMap::new([(
                 VirtualDPad {
                     up: KeyCode::W.into(),
@@ -46,8 +46,10 @@ fn spawn_player(mut commands: Commands) {
 // Query for the `ActionState` component in your game logic systems!
 fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
-    // Each action has a button-like state of its own that you can check
+    // If any button in a virtual direction pad is pressed, then the action state is "pressed"
     if action_state.pressed(Action::Move) {
+        // Virtual direction pads are one of the types which return an AxisPair. The values will be
+        // represented as `-1.0`, `0.0`, or `1.0` depending on the combination of buttons pressed.
         let axis_pair = action_state.action_axis_pair(Action::Move).unwrap();
         println!("Move:");
         println!("   distance: {}", axis_pair.length());

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -18,7 +18,6 @@ fn main() {
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Move,
-    Throttle,
 }
 
 #[derive(Component)]
@@ -33,20 +32,14 @@ fn spawn_player(mut commands: Commands) {
             action_state: ActionState::default(),
             // Describes how to convert from player inputs into those actions
             input_map: InputMap::new([(
-                // We want to trigger our move action when the left stick is moved more than 10% in
-                // any direction.
-                DualGamepadAxisThreshold {
-                    x_axis: GamepadAxisType::LeftStickX,
-                    y_axis: GamepadAxisType::LeftStickY,
-                    comparison: GamepadAxisComparison::Greater,
-                    threshold: 0.1,
+                UserInput::VirtualDPad {
+                    up: KeyCode::W.into(),
+                    down: KeyCode::S.into(),
+                    left: KeyCode::A.into(),
+                    right: KeyCode::D.into(),
                 },
                 Action::Move,
             )])
-            // Let's also add a gamepad button binding to the right trigger
-            .insert(GamepadButtonType::RightTrigger2, Action::Throttle)
-            // Listen for events on the first gamepad
-            .set_gamepad(Gamepad(0))
             .build(),
         });
 }
@@ -61,17 +54,5 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
         println!("   distance: {}", axis_pair.magnitude());
         println!("          x: {}", axis_pair.x());
         println!("          y: {}", axis_pair.y());
-    }
-
-    if action_state.pressed(Action::Throttle) {
-        // Note that some gamepad buttons are also tied to axes,
-        // so even though we used a GamepadbuttonType::RightTrigger2 binding to trigger the
-        // throttle action,
-        // we can get a variable value here if you have a variable right trigger on your gamepad.
-        //
-        // If you don't have a variable trigger,
-        // this will just return 0.0 when not pressed and 1.0 when pressed.
-        let value = action_state.action_value(Action::Throttle);
-        println!("Throttle: {}", value);
     }
 }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -195,19 +195,20 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// Different kinds of bindings have different ways of calculating the value:
     ///
-    /// - Binary buttons will have a value of `0.0` when the button is not pressed,
-    /// and a value of `1.0` when the button is pressed.
+    /// - Binary buttons will have a value of `0.0` when the button is not pressed, and a value of
+    /// `1.0` when the button is pressed.
     /// - Some axes, such as an analog stick, will have a value in the range `-1.0..=1.0`.
     /// - Some axes, such as a variable trigger, will have a value in the range `0.0..=1.0`.
-    /// - Some buttons will also return a value in the range `0.0..=1.0`,
-    /// such as variable triggers, which may be tracked as buttons or axes.
-    /// - Dual axis inputs will return the magnitude of it's [`AxisPair`] and will be in the range
+    /// - Some buttons will also return a value in the range `0.0..=1.0`, such as analog gamepad
+    /// triggers which may be tracked as buttons or axes. Examples of these include the Xbox LT/RT
+    /// triggers and the Playstation L2/R2 triggers. See also the `axis_inputs` example in the
+    /// repository.
+    /// - Dual axis inputs will return the magnitude of its [`AxisPair`] and will be in the range
     /// `0.0..=1.0`.
-    /// - Chord inputs will return the value of it's first input.
+    /// - Chord inputs will return the value of its first input.
     ///
-    /// If multiple inputs trigger the same game action at the same time,
-    /// the value of each triggering input will be added together and clamped to the range
-    /// `-1.0..=1.0`
+    /// If multiple inputs trigger the same game action at the same time, the value of each
+    /// triggering input will be added together and clamped to the range `-1.0..=1.0`
     pub fn action_value(&self, action: A) -> f32 {
         self.action_data(action).value
     }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -214,14 +214,14 @@ impl<A: Actionlike> ActionState<A> {
 
     /// Get the [`AxisPair`] from the binding that triggered the corresponding `action`.
     ///
-    /// Only certain events such as [`UserInput::VirtualDPad`] and
-    /// [`InputKind::DualGamepadAxis`][crate::user_input::InputKind::DualGamepadAxis] provide an
-    /// [`AxisPair`], and this will return [`None`] for other events.
+    /// Only certain events such as [`VirtualDPad`][crate::user_input::VirtualDPad] and
+    /// [`DualGamepadAxis`][crate::user_input::DualGamepadAxis] provide an [`AxisPair`], and this
+    /// will return [`None`] for other events.
     ///
     /// Chord inputs will return the [`AxisPair`] of it's first input.
     ///
-    /// If multiple inputs with an axis pair trigger the same game action at the same time,
-    /// the value of each axis pair will be added together and be clamped to a maximum magnitude of
+    /// If multiple inputs with an axis pair trigger the same game action at the same time, the
+    /// value of each axis pair will be added together and be clamped to a maximum magnitude of
     /// `1.0`.
     pub fn action_axis_pair(&self, action: A) -> Option<AxisPair> {
         self.action_data(action).axis_pair

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -16,6 +16,11 @@ use std::marker::PhantomData;
 pub struct ActionData {
     /// Is the action pressed or released?
     pub state: ButtonState,
+    /// The analog value of this button/axis, if applicable
+    ///
+    /// For binary inputs such as buttons, this will always be either 0.0 or 1.0. For analog axes
+    /// this will be in the range of `-1.0..=1.0`.
+    pub value: f32,
     /// What inputs were responsible for causing this action to be pressed?
     pub reasons_pressed: Vec<UserInput>,
     /// When was the button pressed / released, and how long has it been held for?
@@ -96,6 +101,7 @@ impl<A: Actionlike> ActionState<A> {
                 ButtonState::Released => self.release(action),
             }
 
+            self.action_data[i].value = action_data[i].value;
             self.action_data[i].reasons_pressed = action_data[i].reasons_pressed.clone();
         }
     }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -204,7 +204,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - Dual axis inputs will return the magnitude of it's [`AxisPair`] and will be in the range
     /// `0.0..=1.0`.
     /// - Chord inputs will return the value of it's first input.
-    /// 
+    ///
     /// If multiple inputs trigger the same game action at the same time,
     /// the value of each triggering input will be added together and clamped to the range
     /// `-1.0..=1.0`
@@ -217,9 +217,9 @@ impl<A: Actionlike> ActionState<A> {
     /// Only certain events such as [`UserInput::VirtualDPad`] and
     /// [`InputKind::DualGamepadAxis`][crate::user_input::InputKind::DualGamepadAxis] provide an
     /// [`AxisPair`], and this will return [`None`] for other events.
-    /// 
+    ///
     /// Chord inputs will return the [`AxisPair`] of it's first input.
-    /// 
+    ///
     /// If multiple inputs with an axis pair trigger the same game action at the same time,
     /// the value of each axis pair will be added together and be clamped to a maximum magnitude of
     /// `1.0`.

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -187,6 +187,23 @@ impl<A: Actionlike> ActionState<A> {
         self.action_data[action.index()].clone()
     }
 
+    /// Get the value associated with the corresponding `action`
+    /// 
+    /// For actions triggered by a variable axis, such as an analog stick,
+    /// this will be in the range of `-1.0..=1.0`.
+    /// 
+    /// For buttons this will be `0.0` when the button is not pressed,
+    /// and `1.0` when the button is pressed.
+    /// 
+    /// Some axes such as trigger buttons will return a value in the range of `-1.0..=1.0`.
+    /// 
+    /// Note that some buttons, such as [`GamepadButtonType::RightTrigger2`] are variable.
+    /// Variable buttons will return how "pressed" they are in this case as a value in the range
+    /// `0.0..=1.0`.
+    pub fn action_value(&self, action: A) -> f32 {
+        self.action_data(action).value
+    }
+
     /// Manually sets the [`ActionData`] of the corresponding `action`
     ///
     /// You should almost always use more direct methods, as they are simpler and less error-prone.

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -23,7 +23,7 @@ pub struct ActionData {
     /// The [`AxisPair`] of the binding that triggered the action.
     ///
     /// See [`ActionState::action_axis_pair()`] for more details.
-    pub axis_pair: AxisPair,
+    pub axis_pair: Option<AxisPair>,
     /// What inputs were responsible for causing this action to be pressed?
     pub reasons_pressed: Vec<UserInput>,
     /// When was the button pressed / released, and how long has it been held for?
@@ -203,16 +203,27 @@ impl<A: Actionlike> ActionState<A> {
     /// such as variable triggers, which may be tracked as buttons or axes.
     /// - Dual axis inputs will return the magnitude of it's [`AxisPair`] and will be in the range
     /// `0.0..=1.0`.
+    /// - Chord inputs will return the value of it's first input.
+    /// 
+    /// If multiple inputs trigger the same game action at the same time,
+    /// the value of each triggering input will be added together and clamped to the range
+    /// `-1.0..=1.0`
     pub fn action_value(&self, action: A) -> f32 {
         self.action_data(action).value
     }
 
-    /// Get the [`AxisPair`] associated to the binding that triggered the corresponding `action`.
+    /// Get the [`AxisPair`] from the binding that triggered the corresponding `action`.
     ///
-    /// If it was not a [`DualGamepadAxisThreshold`] that triggered the action,
-    /// this will be equal to an [`AxisPair`] that has it's x and y values set to the same value as
-    /// returned by [`action_value()`].
-    pub fn action_axis_pair(&self, action: A) -> AxisPair {
+    /// Only certain events such as [`UserInput::VirtualDPad`] and
+    /// [`InputKind::DualGamepadAxis`][crate::user_input::InputKind::DualGamepadAxis] provide an
+    /// [`AxisPair`], and this will return [`None`] for other events.
+    /// 
+    /// Chord inputs will return the [`AxisPair`] of it's first input.
+    /// 
+    /// If multiple inputs with an axis pair trigger the same game action at the same time,
+    /// the value of each axis pair will be added together and be clamped to a maximum magnitude of
+    /// `1.0`.
+    pub fn action_axis_pair(&self, action: A) -> Option<AxisPair> {
         self.action_data(action).axis_pair
     }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -29,6 +29,14 @@ impl AxisPair {
             AxisPair { xy: xy / magnitude }
         }
     }
+
+    /// Merge the state of this [`AxisPair`] with another.
+    /// 
+    /// This is useful if you have multiple sticks bound to the same game action,
+    /// and you want to get their combined position.
+    pub fn merged_with(&self, other: AxisPair) -> AxisPair {
+        AxisPair::new(self.xy() + other.xy())
+    }
 }
 
 // Methods

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -67,7 +67,7 @@ impl AxisPair {
     pub fn direction(&self) -> Option<Direction> {
         // TODO: replace this quick-n-dirty hack once Direction::new no longer panics
         if self.xy.length() > 0.00001 {
-            return Some(Direction::new(self.xy))
+            return Some(Direction::new(self.xy));
         }
         None
     }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -90,7 +90,7 @@ impl AxisPair {
     /// If you only need to compare relative magnitudes, use `magnitude_squared` instead for faster computation.
     #[must_use]
     #[inline]
-    pub fn magnitude(&self) -> f32 {
+    pub fn length(&self) -> f32 {
         self.xy.length()
     }
 
@@ -101,7 +101,7 @@ impl AxisPair {
     /// This is faster than `magnitude`, as it avoids a square root, but will generally have less natural behavior.
     #[must_use]
     #[inline]
-    pub fn magnitude_squared(&self) -> f32 {
+    pub fn length_squared(&self) -> f32 {
         self.xy.length_squared()
     }
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -2,6 +2,7 @@
 
 use crate::orientation::{Direction, Rotation};
 use bevy_math::Vec2;
+use serde::{Deserialize, Serialize};
 
 /// A high-level abstract user input that varies from -1 to 1, inclusive, along two axes
 ///
@@ -10,7 +11,7 @@ use bevy_math::Vec2;
 ///
 /// This struct should store the processed form of your raw inputs in a device-agnostic fashion.
 /// Any deadzone correction, rescaling or drift-correction should be done at an earlier level.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize)]
 pub struct AxisPair {
     xy: Vec2,
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -22,11 +22,8 @@ impl AxisPair {
     ///
     /// The direction is preserved, by the magnitude will be clamped to at most 1.
     pub fn new(xy: Vec2) -> AxisPair {
-        let magnitude = xy.length();
-        if magnitude <= 1. {
-            AxisPair { xy }
-        } else {
-            AxisPair { xy: xy / magnitude }
+        AxisPair {
+            xy: xy.clamp_length_max(1.0),
         }
     }
 
@@ -35,7 +32,7 @@ impl AxisPair {
     /// This is useful if you have multiple sticks bound to the same game action,
     /// and you want to get their combined position.
     pub fn merged_with(&self, other: AxisPair) -> AxisPair {
-        AxisPair::new(self.xy() + other.xy())
+        AxisPair::new((self.xy() + other.xy()).clamp_length_max(1.0))
     }
 }
 
@@ -64,11 +61,15 @@ impl AxisPair {
 
     /// The [`Direction`] that this axis is pointing towards, if any
     ///
-    /// If the axis is neutral (x,y) = (0,0), a (0, 0) `Direction` will be returned
+    /// If the axis is neutral (x,y) = (0,0), a (0, 0) `None` will be returned
     #[must_use]
     #[inline]
-    pub fn direction(&self) -> Direction {
-        Direction::new(self.xy)
+    pub fn direction(&self) -> Option<Direction> {
+        // TODO: replace this quick-n-dirty hack once Direction::new no longer panics
+        if self.xy.length() > 0.00001 {
+            return Some(Direction::new(self.xy))
+        }
+        None
     }
 
     /// The [`Rotation`] (measured clockwise from midnight) that this axis is pointing towards, if any

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -31,7 +31,7 @@ impl AxisPair {
     }
 
     /// Merge the state of this [`AxisPair`] with another.
-    /// 
+    ///
     /// This is useful if you have multiple sticks bound to the same game action,
     /// and you want to get their combined position.
     pub fn merged_with(&self, other: AxisPair) -> AxisPair {

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -2,7 +2,7 @@
 
 use crate::action_state::ActionData;
 use crate::input_map::InputMap;
-use crate::user_input::{InputButton, InputStreams, UserInput};
+use crate::user_input::{InputKind, InputStreams, UserInput};
 use crate::Actionlike;
 
 use itertools::Itertools;
@@ -189,7 +189,7 @@ impl<A: Actionlike> Clash<A> {
 
 /// Does the `button` clash with the `chord`?
 #[must_use]
-fn button_chord_clash(button: &InputButton, chord: &PetitSet<InputButton, 8>) -> bool {
+fn button_chord_clash(button: &InputKind, chord: &PetitSet<InputKind, 8>) -> bool {
     if chord.len() <= 1 {
         return false;
     }
@@ -199,10 +199,7 @@ fn button_chord_clash(button: &InputButton, chord: &PetitSet<InputButton, 8>) ->
 
 /// Does the `chord_a` clash with `chord_b`?
 #[must_use]
-fn chord_chord_clash(
-    chord_a: &PetitSet<InputButton, 8>,
-    chord_b: &PetitSet<InputButton, 8>,
-) -> bool {
+fn chord_chord_clash(chord_a: &PetitSet<InputKind, 8>, chord_b: &PetitSet<InputKind, 8>) -> bool {
     if chord_a.len() <= 1 || chord_b.len() <= 1 {
         return false;
     }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -117,7 +117,6 @@ impl<A: Actionlike> InputMap<A> {
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
 
-
         // We can limit our search to the cached set of possibly clashing actions
         for clash in self.possible_clashes() {
             // Clashes can only occur if both actions were triggered

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -2,7 +2,7 @@
 
 use crate::action_state::ActionData;
 use crate::input_map::InputMap;
-use crate::user_input::{InputKind, InputStreams, UserInput};
+use crate::user_input::{InputKind, InputStreams, UserInput, VirtualDPad};
 use crate::Actionlike;
 
 use itertools::Itertools;
@@ -56,15 +56,19 @@ impl UserInput {
         match self {
             Single(self_button) => match other {
                 Single(_) => false,
-                Chord(other_set) => button_chord_clash(self_button, other_set),
-                VirtualDPad { .. } => false,
+                Chord(other_chord) => button_chord_clash(self_button, other_chord),
+                VirtualDPad(other_dpad) => dpad_button_clash(other_dpad, self_button),
             },
-            Chord(self_set) => match other {
-                Single(other_button) => button_chord_clash(other_button, self_set),
-                Chord(other_set) => chord_chord_clash(self_set, other_set),
-                VirtualDPad { .. } => false,
+            Chord(self_chord) => match other {
+                Single(other_button) => button_chord_clash(other_button, self_chord),
+                Chord(other_chord) => chord_chord_clash(self_chord, other_chord),
+                VirtualDPad(other_dpad) => dpad_chord_clash(other_dpad, self_chord),
             },
-            VirtualDPad { .. } => false,
+            VirtualDPad(self_dpad) => match other {
+                Single(other_button) => dpad_button_clash(self_dpad, other_button),
+                Chord(other_chord) => dpad_chord_clash(self_dpad, other_chord),
+                VirtualDPad(other_dpad) => dpad_dpad_clash(self_dpad, other_dpad),
+            },
         }
     }
 }
@@ -112,6 +116,7 @@ impl<A: Actionlike> InputMap<A> {
         input_streams: &InputStreams,
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
+
 
         // We can limit our search to the cached set of possibly clashing actions
         for clash in self.possible_clashes() {
@@ -191,7 +196,7 @@ impl<A: Actionlike> Clash<A> {
     }
 }
 
-/// Does the `button` clash with the `chord`?
+// Does the `button` clash with the `chord`?
 #[must_use]
 fn button_chord_clash(button: &InputKind, chord: &PetitSet<InputKind, 8>) -> bool {
     if chord.len() <= 1 {
@@ -199,6 +204,44 @@ fn button_chord_clash(button: &InputKind, chord: &PetitSet<InputKind, 8>) -> boo
     }
 
     chord.contains(button)
+}
+
+// Does the `dpad` clash with the `chord`?
+#[must_use]
+fn dpad_chord_clash(dpad: &VirtualDPad, chord: &PetitSet<InputKind, 8>) -> bool {
+    if chord.len() <= 1 {
+        return false;
+    }
+
+    for button in &[dpad.up, dpad.down, dpad.left, dpad.right] {
+        if chord.contains(button) {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn dpad_button_clash(dpad: &VirtualDPad, button: &InputKind) -> bool {
+    for dpad_button in &[dpad.up, dpad.down, dpad.left, dpad.right] {
+        if button == dpad_button {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn dpad_dpad_clash(dpad1: &VirtualDPad, dpad2: &VirtualDPad) -> bool {
+    for button1 in &[dpad1.up, dpad1.down, dpad1.left, dpad1.right] {
+        for button2 in &[dpad2.up, dpad2.down, dpad2.left, dpad2.right] {
+            if button1 == button2 {
+                return true;
+            }
+        }
+    }
+
+    false
 }
 
 /// Does the `chord_a` clash with `chord_b`?
@@ -280,6 +323,8 @@ fn resolve_clash<A: Actionlike>(
         }
     }
 
+    println!("real clash");
+
     // There's a real clash; resolve it according to the `clash_strategy`
     match clash_strategy {
         // Do nothing
@@ -329,6 +374,8 @@ mod tests {
         CtrlOne,
         AltOne,
         CtrlAltOne,
+        MoveDPad,
+        CtrlUp,
     }
 
     fn test_input_map() -> InputMap<Action> {
@@ -344,11 +391,23 @@ mod tests {
         input_map.insert_chord([LControl, Key1], CtrlOne);
         input_map.insert_chord([LAlt, Key1], AltOne);
         input_map.insert_chord([LControl, LAlt, Key1], CtrlAltOne);
+        input_map.insert(
+            VirtualDPad {
+                up: Up.into(),
+                down: Down.into(),
+                left: Left.into(),
+                right: Right.into(),
+            },
+            MoveDPad,
+        );
+        input_map.insert_chord([LControl, Up], CtrlUp);
 
         input_map
     }
 
     mod basic_functionality {
+        use crate::user_input::VirtualDPad;
+
         use super::*;
 
         #[test]
@@ -359,12 +418,40 @@ mod tests {
             let ab = UserInput::chord([A, B]);
             let bc = UserInput::chord([B, C]);
             let abc = UserInput::chord([A, B, C]);
+            let axyz_dpad: UserInput = VirtualDPad {
+                up: A.into(),
+                down: X.into(),
+                left: Y.into(),
+                right: Z.into(),
+            }
+            .into();
+            let abcd_dpad: UserInput = VirtualDPad {
+                up: A.into(),
+                down: B.into(),
+                left: C.into(),
+                right: D.into(),
+            }
+            .into();
+
+            let ctrl_up: UserInput = UserInput::chord([Up, LControl]);
+            let directions_dpad: UserInput = VirtualDPad {
+                up: Up.into(),
+                down: Down.into(),
+                left: Left.into(),
+                right: Right.into(),
+            }
+            .into();
 
             assert!(!a.clashes(&b));
             assert!(a.clashes(&ab));
             assert!(!c.clashes(&ab));
             assert!(!ab.clashes(&bc));
-            assert!(ab.clashes(&abc))
+            assert!(ab.clashes(&abc));
+            assert!(axyz_dpad.clashes(&a));
+            assert!(axyz_dpad.clashes(&ab));
+            assert!(!axyz_dpad.clashes(&bc));
+            assert!(axyz_dpad.clashes(&abcd_dpad));
+            assert!(ctrl_up.clashes(&directions_dpad));
         }
 
         #[test]
@@ -424,15 +511,15 @@ mod tests {
         fn clash_caching() {
             let mut input_map = test_input_map();
             // Possible clashes are cached upon initialization
-            assert_eq!(input_map.possible_clashes().len(), 12);
+            assert_eq!(input_map.possible_clashes().len(), 13);
 
             // Possible clashes are cached upon binding insertion
             input_map.insert(UserInput::chord([LControl, LAlt, Key1]), Action::Two);
-            assert_eq!(input_map.possible_clashes().len(), 15);
+            assert_eq!(input_map.possible_clashes().len(), 16);
 
             // Possible clashes are cached upon binding removal
             input_map.clear_action(Action::One);
-            assert_eq!(input_map.possible_clashes().len(), 9);
+            assert_eq!(input_map.possible_clashes().len(), 10);
         }
 
         #[test]
@@ -514,7 +601,7 @@ mod tests {
         }
 
         #[test]
-        fn handle_clashes() {
+        fn handle_clashes1() {
             use crate::buttonlike::ButtonState;
             use bevy::prelude::*;
             use Action::*;
@@ -538,6 +625,35 @@ mod tests {
 
             let mut expected = vec![ActionData::default(); Action::N_VARIANTS];
             expected[OneAndTwo.index()].state = ButtonState::JustPressed;
+
+            assert_eq!(action_data, expected);
+        }
+
+        // Checks that a clash between a VirtualDPad and a chord choses the chord
+        #[test]
+        fn handle_clashes2() {
+            use crate::buttonlike::ButtonState;
+            use bevy::prelude::*;
+            use Action::*;
+
+            let input_map = test_input_map();
+
+            let mut keyboard: Input<KeyCode> = Default::default();
+            keyboard.press(LControl);
+            keyboard.press(Up);
+
+            let mut action_data = vec![ActionData::default(); Action::N_VARIANTS];
+            action_data[MoveDPad.index()].state = ButtonState::JustPressed;
+            action_data[CtrlUp.index()].state = ButtonState::JustPressed;
+
+            input_map.handle_clashes(
+                &mut action_data,
+                &InputStreams::from_keyboard(&keyboard),
+                ClashStrategy::PrioritizeLongest,
+            );
+
+            let mut expected = vec![ActionData::default(); Action::N_VARIANTS];
+            expected[CtrlUp.index()].state = ButtonState::JustPressed;
 
             assert_eq!(action_data, expected);
         }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -52,15 +52,19 @@ impl UserInput {
     fn clashes(&self, other: &UserInput) -> bool {
         use UserInput::*;
 
+        // TODO: Clash with dpads ( if that even makes sense )
         match self {
             Single(self_button) => match other {
                 Single(_) => false,
                 Chord(other_set) => button_chord_clash(self_button, other_set),
+                VirtualDPad { .. } => false,
             },
             Chord(self_set) => match other {
                 Single(other_button) => button_chord_clash(other_button, self_set),
                 Chord(other_set) => chord_chord_clash(self_set, other_set),
+                VirtualDPad { .. } => false,
             },
+            VirtualDPad { .. } => false,
         }
     }
 }

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -24,7 +24,8 @@ impl Display for UserInput {
 impl Display for InputKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InputKind::GamepadAxis(axis) => write!(f, "{axis:?}"),
+            InputKind::SingleGamepadAxis(axis) => write!(f, "{axis:?}"),
+            InputKind::DualGamepadAxis(axis) => write!(f, "{axis:?}"),
             InputKind::GamepadButton(button) => write!(f, "{button:?}"),
             InputKind::Mouse(button) => write!(f, "{button:?}"),
             InputKind::Keyboard(button) => write!(f, "{button:?}"),

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -1,6 +1,6 @@
 //! Containment module for boring implmentations of the [`Display`] trait
 
-use crate::user_input::{InputKind, UserInput};
+use crate::user_input::{InputKind, UserInput, VirtualDPad};
 use std::fmt::Display;
 
 impl Display for UserInput {
@@ -17,12 +17,12 @@ impl Display for UserInput {
                 }
                 write!(f, "{string}")
             }
-            UserInput::VirtualDPad {
+            UserInput::VirtualDPad(VirtualDPad {
                 up,
                 down,
                 left,
                 right,
-            } => {
+            }) => {
                 write!(
                     f,
                     "VirtualDPad(up: {}, down: {}, left: {}, right: {})",

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -17,6 +17,18 @@ impl Display for UserInput {
                 }
                 write!(f, "{string}")
             }
+            UserInput::VirtualDPad {
+                up,
+                down,
+                left,
+                right,
+            } => {
+                write!(
+                    f,
+                    "VirtualDPad(up: {}, down: {}, left: {}, right: {})",
+                    up, down, left, right
+                )
+            }
         }
     }
 }

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -1,6 +1,6 @@
 //! Containment module for boring implmentations of the [`Display`] trait
 
-use crate::user_input::{InputButton, UserInput};
+use crate::user_input::{InputKind, UserInput};
 use std::fmt::Display;
 
 impl Display for UserInput {
@@ -21,12 +21,13 @@ impl Display for UserInput {
     }
 }
 
-impl Display for InputButton {
+impl Display for InputKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            InputButton::Gamepad(button) => write!(f, "{button:?}"),
-            InputButton::Mouse(button) => write!(f, "{button:?}"),
-            InputButton::Keyboard(button) => write!(f, "{button:?}"),
+            InputKind::GamepadAxis(axis) => write!(f, "{axis:?}"),
+            InputKind::GamepadButton(button) => write!(f, "{button:?}"),
+            InputKind::Mouse(button) => write!(f, "{button:?}"),
+            InputKind::Keyboard(button) => write!(f, "{button:?}"),
         }
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -321,7 +321,15 @@ impl<A: Actionlike> InputMap<A> {
                     action.reasons_pressed.push(input.clone());
                     action.value += value;
                     action.value = action.value.clamp(-1.0, 1.0);
-                    action.axis_pair = AxisPair::new(action.axis_pair.xy() + axis_pair.xy());
+
+                    // Merge axis pair into action data
+                    if let Some(axis_pair) = axis_pair {
+                        if let Some(current_axis_pair) = &mut action.axis_pair {
+                            *current_axis_pair = current_axis_pair.merged_with(axis_pair);
+                        } else {
+                            action.axis_pair = Some(axis_pair);
+                        }
+                    }
                 }
             }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,7 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
 use crate::action_state::ActionData;
+use crate::axislike::AxisPair;
 use crate::buttonlike::ButtonState;
 use crate::clashing_inputs::ClashStrategy;
 use crate::user_input::{InputKind, InputStreams, UserInput};
@@ -313,12 +314,14 @@ impl<A: Actionlike> InputMap<A> {
 
             for input in self.get(action.clone()).iter() {
                 let value = input_streams.get_input_value(input);
+                let axis_pair = input_streams.get_input_axis_pair(input);
                 if input_streams.input_pressed(input) {
                     inputs.push(input.clone());
                     let action = &mut action_data[action.index()];
                     action.reasons_pressed.push(input.clone());
                     action.value += value;
                     action.value = action.value.clamp(-1.0, 1.0);
+                    action.axis_pair = AxisPair::new(action.axis_pair.xy() + axis_pair.xy());
                 }
             }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -3,7 +3,7 @@
 use crate::action_state::ActionData;
 use crate::buttonlike::ButtonState;
 use crate::clashing_inputs::ClashStrategy;
-use crate::user_input::{InputButton, InputStreams, UserInput};
+use crate::user_input::{InputKind, InputStreams, UserInput};
 use crate::Actionlike;
 
 use bevy_ecs::component::Component;
@@ -38,7 +38,7 @@ use std::marker::PhantomData;
 /// ```rust
 /// use bevy::prelude::*;
 /// use leafwing_input_manager::prelude::*;
-/// use leafwing_input_manager::user_input::InputButton;
+/// use leafwing_input_manager::user_input::InputKind;
 ///
 /// // You can Run!
 /// // But you can't Hide :(
@@ -51,7 +51,7 @@ use std::marker::PhantomData;
 /// // Construction
 /// let mut input_map = InputMap::new([
 ///    // Note that the type of your iterators must be homogenous;
-///    // you can use `InputButton` or `UserInput` if needed
+///    // you can use `InputKind` or `UserInput` if needed
 ///    // as unifiying types
 ///   (GamepadButtonType::South, Action::Run),
 ///   (GamepadButtonType::LeftTrigger, Action::Hide),
@@ -63,9 +63,9 @@ use std::marker::PhantomData;
 /// .insert(KeyCode::LShift, Action::Run)
 /// // Chords
 /// .insert_chord([KeyCode::LControl, KeyCode::R], Action::Run)
-/// .insert_chord([InputButton::Keyboard(KeyCode::H),
-///                InputButton::Gamepad(GamepadButtonType::South),
-///                InputButton::Mouse(MouseButton::Middle)],
+/// .insert_chord([InputKind::Keyboard(KeyCode::H),
+///                InputKind::GamepadButton(GamepadButtonType::South),
+///                InputKind::Mouse(MouseButton::Middle)],
 ///            Action::Hide);
 ///
 /// // Removal
@@ -217,7 +217,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Panics if the map is full and `buttons` is not a duplicate.
     pub fn insert_chord(
         &mut self,
-        buttons: impl IntoIterator<Item = impl Into<InputButton>>,
+        buttons: impl IntoIterator<Item = impl Into<InputKind>>,
         action: A,
     ) -> &mut Self {
         self.insert(UserInput::chord(buttons), action);
@@ -312,11 +312,13 @@ impl<A: Actionlike> InputMap<A> {
             let mut inputs = Vec::new();
 
             for input in self.get(action.clone()).iter() {
+                let value = input_streams.get_input_value(input);
                 if input_streams.input_pressed(input) {
                     inputs.push(input.clone());
-                    action_data[action.index()]
-                        .reasons_pressed
-                        .push(input.clone());
+                    let action = &mut action_data[action.index()];
+                    action.reasons_pressed.push(input.clone());
+                    action.value += value;
+                    action.value = action.value.clamp(-1.0, 1.0);
                 }
             }
 
@@ -526,7 +528,7 @@ mod tests {
 
     #[test]
     fn mock_inputs() {
-        use crate::input_map::InputButton;
+        use crate::input_map::InputKind;
         use crate::user_input::InputStreams;
         use bevy::prelude::*;
 
@@ -552,19 +554,23 @@ mod tests {
         // Cross-device chords
         input_map.insert_chord(
             [
-                InputButton::Keyboard(KeyCode::LControl),
-                InputButton::Mouse(MouseButton::Left),
+                InputKind::Keyboard(KeyCode::LControl),
+                InputKind::Mouse(MouseButton::Left),
             ],
             Action::Hide,
         );
 
         // Input streams
-        let mut gamepad_input_stream = Input::<GamepadButton>::default();
+        let mut gamepad_button_input_stream = Input::<GamepadButton>::default();
+        let gamepad_button_axis_input_stream = Axis::<GamepadButton>::default();
+        let gamepad_axis_input_stream = Axis::<GamepadAxis>::default();
         let mut keyboard_input_stream = Input::<KeyCode>::default();
         let mut mouse_input_stream = Input::<MouseButton>::default();
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -576,10 +582,12 @@ mod tests {
         }
 
         // Pressing the wrong gamepad
-        gamepad_input_stream.press(GamepadButton(Gamepad(0), GamepadButtonType::South));
+        gamepad_button_input_stream.press(GamepadButton(Gamepad(0), GamepadButtonType::South));
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -589,10 +597,12 @@ mod tests {
         }
 
         // Pressing the correct gamepad
-        gamepad_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::South));
+        gamepad_button_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::South));
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -602,11 +612,13 @@ mod tests {
         assert!(!input_map.pressed(Action::Jump, &input_streams, ClashStrategy::PressAll));
 
         // Chord
-        gamepad_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::South));
-        gamepad_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::North));
+        gamepad_button_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::South));
+        gamepad_button_input_stream.press(GamepadButton(Gamepad(42), GamepadButtonType::North));
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -616,9 +628,11 @@ mod tests {
         assert!(input_map.pressed(Action::Jump, &input_streams, ClashStrategy::PressAll));
 
         // Clearing inputs
-        gamepad_input_stream = Input::<GamepadButton>::default();
+        gamepad_button_input_stream = Input::<GamepadButton>::default();
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -632,7 +646,9 @@ mod tests {
         keyboard_input_stream.press(KeyCode::LShift);
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -648,7 +664,9 @@ mod tests {
         mouse_input_stream.press(MouseButton::Other(42));
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),
@@ -664,7 +682,9 @@ mod tests {
         mouse_input_stream.press(MouseButton::Left);
 
         let input_streams = InputStreams {
-            gamepad: Some(&gamepad_input_stream),
+            gamepad_buttons: Some(&gamepad_button_input_stream),
+            gamepad_button_axes: Some(&gamepad_button_axis_input_stream),
+            gamepad_axes: Some(&gamepad_axis_input_stream),
             keyboard: Some(&keyboard_input_stream),
             mouse: Some(&mouse_input_stream),
             associated_gamepad: Some(Gamepad(42)),

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,7 +1,6 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
 use crate::action_state::ActionData;
-use crate::axislike::AxisPair;
 use crate::buttonlike::ButtonState;
 use crate::clashing_inputs::ClashStrategy;
 use crate::user_input::{InputKind, InputStreams, UserInput};

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -121,13 +121,24 @@ impl<'a> MutableInputStreams<'a> {
     /// Called by the methods of [`MockInput`].
     pub fn send_user_input(&mut self, input: impl Into<UserInput>) {
         let input_to_send: UserInput = input.into();
-        let (gamepad_buttons, keyboard_buttons, mouse_buttons) = input_to_send.raw_inputs();
+        let (gamepad_buttons, gamepad_axes, keyboard_buttons, mouse_buttons) =
+            input_to_send.raw_inputs();
 
         if let Some(ref mut gamepad_input) = self.gamepad_buttons {
             for button in gamepad_buttons {
                 if let Some(associated_gamepad) = self.associated_gamepad {
                     let gamepad_button = GamepadButton(associated_gamepad, button);
                     gamepad_input.press(gamepad_button);
+                }
+            }
+        }
+
+        if let Some(ref mut gamepad_input) = self.gamepad_axes {
+            for axis in gamepad_axes {
+                if let Some(associated_gamepad) = self.associated_gamepad {
+                    let gamepad_axis = GamepadAxis(associated_gamepad, axis);
+                    // FIXME: Allow setting axis input value
+                    gamepad_input.set(gamepad_axis, 1.0);
                 }
             }
         }
@@ -150,13 +161,23 @@ impl<'a> MutableInputStreams<'a> {
     /// Called by the methods of [`MockInput`].
     pub fn release_user_input(&mut self, input: impl Into<UserInput>) {
         let input_to_release: UserInput = input.into();
-        let (gamepad_buttons, keyboard_buttons, mouse_buttons) = input_to_release.raw_inputs();
+        let (gamepad_buttons, gamepad_axes, keyboard_buttons, mouse_buttons) =
+            input_to_release.raw_inputs();
 
         if let Some(ref mut gamepad_input) = self.gamepad_buttons {
             for button in gamepad_buttons {
                 if let Some(associated_gamepad) = self.associated_gamepad {
                     let gamepad_button = GamepadButton(associated_gamepad, button);
                     gamepad_input.release(gamepad_button);
+                }
+            }
+        }
+
+        if let Some(ref mut gamepad_input) = self.gamepad_axes {
+            for axis in gamepad_axes {
+                if let Some(associated_gamepad) = self.associated_gamepad {
+                    let gamepad_axis = GamepadAxis(associated_gamepad, axis);
+                    gamepad_input.remove(gamepad_axis);
                 }
             }
         }

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -8,11 +8,11 @@ use bevy_ecs::world::World;
 #[cfg(feature = "ui")]
 use bevy_ecs::{component::Component, query::With, system::Query};
 use bevy_input::{
-    gamepad::{Gamepad, GamepadButton, GamepadEvent, Gamepads},
+    gamepad::{Gamepad, GamepadAxis, GamepadButton, GamepadEvent, Gamepads},
     keyboard::{KeyCode, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseWheel},
     touch::{TouchInput, Touches},
-    Input,
+    Axis, Input,
 };
 #[cfg(feature = "ui")]
 use bevy_ui::Interaction;
@@ -123,7 +123,7 @@ impl<'a> MutableInputStreams<'a> {
         let input_to_send: UserInput = input.into();
         let (gamepad_buttons, keyboard_buttons, mouse_buttons) = input_to_send.raw_inputs();
 
-        if let Some(ref mut gamepad_input) = self.gamepad {
+        if let Some(ref mut gamepad_input) = self.gamepad_buttons {
             for button in gamepad_buttons {
                 if let Some(associated_gamepad) = self.associated_gamepad {
                     let gamepad_button = GamepadButton(associated_gamepad, button);
@@ -152,7 +152,7 @@ impl<'a> MutableInputStreams<'a> {
         let input_to_release: UserInput = input.into();
         let (gamepad_buttons, keyboard_buttons, mouse_buttons) = input_to_release.raw_inputs();
 
-        if let Some(ref mut gamepad_input) = self.gamepad {
+        if let Some(ref mut gamepad_input) = self.gamepad_buttons {
             for button in gamepad_buttons {
                 if let Some(associated_gamepad) = self.associated_gamepad {
                     let gamepad_button = GamepadButton(associated_gamepad, button);
@@ -191,15 +191,24 @@ impl MockInput for World {
         // in a non-exclusive system
         let mut input_system_state: SystemState<(
             Option<ResMut<Input<GamepadButton>>>,
+            Option<ResMut<Axis<GamepadButton>>>,
+            Option<ResMut<Axis<GamepadAxis>>>,
             Option<ResMut<Input<KeyCode>>>,
             Option<ResMut<Input<MouseButton>>>,
         )> = SystemState::new(self);
 
-        let (mut maybe_gamepad, mut maybe_keyboard, mut maybe_mouse) =
-            input_system_state.get_mut(self);
+        let (
+            mut maybe_gamepad_buttons,
+            mut maybe_gamepad_button_axes,
+            mut maybe_gamepad_axes,
+            mut maybe_keyboard,
+            mut maybe_mouse,
+        ) = input_system_state.get_mut(self);
 
         let mut mutable_input_streams = MutableInputStreams {
-            gamepad: maybe_gamepad.as_deref_mut(),
+            gamepad_buttons: maybe_gamepad_buttons.as_deref_mut(),
+            gamepad_button_axes: maybe_gamepad_button_axes.as_deref_mut(),
+            gamepad_axes: maybe_gamepad_axes.as_deref_mut(),
             keyboard: maybe_keyboard.as_deref_mut(),
             mouse: maybe_mouse.as_deref_mut(),
             associated_gamepad: gamepad,
@@ -221,15 +230,24 @@ impl MockInput for World {
     fn release_input_for_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
         let mut input_system_state: SystemState<(
             Option<ResMut<Input<GamepadButton>>>,
+            Option<ResMut<Axis<GamepadButton>>>,
+            Option<ResMut<Axis<GamepadAxis>>>,
             Option<ResMut<Input<KeyCode>>>,
             Option<ResMut<Input<MouseButton>>>,
         )> = SystemState::new(self);
 
-        let (mut maybe_gamepad, mut maybe_keyboard, mut maybe_mouse) =
-            input_system_state.get_mut(self);
+        let (
+            mut maybe_gamepad_buttons,
+            mut maybe_gamepad_button_axes,
+            mut maybe_gamepad_axes,
+            mut maybe_keyboard,
+            mut maybe_mouse,
+        ) = input_system_state.get_mut(self);
 
         let mut mutable_input_streams = MutableInputStreams {
-            gamepad: maybe_gamepad.as_deref_mut(),
+            gamepad_buttons: maybe_gamepad_buttons.as_deref_mut(),
+            gamepad_button_axes: maybe_gamepad_button_axes.as_deref_mut(),
+            gamepad_axes: maybe_gamepad_axes.as_deref_mut(),
             keyboard: maybe_keyboard.as_deref_mut(),
             mouse: maybe_mouse.as_deref_mut(),
             associated_gamepad: gamepad,
@@ -255,14 +273,24 @@ impl MockInput for World {
     ) -> bool {
         let mut input_system_state: SystemState<(
             Option<Res<Input<GamepadButton>>>,
+            Option<Res<Axis<GamepadButton>>>,
+            Option<Res<Axis<GamepadAxis>>>,
             Option<Res<Input<KeyCode>>>,
             Option<Res<Input<MouseButton>>>,
         )> = SystemState::new(self);
 
-        let (maybe_gamepad, maybe_keyboard, maybe_mouse) = input_system_state.get(self);
+        let (
+            maybe_gamepad_buttons,
+            maybe_gamepad_button_axes,
+            maybe_gamepad_axes,
+            maybe_keyboard,
+            maybe_mouse,
+        ) = input_system_state.get(self);
 
         let input_streams = InputStreams {
-            gamepad: maybe_gamepad.as_deref(),
+            gamepad_buttons: maybe_gamepad_buttons.as_deref(),
+            gamepad_button_axes: maybe_gamepad_button_axes.as_deref(),
+            gamepad_axes: maybe_gamepad_axes.as_deref(),
             keyboard: maybe_keyboard.as_deref(),
             mouse: maybe_mouse.as_deref(),
             associated_gamepad: gamepad,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::UserInput;
+    pub use crate::user_input::{GamepadAxisComparison, GamepadAxisThreshold, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput};
+    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput, VirtualDPad};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,9 @@ pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{GamepadAxisComparison, SingleGamepadAxisThreshold, UserInput};
+    pub use crate::user_input::{
+        DualGamepadAxisThreshold, GamepadAxisComparison, SingleGamepadAxisThreshold, UserInput,
+    };
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,7 @@ pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{
-        DualGamepadAxisThreshold, GamepadAxisComparison, SingleGamepadAxisThreshold, UserInput,
-    };
+    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{GamepadAxisComparison, GamepadAxisThreshold, UserInput};
+    pub use crate::user_input::{GamepadAxisComparison, SingleGamepadAxisThreshold, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -13,7 +13,12 @@ use crate::{
 
 use bevy_core::Time;
 use bevy_ecs::{prelude::*, schedule::ShouldRun};
-use bevy_input::{gamepad::GamepadButton, keyboard::KeyCode, mouse::MouseButton, Input};
+use bevy_input::{
+    gamepad::{GamepadAxis, GamepadButton},
+    keyboard::KeyCode,
+    mouse::MouseButton,
+    Axis, Input,
+};
 use bevy_utils::Instant;
 
 #[cfg(feature = "ui")]
@@ -54,7 +59,9 @@ pub fn tick_action_state<A: Actionlike>(
 /// Missing resources will be ignored, and treated as if none of the corresponding inputs were pressed
 #[allow(clippy::too_many_arguments)]
 pub fn update_action_state<A: Actionlike>(
-    maybe_gamepad_input_stream: Option<Res<Input<GamepadButton>>>,
+    maybe_gamepad_button_input_stream: Option<Res<Input<GamepadButton>>>,
+    maybe_gamepad_button_axes_input_stream: Option<Res<Axis<GamepadButton>>>,
+    maybe_gamepad_axes_input_stream: Option<Res<Axis<GamepadAxis>>>,
     maybe_keyboard_input_stream: Option<Res<Input<KeyCode>>>,
     maybe_mouse_input_stream: Option<Res<Input<MouseButton>>>,
     clash_strategy: Res<ClashStrategy>,
@@ -62,7 +69,9 @@ pub fn update_action_state<A: Actionlike>(
     mut input_map: Option<ResMut<InputMap<A>>>,
     mut query: Query<(&mut ActionState<A>, &InputMap<A>)>,
 ) {
-    let gamepad = maybe_gamepad_input_stream.as_deref();
+    let gamepad_buttons = maybe_gamepad_button_input_stream.as_deref();
+    let gamepad_button_axes = maybe_gamepad_button_axes_input_stream.as_deref();
+    let gamepad_axes = maybe_gamepad_axes_input_stream.as_deref();
 
     let keyboard = maybe_keyboard_input_stream.as_deref();
 
@@ -70,7 +79,9 @@ pub fn update_action_state<A: Actionlike>(
 
     if let (Some(input_map), Some(action_state)) = (&mut input_map, &mut action_state) {
         let input_streams = InputStreams {
-            gamepad,
+            gamepad_buttons,
+            gamepad_button_axes,
+            gamepad_axes,
             keyboard,
             mouse,
             associated_gamepad: input_map.gamepad(),
@@ -81,7 +92,9 @@ pub fn update_action_state<A: Actionlike>(
 
     for (mut action_state, input_map) in query.iter_mut() {
         let input_streams = InputStreams {
-            gamepad,
+            gamepad_buttons,
+            gamepad_button_axes,
+            gamepad_axes,
             keyboard,
             mouse,
             associated_gamepad: input_map.gamepad(),

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -381,7 +381,7 @@ pub struct SingleGamepadAxis {
     /// The axis that is being checked.
     pub axis: GamepadAxisType,
     /// How high the axis movement must go in the positive direction before the action is triggered.
-    /// 
+    ///
     /// For example if this is set to `0.2`,
     /// an axis movement value of `0.3` will trigger the action,
     /// but an axis movement of `0.1` will not trigger the action.
@@ -411,7 +411,7 @@ impl std::hash::Hash for SingleGamepadAxis {
 }
 
 /// Two gamepad axes combined as one input.
-/// 
+///
 /// This input will generate [`AxisPair`] can be read with
 /// [`ActionState::action_axis_pair()`][crate::ActionState::action_axis_pair()].
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -259,7 +259,12 @@ impl UserInput {
             }
         };
 
-        (gamepad_buttons, gamepad_axes, keyboard_buttons, mouse_buttons)
+        (
+            gamepad_buttons,
+            gamepad_axes,
+            keyboard_buttons,
+            mouse_buttons,
+        )
     }
 }
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -1,10 +1,10 @@
 //! Helpful abstractions over user inputs of all sorts
 
 use bevy_input::{
-    gamepad::{Gamepad, GamepadButton, GamepadButtonType},
+    gamepad::{Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType},
     keyboard::KeyCode,
     mouse::MouseButton,
-    Input,
+    Axis, Input,
 };
 
 use bevy_utils::HashSet;
@@ -17,23 +17,23 @@ use serde::{Deserialize, Serialize};
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum UserInput {
     /// A single button
-    Single(InputButton),
+    Single(InputKind),
     /// A combination of buttons, pressed simultaneously
     ///
     /// Up to 8 (!!) buttons can be chorded together at once.
     /// Chords are considered to belong to all of the [InputMode]s of their constituent buttons.
-    Chord(PetitSet<InputButton, 8>),
+    Chord(PetitSet<InputKind, 8>),
 }
 
 impl UserInput {
     /// Creates a [`UserInput::Chord`] from an iterator of [`Button`]s
     ///
     /// If `buttons` has a length of 1, a [`UserInput::Single`] variant will be returned instead.
-    pub fn chord(buttons: impl IntoIterator<Item = impl Into<InputButton>>) -> Self {
+    pub fn chord(buttons: impl IntoIterator<Item = impl Into<InputKind>>) -> Self {
         // We can't just check the length unless we add an ExactSizeIterator bound :(
         let mut length: u8 = 0;
 
-        let mut set: PetitSet<InputButton, 8> = PetitSet::default();
+        let mut set: PetitSet<InputKind, 8> = PetitSet::default();
         for button in buttons {
             length += 1;
             set.insert(button.into());
@@ -114,7 +114,7 @@ impl UserInput {
     /// assert_eq!(ctrl_a.n_matching(&buttons), 1);
     /// assert_eq!(ctrl_alt_a.n_matching(&buttons), 2);
     /// ```
-    pub fn n_matching(&self, buttons: &HashSet<InputButton>) -> usize {
+    pub fn n_matching(&self, buttons: &HashSet<InputKind>) -> usize {
         match self {
             UserInput::Single(button) => {
                 if buttons.contains(button) {
@@ -138,22 +138,25 @@ impl UserInput {
 
     /// Returns the raw inputs that make up this [`UserInput`]
     pub fn raw_inputs(&self) -> (Vec<GamepadButtonType>, Vec<KeyCode>, Vec<MouseButton>) {
+        let mut gamepad_axes: Vec<GamepadAxisType> = Vec::default();
         let mut gamepad_buttons: Vec<GamepadButtonType> = Vec::default();
         let mut keyboard_buttons: Vec<KeyCode> = Vec::default();
         let mut mouse_buttons: Vec<MouseButton> = Vec::default();
 
         match self {
             UserInput::Single(button) => match *button {
-                InputButton::Gamepad(variant) => gamepad_buttons.push(variant),
-                InputButton::Keyboard(variant) => keyboard_buttons.push(variant),
-                InputButton::Mouse(variant) => mouse_buttons.push(variant),
+                InputKind::GamepadAxis(variant) => gamepad_axes.push(variant.axis),
+                InputKind::GamepadButton(variant) => gamepad_buttons.push(variant),
+                InputKind::Keyboard(variant) => keyboard_buttons.push(variant),
+                InputKind::Mouse(variant) => mouse_buttons.push(variant),
             },
             UserInput::Chord(button_set) => {
                 for button in button_set.iter() {
                     match button {
-                        InputButton::Gamepad(variant) => gamepad_buttons.push(*variant),
-                        InputButton::Keyboard(variant) => keyboard_buttons.push(*variant),
-                        InputButton::Mouse(variant) => mouse_buttons.push(*variant),
+                        InputKind::GamepadAxis(variant) => gamepad_axes.push(variant.axis),
+                        InputKind::GamepadButton(variant) => gamepad_buttons.push(*variant),
+                        InputKind::Keyboard(variant) => keyboard_buttons.push(*variant),
+                        InputKind::Mouse(variant) => mouse_buttons.push(*variant),
                     }
                 }
             }
@@ -163,27 +166,33 @@ impl UserInput {
     }
 }
 
-impl From<InputButton> for UserInput {
-    fn from(input: InputButton) -> Self {
+impl From<InputKind> for UserInput {
+    fn from(input: InputKind) -> Self {
         UserInput::Single(input)
+    }
+}
+
+impl From<GamepadAxisThreshold> for UserInput {
+    fn from(input: GamepadAxisThreshold) -> Self {
+        UserInput::Single(InputKind::GamepadAxis(input))
     }
 }
 
 impl From<GamepadButtonType> for UserInput {
     fn from(input: GamepadButtonType) -> Self {
-        UserInput::Single(InputButton::Gamepad(input))
+        UserInput::Single(InputKind::GamepadButton(input))
     }
 }
 
 impl From<KeyCode> for UserInput {
     fn from(input: KeyCode) -> Self {
-        UserInput::Single(InputButton::Keyboard(input))
+        UserInput::Single(InputKind::Keyboard(input))
     }
 }
 
 impl From<MouseButton> for UserInput {
     fn from(input: MouseButton) -> Self {
-        UserInput::Single(InputButton::Mouse(input))
+        UserInput::Single(InputKind::Mouse(input))
     }
 }
 
@@ -240,12 +249,12 @@ impl Iterator for InputModeIter {
     }
 }
 
-impl From<InputButton> for InputMode {
-    fn from(button: InputButton) -> Self {
+impl From<InputKind> for InputMode {
+    fn from(button: InputKind) -> Self {
         match button {
-            InputButton::Gamepad(_) => InputMode::Gamepad,
-            InputButton::Keyboard(_) => InputMode::Keyboard,
-            InputButton::Mouse(_) => InputMode::Mouse,
+            InputKind::GamepadButton(_) | InputKind::GamepadAxis(_) => InputMode::Gamepad,
+            InputKind::Keyboard(_) => InputMode::Keyboard,
+            InputKind::Mouse(_) => InputMode::Mouse,
         }
     }
 }
@@ -260,30 +269,81 @@ impl From<InputButton> for InputMode {
 /// Please contact the maintainers if you need support for another type!
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub enum InputButton {
+pub enum InputKind {
     /// A button on a gamepad
-    Gamepad(GamepadButtonType),
+    GamepadButton(GamepadButtonType),
+    /// An axis on a gamepad
+    GamepadAxis(GamepadAxisThreshold),
     /// A button on a keyboard
     Keyboard(KeyCode),
     /// A button on a mouse
     Mouse(MouseButton),
 }
 
-impl From<GamepadButtonType> for InputButton {
+/// Used to indicate at which point a gamepad axis event should trigger an action.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct GamepadAxisThreshold {
+    /// The axis that is being checked.
+    pub axis: GamepadAxisType,
+    /// Indicates whether the action should trigger when the axis value is greater, lesser, or equal
+    /// to the `threshold`.
+    pub comparison: GamepadAxisComparison,
+    /// The threshold to compare the current axis value with.
+    pub threshold: f32,
+}
+
+impl PartialEq for GamepadAxisThreshold {
+    fn eq(&self, other: &Self) -> bool {
+        use bevy_core::FloatOrd;
+        self.axis == other.axis
+            && self.comparison == other.comparison
+            && FloatOrd(self.threshold) == FloatOrd(other.threshold)
+    }
+}
+impl Eq for GamepadAxisThreshold {}
+impl std::hash::Hash for GamepadAxisThreshold {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        use bevy_core::FloatOrd;
+        self.axis.hash(state);
+        self.comparison.hash(state);
+        FloatOrd(self.threshold).hash(state);
+    }
+}
+
+/// Different possible ways to compare an axis threshold to the axis value.
+///
+/// See [`GamepadAxisThreshold`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum GamepadAxisComparison {
+    /// Value must be less than threshold
+    Less,
+    /// Value must be greater than threshold
+    Greater,
+    /// Value must be equal to threshold
+    Equal,
+}
+
+impl From<GamepadAxisThreshold> for InputKind {
+    fn from(input: GamepadAxisThreshold) -> Self {
+        InputKind::GamepadAxis(input)
+    }
+}
+
+impl From<GamepadButtonType> for InputKind {
     fn from(input: GamepadButtonType) -> Self {
-        InputButton::Gamepad(input)
+        InputKind::GamepadButton(input)
     }
 }
 
-impl From<KeyCode> for InputButton {
+impl From<KeyCode> for InputKind {
     fn from(input: KeyCode) -> Self {
-        InputButton::Keyboard(input)
+        InputKind::Keyboard(input)
     }
 }
 
-impl From<MouseButton> for InputButton {
+impl From<MouseButton> for InputKind {
     fn from(input: MouseButton) -> Self {
-        InputButton::Mouse(input)
+        InputKind::Mouse(input)
     }
 }
 
@@ -295,7 +355,11 @@ impl From<MouseButton> for InputButton {
 #[derive(Debug, Clone)]
 pub struct InputStreams<'a> {
     /// An optional [`GamepadButton`] [`Input`] stream
-    pub gamepad: Option<&'a Input<GamepadButton>>,
+    pub gamepad_buttons: Option<&'a Input<GamepadButton>>,
+    /// An optional [`GamepadButton`] [`Axis`] stream
+    pub gamepad_button_axes: Option<&'a Axis<GamepadButton>>,
+    /// An optional [`GamepadAxis`] [`Axis`] stream
+    pub gamepad_axes: Option<&'a Axis<GamepadAxis>>,
     /// An optional [`KeyCode`] [`Input`] stream
     pub keyboard: Option<&'a Input<KeyCode>>,
     /// An optional [`MouseButton`] [`Input`] stream
@@ -308,11 +372,15 @@ pub struct InputStreams<'a> {
 impl<'a> InputStreams<'a> {
     /// Construct [`InputStreams`] with only a [`GamepadButton`] input stream
     pub fn from_gamepad(
-        gamepad_input_stream: &'a Input<GamepadButton>,
+        gamepad_button_stream: &'a Input<GamepadButton>,
+        gamepad_button_axis_stream: &'a Axis<GamepadButton>,
+        gamepad_axis_stream: &'a Axis<GamepadAxis>,
         associated_gamepad: Gamepad,
     ) -> Self {
         Self {
-            gamepad: Some(gamepad_input_stream),
+            gamepad_buttons: Some(gamepad_button_stream),
+            gamepad_button_axes: Some(gamepad_button_axis_stream),
+            gamepad_axes: Some(gamepad_axis_stream),
             keyboard: None,
             mouse: None,
             associated_gamepad: Some(associated_gamepad),
@@ -322,7 +390,9 @@ impl<'a> InputStreams<'a> {
     /// Construct [`InputStreams`] with only a [`KeyCode`] input stream
     pub fn from_keyboard(keyboard_input_stream: &'a Input<KeyCode>) -> Self {
         Self {
-            gamepad: None,
+            gamepad_buttons: None,
+            gamepad_button_axes: None,
+            gamepad_axes: None,
             keyboard: Some(keyboard_input_stream),
             mouse: None,
             associated_gamepad: None,
@@ -332,7 +402,9 @@ impl<'a> InputStreams<'a> {
     /// Construct [`InputStreams`] with only a [`GamepadButton`] input stream
     pub fn from_mouse(mouse_input_stream: &'a Input<MouseButton>) -> Self {
         Self {
-            gamepad: None,
+            gamepad_buttons: None,
+            gamepad_button_axes: None,
+            gamepad_axes: None,
             keyboard: None,
             mouse: Some(mouse_input_stream),
             associated_gamepad: None,
@@ -364,13 +436,24 @@ impl<'a> InputStreams<'a> {
 
     /// Is the `button` pressed?
     #[must_use]
-    pub fn button_pressed(&self, button: InputButton) -> bool {
+    pub fn button_pressed(&self, button: InputKind) -> bool {
         match button {
-            InputButton::Gamepad(gamepad_button) => {
+            InputKind::GamepadAxis(axis) => {
+                let value = self.get_input_value(&UserInput::Single(button));
+
+                match axis.comparison {
+                    GamepadAxisComparison::Less => value < axis.threshold,
+                    GamepadAxisComparison::Greater => value > axis.threshold,
+                    GamepadAxisComparison::Equal => {
+                        (axis.threshold.abs() - value.abs()) > f32::EPSILON
+                    }
+                }
+            }
+            InputKind::GamepadButton(gamepad_button) => {
                 // If no gamepad is registered, we know for sure that no match was found
                 if let Some(gamepad) = self.associated_gamepad {
-                    if let Some(gamepad_stream) = self.gamepad {
-                        gamepad_stream.pressed(GamepadButton(gamepad, gamepad_button))
+                    if let Some(gamepad_buttons) = self.gamepad_buttons {
+                        gamepad_buttons.pressed(GamepadButton(gamepad, gamepad_button))
                     } else {
                         false
                     }
@@ -378,14 +461,14 @@ impl<'a> InputStreams<'a> {
                     false
                 }
             }
-            InputButton::Keyboard(keycode) => {
+            InputKind::Keyboard(keycode) => {
                 if let Some(keyboard_stream) = self.keyboard {
                     keyboard_stream.pressed(keycode)
                 } else {
                     false
                 }
             }
-            InputButton::Mouse(mouse_button) => {
+            InputKind::Mouse(mouse_button) => {
                 if let Some(mouse_stream) = self.mouse {
                     mouse_stream.pressed(mouse_button)
                 } else {
@@ -397,7 +480,7 @@ impl<'a> InputStreams<'a> {
 
     /// Are all of the `buttons` pressed?
     #[must_use]
-    pub fn all_buttons_pressed(&self, buttons: &PetitSet<InputButton, 8>) -> bool {
+    pub fn all_buttons_pressed(&self, buttons: &PetitSet<InputKind, 8>) -> bool {
         for &button in buttons.iter() {
             // If any of the appropriate inputs failed to match, the action is considered pressed
             if !self.button_pressed(button) {
@@ -406,6 +489,53 @@ impl<'a> InputStreams<'a> {
         }
         // If none of the inputs failed to match, return true
         true
+    }
+
+    /// Get the "value" of the input.
+    ///
+    /// For binary inputs such as buttons, this will always be either `0.0` or `1.0`. For analog
+    /// inputs such as axes, this will be the axis value.
+    ///
+    /// [`UserInput::Chord`] inputs are also considered binary and will return `0.0` or `1.0` based
+    /// on whether the chord has been pressed.
+    pub fn get_input_value(&self, input: &UserInput) -> f32 {
+        let use_button_value = || {
+            if self.input_pressed(input) {
+                1.0
+            } else {
+                0.0
+            }
+        };
+
+        if let Some(gamepad) = self.associated_gamepad {
+            match input {
+                UserInput::Single(InputKind::GamepadAxis(threshold)) => {
+                    if let Some(axes) = self.gamepad_axes {
+                        axes.get(GamepadAxis(gamepad, threshold.axis))
+                            .unwrap_or_default()
+                    } else {
+                        0.0
+                    }
+                }
+                UserInput::Single(InputKind::GamepadButton(button_type)) => {
+                    if let Some(button_axes) = self.gamepad_button_axes {
+                        button_axes
+                            .get(GamepadButton(gamepad, *button_type))
+                            .unwrap_or_default()
+                    } else {
+                        0.0
+                    }
+                }
+                _ => use_button_value(),
+            }
+
+        // If there is no gamepad
+        } else {
+            match input {
+                UserInput::Single(InputKind::GamepadAxis(_) | InputKind::GamepadButton(_)) => 0.0,
+                _ => use_button_value(),
+            }
+        }
     }
 }
 
@@ -417,7 +547,11 @@ impl<'a> InputStreams<'a> {
 #[derive(Debug)]
 pub struct MutableInputStreams<'a> {
     /// An optional [`GamepadButton`] [`Input`] stream
-    pub gamepad: Option<&'a mut Input<GamepadButton>>,
+    pub gamepad_buttons: Option<&'a mut Input<GamepadButton>>,
+    /// An optional [`GamepadButton`] [`Axis`] stream
+    pub gamepad_button_axes: Option<&'a mut Axis<GamepadButton>>,
+    /// An optional [`GamepadAxis`] [`Axis`] stream
+    pub gamepad_axes: Option<&'a mut Axis<GamepadAxis>>,
     /// An optional [`KeyCode`] [`Input`] stream
     pub keyboard: Option<&'a mut Input<KeyCode>>,
     /// An optional [`MouseButton`] [`Input`] stream
@@ -428,14 +562,24 @@ pub struct MutableInputStreams<'a> {
 
 impl<'a> From<MutableInputStreams<'a>> for InputStreams<'a> {
     fn from(mutable_streams: MutableInputStreams<'a>) -> Self {
-        let gamepad = mutable_streams.gamepad.map(|mutable_ref| &*mutable_ref);
+        let gamepad_buttons = mutable_streams
+            .gamepad_buttons
+            .map(|mutable_ref| &*mutable_ref);
+        let gamepad_button_axes = mutable_streams
+            .gamepad_button_axes
+            .map(|mutable_ref| &*mutable_ref);
+        let gamepad_axes = mutable_streams
+            .gamepad_axes
+            .map(|mutable_ref| &*mutable_ref);
 
         let keyboard = mutable_streams.keyboard.map(|mutable_ref| &*mutable_ref);
 
         let mouse = mutable_streams.mouse.map(|mutable_ref| &*mutable_ref);
 
         InputStreams {
-            gamepad,
+            gamepad_buttons,
+            gamepad_button_axes,
+            gamepad_axes,
             keyboard,
             mouse,
             associated_gamepad: mutable_streams.associated_gamepad,

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -380,17 +380,9 @@ pub enum InputKind {
 pub struct SingleGamepadAxis {
     /// The axis that is being checked.
     pub axis: GamepadAxisType,
-    /// How high the axis movement must go in the positive direction before the action is triggered.
-    ///
-    /// For example if this is set to `0.2`,
-    /// an axis movement value of `0.3` will trigger the action,
-    /// but an axis movement of `0.1` will not trigger the action.
+    /// Any axis value higher than this will trigger the input.
     pub positive_low: f32,
-    /// How low the axis movement must go in the negative direction before the action is triggered.
-    ///
-    /// For example if this is set to `-0.2`,
-    /// an axis movement value of `-0.3` will trigger the action,
-    /// but an axis movement of `-0.1` will not trigger the action.
+    /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
 }
 
@@ -443,9 +435,13 @@ impl std::hash::Hash for DualGamepadAxis {
 /// A virtual dpad that you will be able to read as an [`AxisPair`]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VirtualDPad {
+    // The up input
     up: InputKind,
+    // The down input
     down: InputKind,
+    // The left input
     left: InputKind,
+    // The right input
     right: InputKind,
 }
 
@@ -591,7 +587,7 @@ impl<'a> InputStreams<'a> {
             InputKind::SingleGamepadAxis(axis) => {
                 let value = self.get_input_value(&UserInput::Single(button));
 
-                value <= axis.negative_low || value >= axis.positive_low
+                value < axis.negative_low || value > axis.positive_low
             }
             InputKind::GamepadButton(gamepad_button) => {
                 // If no gamepad is registered, we know for sure that no match was found

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -681,17 +681,14 @@ impl<'a> InputStreams<'a> {
             }
             UserInput::Single(InputKind::DualGamepadAxis(_)) => {
                 if self.gamepad_axes.is_some() {
-                    self.get_input_axis_pair(input)
-                        .unwrap_or_default()
-                        .magnitude()
+                    self.get_input_axis_pair(input).unwrap_or_default().length()
                 } else {
                     0.0
                 }
             }
-            UserInput::VirtualDPad { .. } => self
-                .get_input_axis_pair(input)
-                .unwrap_or_default()
-                .magnitude(),
+            UserInput::VirtualDPad { .. } => {
+                self.get_input_axis_pair(input).unwrap_or_default().length()
+            }
             UserInput::Single(InputKind::GamepadButton(button_type)) => {
                 if let Some(gamepad) = self.associated_gamepad {
                     if let Some(button_axes) = self.gamepad_button_axes {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -200,7 +200,14 @@ impl UserInput {
     }
 
     /// Returns the raw inputs that make up this [`UserInput`]
-    pub fn raw_inputs(&self) -> (Vec<GamepadButtonType>, Vec<KeyCode>, Vec<MouseButton>) {
+    pub fn raw_inputs(
+        &self,
+    ) -> (
+        Vec<GamepadButtonType>,
+        Vec<GamepadAxisType>,
+        Vec<KeyCode>,
+        Vec<MouseButton>,
+    ) {
         let mut gamepad_axes: Vec<GamepadAxisType> = Vec::default();
         let mut gamepad_buttons: Vec<GamepadButtonType> = Vec::default();
         let mut keyboard_buttons: Vec<KeyCode> = Vec::default();
@@ -252,7 +259,7 @@ impl UserInput {
             }
         };
 
-        (gamepad_buttons, keyboard_buttons, mouse_buttons)
+        (gamepad_buttons, gamepad_axes, keyboard_buttons, mouse_buttons)
     }
 }
 
@@ -298,10 +305,9 @@ impl From<MouseButton> for UserInput {
     }
 }
 
-/// A button-like input type
+/// What mode (sort of device) an [`InputKind`] originated from.
 ///
-/// See [`Button`] for the value-ful equivalent.
-/// Use the [`From`] or [`Into`] traits to convert from a [`InputButton`] to a [`InputMode`].
+/// Use the [`From`] or [`Into`] traits to convert from a [`InputKind`] to a [`InputMode`].
 ///
 /// Unfortunately we cannot use a trait object here, as the types used by `Input`
 /// require traits that are not object-safe.
@@ -727,10 +733,10 @@ impl<'a> InputStreams<'a> {
                             .unwrap_or_default();
                         Some(AxisPair::new(Vec2::new(x, y)))
                     } else {
-                        Some(AxisPair::new(Vec2::ZERO))
+                        None
                     }
                 } else {
-                    Some(AxisPair::new(Vec2::ZERO))
+                    None
                 }
             }
             UserInput::VirtualDPad(VirtualDPad {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -129,12 +129,16 @@ impl UserInput {
         }
     }
 
-    /// The number of buttons in the [`UserInput`]
+    /// The number of logical inputs that make up the [`UserInput`].
+    /// 
+    /// - A [`Single`][UserInput::Single] input returns 1
+    /// - A [`Chord`][UserInput::Chord] returns the number of buttons in the chord
+    /// - A [`VirtualDPad`][UserInput::VirtualDPad] returns 1
     pub fn len(&self) -> usize {
         match self {
             UserInput::Single(_) => 1,
             UserInput::Chord(button_set) => button_set.len(),
-            UserInput::VirtualDPad { .. } => 4,
+            UserInput::VirtualDPad { .. } => 1,
         }
     }
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -130,7 +130,7 @@ impl UserInput {
     }
 
     /// The number of logical inputs that make up the [`UserInput`].
-    /// 
+    ///
     /// - A [`Single`][UserInput::Single] input returns 1
     /// - A [`Chord`][UserInput::Chord] returns the number of buttons in the chord
     /// - A [`VirtualDPad`][UserInput::VirtualDPad] returns 1


### PR DESCRIPTION
This should be functionally ready, but I haven't necessarily done my due diligence with the doc strings or self-review yet. I also need to add a new example demonstrating the use of the controller axes. I'll get to that tomorrow probably.

The PR ended up somewhat large, but the changes are pretty straight-forward.

- Now every event kind has a "value". This will be between -1.0 and 1.0.
- If you wanted to implement simple character bindings with an analog stick you could do this:
```rust
let input_map = InputMap::<PlayerAction>::new(vec![
    (
        PlayerAction::Right,
        GamepadAxisThreshold {
            axis: GamepadAxisType::LeftStickX,
            comparison: GamepadAxisComparison::Greater,
            threshold: 0.1,
        },
    ),
    (
        PlayerAction::Left,
        GamepadAxisThreshold {
            axis: GamepadAxisType::LeftStickX,
            comparison: GamepadAxisComparison::Less,
            threshold: -0.1,
        },
    ),
    (
        PlayerAction::Up,
        GamepadAxisThreshold {
            axis: GamepadAxisType::LeftStickY,
            comparison: GamepadAxisComparison::Greater,
            threshold: 0.1,
        },
    ),
    (
        PlayerAction::Down,
        GamepadAxisThreshold {
            axis: GamepadAxisType::LeftStickX,
            comparison: GamepadAxisComparison::Less,
            threshold: -0.1,
        },
    ),
]);
```
- In order to get the `f32` threshold to fit inside of the `Eq + Hash` `UserInput` struct, I made use of the `decorum` crate, which has suitable `Eq` and `Hash` implementations for floats. Technically we can get rid of the dependency if you want to copy the [`to_canonical_bits`](https://docs.rs/decorum/latest/src/decorum/canonical.rs.html#13-21) function from the `decorum` crate.

We really just need a way to hash and compare floats and that would give us what we need.