### PR TITLE
Fix conflict between macro crate name and version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ['ui']
 ui = ['bevy_ui']
 
 [dependencies]
-leafwing_input_manager_macros = { path = "macros", version = "0.3" }
+leafwing_input_manager_macros = { path = "macros", version = "0.4.1" }
 
 bevy_app = {version = "0.7", default-features = false}
 bevy_core = {version = "0.7", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerfully direct stateful input manager for the Bevy game engine."
-version = "0.4.1"
+version = "0.4.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"
@@ -22,7 +22,7 @@ default = ['ui']
 ui = ['bevy_ui']
 
 [dependencies]
-leafwing-input-manager-macros = { path = "macros", version = "0.3" }
+leafwing_input_manager_macros = { path = "macros", version = "0.3" }
 
 bevy_app = {version = "0.7", default-features = false}
 bevy_core = {version = "0.7", default-features = false}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerfully direct stateful input manager for the Bevy game engine."
-version = "0.4.0"
+version = "0.4.1"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,5 @@
 # Release Notes
 
-## Version 0.4.1
-
-### Bug fixes
-
-- fixed out of date / broken reference to the input manager macros dependency
-
 ## Version 0.4
 
 ### Usability

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 0.4.1
+
+### Bug fixes
+
+- fixed a compilation error caused by mistakenly renaming the macros crate
+
 ## Version 0.4
 
 ### Usability

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_input_manager_macros"
 description = "Macros for the `leafwing-input-manager` crate"
-version = "0.3.0"
+version = "0.4.1"
 license = "MIT OR Apache-2.0"
 edition = "2021"
 authors = ["Leafwing Studios"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "leafwing-input-manager-macros"
+name = "leafwing_input_manager_macros"
 description = "Macros for the `leafwing-input-manager` crate"
 version = "0.3.0"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
This reverts commit ba4e704dac4cdde79f4c270a73e0f1282b764dc2, PR #161.

Fixes #160. The approach there worked, but since we can't rename crates we must do this instead.