### PR TITLE
Reverse order of `InputMap` from `(action, input)` to `(input, action)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ fn spawn_player(mut commands: Commands) {
             // Stores "which actions are currently pressed"
             action_state: ActionState::default(),
             // Describes how to convert from player inputs into those actions
-            input_map: InputMap::new([(Action::Jump, KeyCode::Space)]),
+            input_map: InputMap::new([(KeyCode::Space, Action::Jump)]),
         });
 }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,9 @@
 
 - reduced required `derive_more` features
 - removed `thiserror` dependency
+- the order of all methods on `InputMap` is now `(input, action)`, rather than `(action, input`) to better match user mental models
+  - this is a map-like struct: one presses `KeyCode::F` to `Actions::PayRespects`, not the other way around!
+  - this includes the order of all paired tuples, including the returned values
 
 ### Bug fixes
 

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -86,13 +86,13 @@ fn spawn_player(mut commands: Commands) {
     commands.spawn_bundle(PlayerBundle {
         player: Player,
         slot_input_map: InputMap::new([
-            (Slot::Ability1, Q),
-            (Slot::Ability2, W),
-            (Slot::Ability3, E),
-            (Slot::Ability4, R),
+            (Q, Slot::Ability1),
+            (W, Slot::Ability2),
+            (E, Slot::Ability3),
+            (R, Slot::Ability4),
         ])
-        .insert(Slot::Primary, MouseButton::Left)
-        .insert(Slot::Secondary, MouseButton::Right)
+        .insert(MouseButton::Left, Slot::Primary)
+        .insert(MouseButton::Right, Slot::Secondary)
         .build(),
         slot_action_state: ActionState::default(),
         ability_action_state: ActionState::default(),

--- a/examples/binding_menu.rs
+++ b/examples/binding_menu.rs
@@ -29,8 +29,8 @@ fn main() {
 fn spawn_player_system(mut commands: Commands, control_settings: Res<ControlSettings>) {
     commands.spawn().insert(control_settings.input.clone());
     commands.insert_resource(InputMap::<UiAction>::new([(
-        UiAction::Back,
         KeyCode::Escape,
+        UiAction::Back,
     )]));
     commands.insert_resource(ActionState::<UiAction>::default());
 }
@@ -133,8 +133,8 @@ fn binding_window_system(
                             .input
                             .remove(conflict.action, conflict.input_button);
                         control_settings.input.insert_at(
-                            active_binding.action,
                             conflict.input_button,
+                            active_binding.action,
                             active_binding.index,
                         );
                         commands.remove_resource::<ActiveBinding>();
@@ -149,7 +149,7 @@ fn binding_window_system(
                     commands.remove_resource::<ActiveBinding>();
                 } else if let Some(input_button) = input_events.input_button() {
                     let conflict_action =
-                        control_settings.input.iter().find_map(|(action, inputs)| {
+                        control_settings.input.iter().find_map(|(inputs, action)| {
                             if action != active_binding.action
                                 && inputs.contains(&input_button.into())
                             {
@@ -164,8 +164,8 @@ fn binding_window_system(
                         });
                     } else {
                         control_settings.input.insert_at(
-                            active_binding.action,
                             input_button,
+                            active_binding.action,
                             active_binding.index,
                         );
                         commands.remove_resource::<ActiveBinding>();
@@ -205,16 +205,16 @@ impl Default for ControlSettings {
     fn default() -> Self {
         let mut input = InputMap::default();
         input
-            .insert(ControlAction::Forward, KeyCode::W)
-            .insert(ControlAction::Backward, KeyCode::S)
-            .insert(ControlAction::Left, KeyCode::A)
-            .insert(ControlAction::Right, KeyCode::D)
-            .insert(ControlAction::Jump, KeyCode::Space)
-            .insert(ControlAction::BaseAttack, MouseButton::Left)
-            .insert(ControlAction::Ability1, KeyCode::Q)
-            .insert(ControlAction::Ability2, KeyCode::E)
-            .insert(ControlAction::Ability3, KeyCode::LShift)
-            .insert(ControlAction::Ultimate, KeyCode::R);
+            .insert(KeyCode::W, ControlAction::Forward)
+            .insert(KeyCode::S, ControlAction::Backward)
+            .insert(KeyCode::A, ControlAction::Left)
+            .insert(KeyCode::D, ControlAction::Right)
+            .insert(KeyCode::Space, ControlAction::Jump)
+            .insert(MouseButton::Left, ControlAction::BaseAttack)
+            .insert(KeyCode::Q, ControlAction::Ability1)
+            .insert(KeyCode::E, ControlAction::Ability2)
+            .insert(KeyCode::LShift, ControlAction::Ability3)
+            .insert(KeyCode::R, ControlAction::Ultimate);
 
         Self { input }
     }

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -36,13 +36,13 @@ fn spawn_input_map(mut commands: Commands) {
     let mut input_map = InputMap::default();
 
     // Setting up input mappings in the obvious way
-    input_map.insert_multiple([(One, Key1), (Two, Key2), (Three, Key3)]);
+    input_map.insert_multiple([(Key1, One), (Key2, Two), (Key3, Three)]);
 
-    input_map.insert_chord(OneAndTwo, [Key1, Key2]);
-    input_map.insert_chord(OneAndThree, [Key1, Key3]);
-    input_map.insert_chord(TwoAndThree, [Key2, Key3]);
+    input_map.insert_chord([Key1, Key2], OneAndTwo);
+    input_map.insert_chord([Key1, Key3], OneAndThree);
+    input_map.insert_chord([Key2, Key3], TwoAndThree);
 
-    input_map.insert_chord(OneAndTwoAndThree, [Key1, Key2, Key3]);
+    input_map.insert_chord([Key1, Key2, Key3], OneAndTwoAndThree);
 
     commands.spawn_bundle(InputManagerBundle {
         input_map,

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -12,9 +12,9 @@ fn main() {
         .add_plugin(InputManagerPlugin::<MenuAction>::default())
         .init_resource::<ActionState<MenuAction>>()
         .insert_resource(InputMap::<MenuAction>::new([
-            (MenuAction::CloseWindow, KeyCode::Escape),
-            (MenuAction::OpenMainMenu, KeyCode::M),
-            (MenuAction::OpenSubMenu, KeyCode::S),
+            (KeyCode::Escape, MenuAction::CloseWindow),
+            (KeyCode::M, MenuAction::OpenMainMenu),
+            (KeyCode::S, MenuAction::OpenSubMenu),
         ]))
         .init_resource::<MainMenu>()
         .init_resource::<SubMenu>()

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -32,7 +32,7 @@ fn spawn_player(mut commands: Commands) {
             // Stores "which actions are currently pressed"
             action_state: ActionState::default(),
             // Describes how to convert from player inputs into those actions
-            input_map: InputMap::new([(Action::Jump, KeyCode::Space)]),
+            input_map: InputMap::new([(KeyCode::Space, Action::Jump)]),
         });
 }
 

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -34,9 +34,9 @@ impl PlayerBundle {
     fn input_map(player: Player) -> InputMap<Action> {
         let mut input_map = match player {
             Player::One => InputMap::new([
-                (Action::Left, KeyCode::A),
-                (Action::Right, KeyCode::D),
-                (Action::Jump, KeyCode::W),
+                (KeyCode::A, Action::Left),
+                (KeyCode::D, Action::Right),
+                (KeyCode::W, Action::Jump),
             ])
             // This is a quick and hacky solution:
             // you should coordinate with the `Gamepads` resource to determine the correct gamepad for each player
@@ -44,9 +44,9 @@ impl PlayerBundle {
             .set_gamepad(Gamepad(0))
             .build(),
             Player::Two => InputMap::new([
-                (Action::Left, KeyCode::A),
-                (Action::Right, KeyCode::D),
-                (Action::Jump, KeyCode::W),
+                (KeyCode::Left, Action::Left),
+                (KeyCode::Right, Action::Right),
+                (KeyCode::Up, Action::Jump),
             ])
             .set_gamepad(Gamepad(1))
             .build(),
@@ -54,10 +54,10 @@ impl PlayerBundle {
 
         // Each player will use the same gamepad controls, but on seperate gamepads
         input_map.insert_multiple([
-            (Action::Left, GamepadButtonType::DPadLeft),
-            (Action::Right, GamepadButtonType::DPadRight),
-            (Action::Jump, GamepadButtonType::DPadUp),
-            (Action::Jump, GamepadButtonType::South),
+            (GamepadButtonType::DPadLeft, Action::Left),
+            (GamepadButtonType::DPadRight, Action::Right),
+            (GamepadButtonType::DPadUp, Action::Jump),
+            (GamepadButtonType::South, Action::Jump),
         ]);
 
         input_map

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -49,10 +49,10 @@ impl PlayerBundle {
         use Action::*;
 
         InputMap::new([
-            (Left, KeyCode::A),
-            (Left, KeyCode::Left),
-            (Right, KeyCode::D),
-            (Right, KeyCode::Right),
+            (KeyCode::A, Left),
+            (KeyCode::Left, Left),
+            (KeyCode::D, Right),
+            (KeyCode::Right, Right),
         ])
     }
 }

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -118,8 +118,8 @@ fn spawn_player(mut commands: Commands) {
 
     commands
         .spawn_bundle(InputManagerBundle {
-            input_map: InputMap::new([(MoveLeft, W), (MoveRight, D), (Jump, Space)])
-                .insert(Shoot, MouseButton::Left)
+            input_map: InputMap::new([(W, MoveLeft), (D, MoveRight), (Space, Jump)])
+                .insert(MouseButton::Left, Shoot)
                 .build(),
             action_state: ActionState::default(),
         })

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -81,35 +81,35 @@ impl PlayerBundle {
         input_map.set_gamepad(Gamepad(0));
 
         // Movement
-        input_map.insert(Up, KeyCode::Up);
-        input_map.insert(Up, GamepadButtonType::DPadUp);
+        input_map.insert(KeyCode::Up, Up);
+        input_map.insert(GamepadButtonType::DPadUp, Up);
 
-        input_map.insert(Down, KeyCode::Down);
-        input_map.insert(Down, GamepadButtonType::DPadDown);
+        input_map.insert(KeyCode::Down, Down);
+        input_map.insert(GamepadButtonType::DPadDown, Down);
 
-        input_map.insert(Left, KeyCode::Left);
-        input_map.insert(Left, GamepadButtonType::DPadLeft);
+        input_map.insert(KeyCode::Left, Left);
+        input_map.insert(GamepadButtonType::DPadLeft, Left);
 
-        input_map.insert(Right, KeyCode::Right);
-        input_map.insert(Right, GamepadButtonType::DPadRight);
+        input_map.insert(KeyCode::Right, Right);
+        input_map.insert(GamepadButtonType::DPadRight, Right);
 
         // Abilities
-        input_map.insert(Ability1, KeyCode::Q);
-        input_map.insert(Ability1, GamepadButtonType::West);
-        input_map.insert(Ability1, MouseButton::Left);
+        input_map.insert(KeyCode::Q, Ability1);
+        input_map.insert(GamepadButtonType::West, Ability1);
+        input_map.insert(MouseButton::Left, Ability1);
 
-        input_map.insert(Ability2, KeyCode::W);
-        input_map.insert(Ability2, GamepadButtonType::North);
-        input_map.insert(Ability2, MouseButton::Right);
+        input_map.insert(KeyCode::W, Ability2);
+        input_map.insert(GamepadButtonType::North, Ability2);
+        input_map.insert(MouseButton::Right, Ability2);
 
-        input_map.insert(Ability3, KeyCode::E);
-        input_map.insert(Ability3, GamepadButtonType::East);
+        input_map.insert(KeyCode::E, Ability3);
+        input_map.insert(GamepadButtonType::East, Ability3);
 
-        input_map.insert(Ability4, KeyCode::Space);
-        input_map.insert(Ability4, GamepadButtonType::South);
+        input_map.insert(KeyCode::Space, Ability4);
+        input_map.insert(GamepadButtonType::South, Ability4);
 
-        input_map.insert(Ultimate, KeyCode::R);
-        input_map.insert(Ultimate, GamepadButtonType::LeftTrigger2);
+        input_map.insert(KeyCode::R, Ultimate);
+        input_map.insert(GamepadButtonType::LeftTrigger2, Ultimate);
 
         input_map
     }

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -25,8 +25,8 @@ struct Player;
 
 fn spawn_player(mut commands: Commands) {
     let mut input_map = InputMap::default();
-    input_map.insert(Action::Left, KeyCode::Left);
-    input_map.insert(Action::Right, KeyCode::Right);
+    input_map.insert(KeyCode::Left, Action::Left);
+    input_map.insert(KeyCode::Right, Action::Right);
 
     commands
         .spawn()

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -593,7 +593,7 @@ mod tests {
 
         // Input map
         let mut input_map = InputMap::default();
-        input_map.insert(Action::Run, KeyCode::R);
+        input_map.insert(KeyCode::R, Action::Run);
 
         // Input streams
         let mut keyboard_input_stream = Input::<KeyCode>::default();

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -335,14 +335,14 @@ mod tests {
 
         let mut input_map = InputMap::default();
 
-        input_map.insert(One, Key1);
-        input_map.insert(Two, Key2);
-        input_map.insert_chord(OneAndTwo, [Key1, Key2]);
-        input_map.insert_chord(TwoAndThree, [Key2, Key3]);
-        input_map.insert_chord(OneAndTwoAndThree, [Key1, Key2, Key3]);
-        input_map.insert_chord(CtrlOne, [LControl, Key1]);
-        input_map.insert_chord(AltOne, [LAlt, Key1]);
-        input_map.insert_chord(CtrlAltOne, [LControl, LAlt, Key1]);
+        input_map.insert(Key1, One);
+        input_map.insert(Key2, Two);
+        input_map.insert_chord([Key1, Key2], OneAndTwo);
+        input_map.insert_chord([Key2, Key3], TwoAndThree);
+        input_map.insert_chord([Key1, Key2, Key3], OneAndTwoAndThree);
+        input_map.insert_chord([LControl, Key1], CtrlOne);
+        input_map.insert_chord([LAlt, Key1], AltOne);
+        input_map.insert_chord([LControl, LAlt, Key1], CtrlAltOne);
 
         input_map
     }
@@ -426,7 +426,7 @@ mod tests {
             assert_eq!(input_map.possible_clashes().len(), 12);
 
             // Possible clashes are cached upon binding insertion
-            input_map.insert(Action::Two, UserInput::chord([LControl, LAlt, Key1]));
+            input_map.insert(UserInput::chord([LControl, LAlt, Key1]), Action::Two);
             assert_eq!(input_map.possible_clashes().len(), 15);
 
             // Possible clashes are cached upon binding removal

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -53,19 +53,20 @@ use std::marker::PhantomData;
 ///    // Note that the type of your iterators must be homogenous;
 ///    // you can use `InputButton` or `UserInput` if needed
 ///    // as unifiying types
-///   (Action::Run, GamepadButtonType::South),
-///   (Action::Hide, GamepadButtonType::LeftTrigger),
-///   (Action::Hide, GamepadButtonType::RightTrigger),
+///   (GamepadButtonType::South, Action::Run),
+///   (GamepadButtonType::LeftTrigger, Action::Hide),
+///   (GamepadButtonType::RightTrigger, Action::Hide),
 /// ]);
 ///
 /// // Insertion
-/// input_map.insert(Action::Run, MouseButton::Left)
-/// .insert(Action::Run, KeyCode::LShift)
+/// input_map.insert(MouseButton::Left, Action::Run)
+/// .insert(KeyCode::LShift, Action::Run)
 /// // Chords
-/// .insert_chord(Action::Run, [KeyCode::LControl, KeyCode::R])
-/// .insert_chord(Action::Hide, [InputButton::Keyboard(KeyCode::H),
-///                              InputButton::Gamepad(GamepadButtonType::South),
-///                              InputButton::Mouse(MouseButton::Middle)]);
+/// .insert_chord([KeyCode::LControl, KeyCode::R], Action::Run)
+/// .insert_chord([InputButton::Keyboard(KeyCode::H),
+///                InputButton::Gamepad(GamepadButtonType::South),
+///                InputButton::Mouse(MouseButton::Middle)],
+///            Action::Hide);
 ///
 /// // Removal
 /// input_map.clear_action(Action::Hide);
@@ -110,14 +111,14 @@ impl<A: Actionlike> InputMap<A> {
     /// }
     ///
     /// let input_map = InputMap::new([
-    ///     (Action::Run, KeyCode::LShift),
-    ///     (Action::Jump, KeyCode::Space),
+    ///     (KeyCode::LShift, Action::Run),
+    ///     (KeyCode::Space, Action::Jump),
     /// ]);
     ///
     /// assert_eq!(input_map.len(), 2);
     /// ```
     #[must_use]
-    pub fn new(bindings: impl IntoIterator<Item = (A, impl Into<UserInput>)>) -> Self {
+    pub fn new(bindings: impl IntoIterator<Item = (impl Into<UserInput>, A)>) -> Self {
         let mut input_map = InputMap::default();
         input_map.insert_multiple(bindings);
 
@@ -147,7 +148,7 @@ impl<A: Actionlike> InputMap<A> {
     /// }
     ///
     /// let input_map: InputMap<Action> = InputMap::default()
-    ///   .insert(Action::Jump, KeyCode::Space).build();
+    ///   .insert(KeyCode::Space, Action::Jump).build();
     /// ```
     #[inline]
     #[must_use]
@@ -163,7 +164,7 @@ impl<A: Actionlike> InputMap<A> {
     /// # Panics
     ///
     /// Panics if the map is full and `input` is not a duplicate.
-    pub fn insert(&mut self, action: A, input: impl Into<UserInput>) -> &mut Self {
+    pub fn insert(&mut self, input: impl Into<UserInput>, action: A) -> &mut Self {
         let input = input.into();
 
         self.map[action.index()].insert(input);
@@ -178,7 +179,7 @@ impl<A: Actionlike> InputMap<A> {
     /// # Panics
     ///
     /// Panics if the map is full and `input` is not a duplicate.
-    pub fn insert_at(&mut self, action: A, input: impl Into<UserInput>, index: usize) -> &mut Self {
+    pub fn insert_at(&mut self, input: impl Into<UserInput>, action: A, index: usize) -> &mut Self {
         let input = input.into();
 
         self.map[action.index()].insert_at(input, index);
@@ -197,7 +198,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Panics if the map is full and any of `inputs` is not a duplicate.
     pub fn insert_multiple(
         &mut self,
-        inputs: impl IntoIterator<Item = (A, impl Into<UserInput>)>,
+        inputs: impl IntoIterator<Item = (impl Into<UserInput>, A)>,
     ) -> &mut Self {
         for (action, input) in inputs {
             self.insert(action, input);
@@ -216,10 +217,10 @@ impl<A: Actionlike> InputMap<A> {
     /// Panics if the map is full and `buttons` is not a duplicate.
     pub fn insert_chord(
         &mut self,
-        action: A,
         buttons: impl IntoIterator<Item = impl Into<InputButton>>,
+        action: A,
     ) -> &mut Self {
-        self.insert(action, UserInput::chord(buttons));
+        self.insert(UserInput::chord(buttons), action);
         self
     }
 
@@ -243,11 +244,11 @@ impl<A: Actionlike> InputMap<A> {
 
         for action in A::variants() {
             for input in self.get(action.clone()).iter() {
-                new_map.insert(action.clone(), input.clone());
+                new_map.insert(input.clone(), action.clone());
             }
 
             for input in other.get(action.clone()).iter() {
-                new_map.insert(action.clone(), input.clone());
+                new_map.insert(input.clone(), action.clone());
             }
         }
 
@@ -334,11 +335,11 @@ impl<A: Actionlike> InputMap<A> {
 // Utilities
 impl<A: Actionlike> InputMap<A> {
     /// Returns an iterator over actions with their inputs
-    pub fn iter(&self) -> impl Iterator<Item = (A, &PetitSet<UserInput, 16>)> {
+    pub fn iter(&self) -> impl Iterator<Item = (&PetitSet<UserInput, 16>, A)> {
         self.map
             .iter()
             .enumerate()
-            .map(|(action_index, inputs)| (A::get_at(action_index).unwrap(), inputs))
+            .map(|(action_index, inputs)| (inputs, A::get_at(action_index).unwrap()))
     }
 
     /// Returns an iterator over all mapped inputs
@@ -409,7 +410,7 @@ mod tests {
         use petitset::PetitSet;
 
         let mut input_map = InputMap::<Action>::default();
-        input_map.insert(Action::Run, KeyCode::Space);
+        input_map.insert(KeyCode::Space, Action::Run);
 
         assert_eq!(
             *input_map.get(Action::Run),
@@ -417,7 +418,7 @@ mod tests {
         );
 
         // Duplicate insertions should not change anything
-        input_map.insert(Action::Run, KeyCode::Space);
+        input_map.insert(KeyCode::Space, Action::Run);
         assert_eq!(
             *input_map.get(Action::Run),
             PetitSet::<UserInput, 16>::from_iter([KeyCode::Space.into()])
@@ -431,8 +432,8 @@ mod tests {
         use petitset::PetitSet;
 
         let mut input_map_1 = InputMap::<Action>::default();
-        input_map_1.insert(Action::Run, KeyCode::Space);
-        input_map_1.insert(Action::Run, KeyCode::Return);
+        input_map_1.insert(KeyCode::Space, Action::Run);
+        input_map_1.insert(KeyCode::Return, Action::Run);
 
         assert_eq!(
             *input_map_1.get(Action::Run),
@@ -440,8 +441,8 @@ mod tests {
         );
 
         let input_map_2 = InputMap::<Action>::new([
-            (Action::Run, KeyCode::Space),
-            (Action::Run, KeyCode::Return),
+            (KeyCode::Space, Action::Run),
+            (KeyCode::Return, Action::Run),
         ]);
 
         assert_eq!(input_map_1, input_map_2);
@@ -454,10 +455,10 @@ mod tests {
 
         // Single items in a chord should be coerced to a singleton
         let mut input_map_1 = InputMap::<Action>::default();
-        input_map_1.insert(Action::Run, KeyCode::Space);
+        input_map_1.insert(KeyCode::Space, Action::Run);
 
         let mut input_map_2 = InputMap::<Action>::default();
-        input_map_2.insert(Action::Run, UserInput::chord([KeyCode::Space]));
+        input_map_2.insert(UserInput::chord([KeyCode::Space]), Action::Run);
 
         assert_eq!(input_map_1, input_map_2);
     }
@@ -467,15 +468,15 @@ mod tests {
         use bevy_input::keyboard::KeyCode;
 
         let mut input_map = InputMap::<Action>::default();
-        input_map.insert(Action::Run, KeyCode::Space);
+        input_map.insert(KeyCode::Space, Action::Run);
 
         // Clearing action
         input_map.clear_action(Action::Run);
         assert_eq!(input_map, InputMap::default());
 
         // Remove input at existing index
-        input_map.insert(Action::Run, KeyCode::Space);
-        input_map.insert(Action::Run, KeyCode::LShift);
+        input_map.insert(KeyCode::Space, Action::Run);
+        input_map.insert(KeyCode::LShift, Action::Run);
         assert!(input_map.remove_at(Action::Run, 1));
         assert!(
             !input_map.remove_at(Action::Run, 1),
@@ -494,11 +495,11 @@ mod tests {
 
         let mut input_map = InputMap::default();
         let mut default_keyboard_map = InputMap::default();
-        default_keyboard_map.insert(Action::Run, KeyCode::LShift);
-        default_keyboard_map.insert_chord(Action::Hide, [KeyCode::LControl, KeyCode::H]);
+        default_keyboard_map.insert(KeyCode::LShift, Action::Run);
+        default_keyboard_map.insert_chord([KeyCode::LControl, KeyCode::H], Action::Hide);
         let mut default_gamepad_map = InputMap::default();
-        default_gamepad_map.insert(Action::Run, GamepadButtonType::South);
-        default_gamepad_map.insert(Action::Hide, GamepadButtonType::East);
+        default_gamepad_map.insert(GamepadButtonType::South, Action::Run);
+        default_gamepad_map.insert(GamepadButtonType::East, Action::Hide);
 
         // Merging works
         input_map.merge(&default_keyboard_map);
@@ -534,27 +535,27 @@ mod tests {
         input_map.set_gamepad(Gamepad(42));
 
         // Gamepad
-        input_map.insert(Action::Run, GamepadButtonType::South);
+        input_map.insert(GamepadButtonType::South, Action::Run);
         input_map.insert_chord(
+            [GamepadButtonType::North, GamepadButtonType::South],
             Action::Jump,
-            [GamepadButtonType::South, GamepadButtonType::North],
         );
 
         // Keyboard
-        input_map.insert(Action::Run, KeyCode::LShift);
-        input_map.insert(Action::Hide, KeyCode::LShift);
+        input_map.insert(KeyCode::LShift, Action::Run);
+        input_map.insert(KeyCode::LShift, Action::Hide);
 
         // Mouse
-        input_map.insert(Action::Run, MouseButton::Left);
-        input_map.insert(Action::Jump, MouseButton::Other(42));
+        input_map.insert(MouseButton::Left, Action::Run);
+        input_map.insert(MouseButton::Other(42), Action::Jump);
 
         // Cross-device chords
         input_map.insert_chord(
-            Action::Hide,
             [
                 InputButton::Keyboard(KeyCode::LControl),
                 InputButton::Mouse(MouseButton::Left),
             ],
+            Action::Hide,
         );
 
         // Input streams

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -22,14 +22,14 @@ fn spawn_input_map(mut commands: Commands) {
 
     let mut input_map = InputMap::default();
 
-    input_map.insert(One, Key1);
-    input_map.insert(Two, Key2);
-    input_map.insert_chord(OneAndTwo, [Key1, Key2]);
-    input_map.insert_chord(TwoAndThree, [Key2, Key3]);
-    input_map.insert_chord(OneAndTwoAndThree, [Key1, Key2, Key3]);
-    input_map.insert_chord(CtrlOne, [LControl, Key1]);
-    input_map.insert_chord(AltOne, [LAlt, Key1]);
-    input_map.insert_chord(CtrlAltOne, [LControl, LAlt, Key1]);
+    input_map.insert(Key1, One);
+    input_map.insert(Key2, Two);
+    input_map.insert_chord([Key1, Key2], OneAndTwo);
+    input_map.insert_chord([Key2, Key3], TwoAndThree);
+    input_map.insert_chord([Key1, Key2, Key3], OneAndTwoAndThree);
+    input_map.insert_chord([LControl, Key1], CtrlOne);
+    input_map.insert_chord([LAlt, Key1], AltOne);
+    input_map.insert_chord([LControl, LAlt, Key1], CtrlAltOne);
 
     commands.spawn().insert(input_map);
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -42,7 +42,7 @@ fn spawn_player(mut commands: Commands) {
         .spawn()
         .insert(Player)
         .insert_bundle(InputManagerBundle::<Action> {
-            input_map: InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]),
+            input_map: InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]),
             ..Default::default()
         });
 }
@@ -59,7 +59,7 @@ fn do_nothing() {
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(spawn_player)
         .init_resource::<ActionState<Action>>()
-        .insert_resource(InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]));
+        .insert_resource(InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]));
 
     app.update();
     let action_state = app.world.resource::<ActionState<Action>>();
@@ -138,7 +138,7 @@ fn disable_input() {
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(spawn_player)
         .init_resource::<ActionState<Action>>()
-        .insert_resource(InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]))
+        .insert_resource(InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]))
         .init_resource::<Respect>()
         .add_system(pay_respects)
         .add_system_to_stage(CoreStage::PreUpdate, respect_fades);
@@ -181,7 +181,7 @@ fn action_state_driver() {
             .spawn()
             .insert(Player)
             .insert_bundle(InputManagerBundle::<Action> {
-                input_map: InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]),
+                input_map: InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]),
                 ..Default::default()
             })
             .id();
@@ -263,7 +263,7 @@ fn duration() {
         .add_plugin(InputManagerPlugin::<Action>::default())
         .add_startup_system(spawn_player)
         .init_resource::<ActionState<Action>>()
-        .insert_resource(InputMap::<Action>::new([(Action::PayRespects, KeyCode::F)]))
+        .insert_resource(InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]))
         .init_resource::<Respect>()
         .add_system(hold_f_to_pay_respects);
 


### PR DESCRIPTION
User feedback has been unanimous: this direction makes more sense!

Sorry about the tedious migration work, but better now than later 😅 Just chase the compiler errors!