### PR TITLE
Add builder methods for new axislike input types

### DIFF
--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -34,33 +34,14 @@ fn spawn_player(mut commands: Commands) {
             // Describes how to convert from player inputs into those actions
             input_map: InputMap::new([
                 // Configure the left stick as a dual-axis
-                (
-                    DualGamepadAxis {
-                        x_axis: GamepadAxisType::LeftStickX,
-                        y_axis: GamepadAxisType::LeftStickY,
-                        // We want to trigger our move action when the left stick is moved more than 10%
-                        // in any direction.
-                        //
-                        // Note: The Bevy `GamepadSettings` may cause input to be filtered out before
-                        // reaching leafwing.
-                        x_positive_low: 0.1,
-                        x_negative_low: -0.1,
-                        y_positive_low: 0.1,
-                        y_negative_low: -0.1,
-                    },
-                    Action::Move,
-                ),
+                (DualGamepadAxis::left_stick(), Action::Move),
             ])
             // Let's bind the right gamepad trigger to the throttle action
             .insert(GamepadButtonType::RightTrigger2, Action::Throttle)
             // And we'll use the right stick's x axis as a rudder control
             .insert(
-                SingleGamepadAxis {
-                    axis: GamepadAxisType::RightStickX,
-                    // This will trigger if the axis is moved 10% or more in either direction.
-                    negative_low: -0.1,
-                    positive_low: 0.1,
-                },
+                // This will trigger if the axis is moved 10% or more in either direction.
+                SingleGamepadAxis::symmetric(GamepadAxisType::RightStickX, 0.1),
                 Action::Rudder,
             )
             // Listen for events on the first gamepad

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -617,7 +617,7 @@ pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
 
 mod tests {
     use crate as leafwing_input_manager;
-    use crate::Actionlike;
+    use leafwing_input_manager_macros::Actionlike;
 
     #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     enum Action {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -1,6 +1,7 @@
 //! Tools for working with directional axis-like user inputs (gamesticks, D-Pads and emulated equvalents)
 
 use crate::orientation::{Direction, Rotation};
+use crate::user_input::InputKind;
 use bevy_math::Vec2;
 use serde::{Deserialize, Serialize};
 
@@ -105,4 +106,18 @@ impl AxisPair {
     pub fn length_squared(&self) -> f32 {
         self.xy.length_squared()
     }
+}
+
+#[allow(clippy::doc_markdown)] // False alarm because it thinks DPad is an un-quoted item
+/// A virtual DPad that you can get an [`AxisPair`] from
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct VirtualDPad {
+    /// The input that represents the up direction in this virtual DPad
+    pub up: InputKind,
+    /// The input that represents the down direction in this virtual DPad
+    pub down: InputKind,
+    /// The input that represents the left direction in this virtual DPad
+    pub left: InputKind,
+    /// The input that represents the right direction in this virtual DPad
+    pub right: InputKind,
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -222,7 +222,7 @@ impl DualGamepadAxis {
     pub const fn right_stick() -> DualGamepadAxis {
         DualGamepadAxis::symmetric(
             GamepadAxisType::RightStickX,
-            GamepadAxisType::RightStickY,
+            GamepadAxisType::LeftStickY,
             Self::DEFAULT_DEADZONE,
         )
     }
@@ -252,6 +252,11 @@ impl std::hash::Hash for DualGamepadAxis {
 
 #[allow(clippy::doc_markdown)] // False alarm because it thinks DPad is an un-quoted item
 /// A virtual DPad that you can get an [`AxisPair`] from
+///
+/// Typically, you don't want to store a [`DualGamepadAxis`] in this type,
+/// even though it can be stored as an [`InputKind`].
+///
+/// Instead, use it directly as [`InputKind::DualGamepadAxis`]!
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct VirtualDPad {
     /// The input that represents the up direction in this virtual DPad
@@ -304,44 +309,6 @@ impl VirtualDPad {
             down: InputKind::GamepadButton(GamepadButtonType::South),
             left: InputKind::GamepadButton(GamepadButtonType::West),
             right: InputKind::GamepadButton(GamepadButtonType::East),
-        }
-    }
-
-    /// Constructs a [`VirtualDpad`] corresponding to the left analogue stick of a gamepad
-    ///
-    /// A small, symettric deadzone is added for convenience.
-    /// If you wish to control the dead zone yourself, construct this struct manually.
-    pub const fn left_stick() -> VirtualDPad {
-        let dual_gamepad_axis = DualGamepadAxis::left_stick();
-        VirtualDPad {
-            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
-        }
-    }
-
-    /// Constructs a [`VirtualDpad`] corresponding to the right analogue stick of a gamepad
-    ///
-    /// A small, symettric deadzone is added for convenience.
-    /// If you wish to control the dead zone yourself, construct this struct manually.
-    pub const fn right_stick() -> VirtualDPad {
-        let dual_gamepad_axis = DualGamepadAxis::right_stick();
-        VirtualDPad {
-            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
-        }
-    }
-
-    /// Constructs a [`VirtualDpad`] from a [`DualGamepadAxis`].
-    pub const fn from_dual_gamepad_axis(dual_gamepad_axis: DualGamepadAxis) -> VirtualDPad {
-        VirtualDPad {
-            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
-            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
         }
     }
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -290,6 +290,7 @@ impl VirtualDPad {
         }
     }
 
+    #[allow(clippy::doc_markdown)] // False alarm because it thinks DPad is an un-quoted item
     /// Generates a [`VirtualDPad`] corresponding to the DPad on a gamepad
     pub const fn dpad() -> VirtualDPad {
         VirtualDPad {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -2,6 +2,7 @@
 
 use crate::orientation::{Direction, Rotation};
 use crate::user_input::InputKind;
+use bevy_input::{gamepad::GamepadButtonType, keyboard::KeyCode};
 use bevy_math::Vec2;
 use serde::{Deserialize, Serialize};
 
@@ -120,4 +121,48 @@ pub struct VirtualDPad {
     pub left: InputKind,
     /// The input that represents the right direction in this virtual DPad
     pub right: InputKind,
+}
+
+impl VirtualDPad {
+    /// Generates a [`VirtualDPad`] corresponding to the arrow keyboard keycodes
+    pub const fn arrow_keys() -> VirtualDPad {
+        VirtualDPad {
+            up: InputKind::Keyboard(KeyCode::Up),
+            down: InputKind::Keyboard(KeyCode::Down),
+            left: InputKind::Keyboard(KeyCode::Left),
+            right: InputKind::Keyboard(KeyCode::Right),
+        }
+    }
+
+    /// Generates a [`VirtualDPad`] corresponding to the `WASD` keyboard keycodes
+    pub const fn wasd() -> VirtualDPad {
+        VirtualDPad {
+            up: InputKind::Keyboard(KeyCode::W),
+            down: InputKind::Keyboard(KeyCode::S),
+            left: InputKind::Keyboard(KeyCode::A),
+            right: InputKind::Keyboard(KeyCode::D),
+        }
+    }
+
+    /// Generates a [`VirtualDPad`] corresponding to the DPad on a gamepad
+    pub const fn dpad() -> VirtualDPad {
+        VirtualDPad {
+            up: InputKind::GamepadButton(GamepadButtonType::DPadUp),
+            down: InputKind::GamepadButton(GamepadButtonType::DPadDown),
+            left: InputKind::GamepadButton(GamepadButtonType::DPadLeft),
+            right: InputKind::GamepadButton(GamepadButtonType::DPadRight),
+        }
+    }
+
+    /// Generates a [`VirtualDPad`] corresponding to the face buttons on a gamepad
+    ///
+    /// North corresponds to up, west corresponds to left, east corresponds to right, south corresponds to down
+    pub const fn gamepad_face_buttons() -> VirtualDPad {
+        VirtualDPad {
+            up: InputKind::GamepadButton(GamepadButtonType::North),
+            down: InputKind::GamepadButton(GamepadButtonType::South),
+            left: InputKind::GamepadButton(GamepadButtonType::West),
+            right: InputKind::GamepadButton(GamepadButtonType::East),
+        }
+    }
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -114,6 +114,12 @@ impl AxisPair {
 }
 
 /// A single gamepad axis with a configurable trigger zone.
+///
+/// These can be stored in a [`InputKind`] to create a virtual button.
+///
+/// # Warning
+///
+/// `positive_low` must be greater than or equal to `negative_low` for this type to be validly constructed.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct SingleGamepadAxis {
     /// The axis that is being checked.
@@ -122,6 +128,18 @@ pub struct SingleGamepadAxis {
     pub positive_low: f32,
     /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
+}
+
+impl SingleGamepadAxis {
+    /// Creates a [`SingleGamepadAxis`] with both `positive_low` and `negative_low` set to `threshold`.
+    #[must_use]
+    pub const fn symmetric(axis: GamepadAxisType, threshold: f32) -> SingleGamepadAxis {
+        SingleGamepadAxis {
+            axis,
+            positive_low: threshold,
+            negative_low: threshold,
+        }
+    }
 }
 
 impl PartialEq for SingleGamepadAxis {
@@ -142,8 +160,14 @@ impl std::hash::Hash for SingleGamepadAxis {
 
 /// Two gamepad axes combined as one input.
 ///
+/// These can be stored in a [`VirtualDPad`], which is itself stored in an [`InputKind`] for consumption.
+///
 /// This input will generate [`AxisPair`] can be read with
 /// [`ActionState::action_axis_pair()`][crate::ActionState::action_axis_pair()].
+///
+/// # Warning
+///
+/// `positive_low` must be greater than or equal to `negative_low` for both `x` and `y` for this type to be validly constructed.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize)]
 pub struct DualGamepadAxis {
     /// The gamepad axis to use as the x axis.
@@ -158,6 +182,25 @@ pub struct DualGamepadAxis {
     pub y_positive_low: f32,
     /// If the stick is moved down more than this amount the input will be triggered.
     pub y_negative_low: f32,
+}
+
+impl DualGamepadAxis {
+    /// Creates a [`SingleGamepadAxis`] with both `positive_low` and `negative_low` in both axes set to `threshold`.
+    #[must_use]
+    pub const fn symmetric(
+        x_axis: GamepadAxisType,
+        y_axis: GamepadAxisType,
+        threshold: f32,
+    ) -> DualGamepadAxis {
+        DualGamepadAxis {
+            x_axis,
+            y_axis,
+            x_positive_low: threshold,
+            x_negative_low: threshold,
+            y_positive_low: threshold,
+            y_negative_low: threshold,
+        }
+    }
 }
 
 impl PartialEq for DualGamepadAxis {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -2,7 +2,11 @@
 
 use crate::orientation::{Direction, Rotation};
 use crate::user_input::InputKind;
-use bevy_input::{gamepad::GamepadButtonType, keyboard::KeyCode};
+use bevy_core::FloatOrd;
+use bevy_input::{
+    gamepad::{GamepadAxisType, GamepadButtonType},
+    keyboard::KeyCode,
+};
 use bevy_math::Vec2;
 use serde::{Deserialize, Serialize};
 
@@ -106,6 +110,75 @@ impl AxisPair {
     #[inline]
     pub fn length_squared(&self) -> f32 {
         self.xy.length_squared()
+    }
+}
+
+/// A single gamepad axis with a configurable trigger zone.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct SingleGamepadAxis {
+    /// The axis that is being checked.
+    pub axis: GamepadAxisType,
+    /// Any axis value higher than this will trigger the input.
+    pub positive_low: f32,
+    /// Any axis value lower than this will trigger the input.
+    pub negative_low: f32,
+}
+
+impl PartialEq for SingleGamepadAxis {
+    fn eq(&self, other: &Self) -> bool {
+        self.axis == other.axis
+            && FloatOrd(self.positive_low) == FloatOrd(other.positive_low)
+            && FloatOrd(self.negative_low) == FloatOrd(other.negative_low)
+    }
+}
+impl Eq for SingleGamepadAxis {}
+impl std::hash::Hash for SingleGamepadAxis {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.axis.hash(state);
+        FloatOrd(self.positive_low).hash(state);
+        FloatOrd(self.negative_low).hash(state);
+    }
+}
+
+/// Two gamepad axes combined as one input.
+///
+/// This input will generate [`AxisPair`] can be read with
+/// [`ActionState::action_axis_pair()`][crate::ActionState::action_axis_pair()].
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+pub struct DualGamepadAxis {
+    /// The gamepad axis to use as the x axis.
+    pub x_axis: GamepadAxisType,
+    /// The gamepad axis to use as the y axis.
+    pub y_axis: GamepadAxisType,
+    /// If the stick is moved right more than this amount the input will be triggered.
+    pub x_positive_low: f32,
+    /// If the stick is moved left more than this amount the input will be triggered.
+    pub x_negative_low: f32,
+    /// If the stick is moved up more than this amount the input will be triggered.
+    pub y_positive_low: f32,
+    /// If the stick is moved down more than this amount the input will be triggered.
+    pub y_negative_low: f32,
+}
+
+impl PartialEq for DualGamepadAxis {
+    fn eq(&self, other: &Self) -> bool {
+        self.x_axis == other.x_axis
+            && self.y_axis == other.y_axis
+            && FloatOrd(self.x_positive_low) == FloatOrd(other.x_positive_low)
+            && FloatOrd(self.x_negative_low) == FloatOrd(other.x_negative_low)
+            && FloatOrd(self.y_positive_low) == FloatOrd(other.y_positive_low)
+            && FloatOrd(self.y_negative_low) == FloatOrd(other.y_negative_low)
+    }
+}
+impl Eq for DualGamepadAxis {}
+impl std::hash::Hash for DualGamepadAxis {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        self.x_axis.hash(state);
+        self.y_axis.hash(state);
+        FloatOrd(self.x_positive_low).hash(state);
+        FloatOrd(self.x_negative_low).hash(state);
+        FloatOrd(self.y_positive_low).hash(state);
+        FloatOrd(self.y_negative_low).hash(state);
     }
 }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -185,7 +185,12 @@ pub struct DualGamepadAxis {
 }
 
 impl DualGamepadAxis {
-    /// Creates a [`SingleGamepadAxis`] with both `positive_low` and `negative_low` in both axes set to `threshold`.
+    /// The default size of the deadzone used by constructor methods.
+    ///
+    /// This cannot be changed, but the struct can be easily manually constructed.
+    pub const DEFAULT_DEADZONE: f32 = 0.1;
+
+    /// Creates a [`DualGamepadAxis`] with both `positive_low` and `negative_low` in both axes set to `threshold`.
     #[must_use]
     pub const fn symmetric(
         x_axis: GamepadAxisType,
@@ -200,6 +205,26 @@ impl DualGamepadAxis {
             y_positive_low: threshold,
             y_negative_low: threshold,
         }
+    }
+
+    /// Creates a [`DualGamepadAxis`] for the left analogue stick of the gamepad.
+    #[must_use]
+    pub const fn left_stick() -> DualGamepadAxis {
+        DualGamepadAxis::symmetric(
+            GamepadAxisType::LeftStickX,
+            GamepadAxisType::LeftStickY,
+            Self::DEFAULT_DEADZONE,
+        )
+    }
+
+    /// Creates a [`DualGamepadAxis`] for the right analogue stick of the gamepad.
+    #[must_use]
+    pub const fn right_stick() -> DualGamepadAxis {
+        DualGamepadAxis::symmetric(
+            GamepadAxisType::RightStickX,
+            GamepadAxisType::RightStickY,
+            Self::DEFAULT_DEADZONE,
+        )
     }
 }
 
@@ -279,6 +304,44 @@ impl VirtualDPad {
             down: InputKind::GamepadButton(GamepadButtonType::South),
             left: InputKind::GamepadButton(GamepadButtonType::West),
             right: InputKind::GamepadButton(GamepadButtonType::East),
+        }
+    }
+
+    /// Constructs a [`VirtualDpad`] corresponding to the left analogue stick of a gamepad
+    ///
+    /// A small, symettric deadzone is added for convenience.
+    /// If you wish to control the dead zone yourself, construct this struct manually.
+    pub const fn left_stick() -> VirtualDPad {
+        let dual_gamepad_axis = DualGamepadAxis::left_stick();
+        VirtualDPad {
+            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
+        }
+    }
+
+    /// Constructs a [`VirtualDpad`] corresponding to the right analogue stick of a gamepad
+    ///
+    /// A small, symettric deadzone is added for convenience.
+    /// If you wish to control the dead zone yourself, construct this struct manually.
+    pub const fn right_stick() -> VirtualDPad {
+        let dual_gamepad_axis = DualGamepadAxis::right_stick();
+        VirtualDPad {
+            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
+        }
+    }
+
+    /// Constructs a [`VirtualDpad`] from a [`DualGamepadAxis`].
+    pub const fn from_dual_gamepad_axis(dual_gamepad_axis: DualGamepadAxis) -> VirtualDPad {
+        VirtualDPad {
+            up: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            down: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            left: InputKind::DualGamepadAxis(dual_gamepad_axis),
+            right: InputKind::DualGamepadAxis(dual_gamepad_axis),
         }
     }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -361,8 +361,8 @@ fn resolve_clash<A: Actionlike>(
 mod tests {
     use super::*;
     use crate as leafwing_input_manager;
-    use crate::Actionlike;
     use bevy_input::keyboard::KeyCode::*;
+    use leafwing_input_manager_macros::Actionlike;
 
     #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]
     enum Action {

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,8 +1,9 @@
 //! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
 
 use crate::action_state::ActionData;
+use crate::axislike::VirtualDPad;
 use crate::input_map::InputMap;
-use crate::user_input::{InputKind, InputStreams, UserInput, VirtualDPad};
+use crate::user_input::{InputKind, InputStreams, UserInput};
 use crate::Actionlike;
 
 use itertools::Itertools;
@@ -405,7 +406,7 @@ mod tests {
     }
 
     mod basic_functionality {
-        use crate::user_input::VirtualDPad;
+        use crate::axislike::VirtualDPad;
 
         use super::*;
 

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -1,6 +1,7 @@
 //! Containment module for boring implmentations of the [`Display`] trait
 
-use crate::user_input::{InputKind, UserInput, VirtualDPad};
+use crate::axislike::VirtualDPad;
+use crate::user_input::{InputKind, UserInput};
 use std::fmt::Display;
 
 impl Display for UserInput {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,10 +29,10 @@ pub use leafwing_input_manager_macros::Actionlike;
 /// Everything you need to get started
 pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
-    pub use crate::axislike::VirtualDPad;
+    pub use crate::axislike::{DualGamepadAxis, SingleGamepadAxis, VirtualDPad};
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput};
+    pub use crate::user_input::UserInput;
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,9 +29,10 @@ pub use leafwing_input_manager_macros::Actionlike;
 /// Everything you need to get started
 pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
+    pub use crate::axislike::VirtualDPad;
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;
-    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput, VirtualDPad};
+    pub use crate::user_input::{DualGamepadAxis, SingleGamepadAxis, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -1,6 +1,5 @@
 //! Helpful abstractions over user inputs of all sorts
 
-use bevy_core::FloatOrd;
 use bevy_input::{
     gamepad::{Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType},
     keyboard::KeyCode,
@@ -13,7 +12,7 @@ use bevy_utils::HashSet;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
-use crate::axislike::{AxisPair, VirtualDPad};
+use crate::axislike::{AxisPair, DualGamepadAxis, SingleGamepadAxis, VirtualDPad};
 
 /// Some combination of user input, which may cross [`Input`]-mode boundaries
 ///
@@ -385,75 +384,6 @@ pub enum InputKind {
     Keyboard(KeyCode),
     /// A button on a mouse
     Mouse(MouseButton),
-}
-
-/// A single gamepad axis with a configurable trigger zone.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct SingleGamepadAxis {
-    /// The axis that is being checked.
-    pub axis: GamepadAxisType,
-    /// Any axis value higher than this will trigger the input.
-    pub positive_low: f32,
-    /// Any axis value lower than this will trigger the input.
-    pub negative_low: f32,
-}
-
-impl PartialEq for SingleGamepadAxis {
-    fn eq(&self, other: &Self) -> bool {
-        self.axis == other.axis
-            && FloatOrd(self.positive_low) == FloatOrd(other.positive_low)
-            && FloatOrd(self.negative_low) == FloatOrd(other.negative_low)
-    }
-}
-impl Eq for SingleGamepadAxis {}
-impl std::hash::Hash for SingleGamepadAxis {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.axis.hash(state);
-        FloatOrd(self.positive_low).hash(state);
-        FloatOrd(self.negative_low).hash(state);
-    }
-}
-
-/// Two gamepad axes combined as one input.
-///
-/// This input will generate [`AxisPair`] can be read with
-/// [`ActionState::action_axis_pair()`][crate::ActionState::action_axis_pair()].
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-pub struct DualGamepadAxis {
-    /// The gamepad axis to use as the x axis.
-    pub x_axis: GamepadAxisType,
-    /// The gamepad axis to use as the y axis.
-    pub y_axis: GamepadAxisType,
-    /// If the stick is moved right more than this amount the input will be triggered.
-    pub x_positive_low: f32,
-    /// If the stick is moved left more than this amount the input will be triggered.
-    pub x_negative_low: f32,
-    /// If the stick is moved up more than this amount the input will be triggered.
-    pub y_positive_low: f32,
-    /// If the stick is moved down more than this amount the input will be triggered.
-    pub y_negative_low: f32,
-}
-
-impl PartialEq for DualGamepadAxis {
-    fn eq(&self, other: &Self) -> bool {
-        self.x_axis == other.x_axis
-            && self.y_axis == other.y_axis
-            && FloatOrd(self.x_positive_low) == FloatOrd(other.x_positive_low)
-            && FloatOrd(self.x_negative_low) == FloatOrd(other.x_negative_low)
-            && FloatOrd(self.y_positive_low) == FloatOrd(other.y_positive_low)
-            && FloatOrd(self.y_negative_low) == FloatOrd(other.y_negative_low)
-    }
-}
-impl Eq for DualGamepadAxis {}
-impl std::hash::Hash for DualGamepadAxis {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.x_axis.hash(state);
-        self.y_axis.hash(state);
-        FloatOrd(self.x_positive_low).hash(state);
-        FloatOrd(self.x_negative_low).hash(state);
-        FloatOrd(self.y_positive_low).hash(state);
-        FloatOrd(self.y_negative_low).hash(state);
-    }
 }
 
 impl From<DualGamepadAxis> for InputKind {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -13,7 +13,7 @@ use bevy_utils::HashSet;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
-use crate::axislike::AxisPair;
+use crate::axislike::{AxisPair, VirtualDPad};
 
 /// Some combination of user input, which may cross [`Input`]-mode boundaries
 ///
@@ -29,20 +29,6 @@ pub enum UserInput {
     Chord(PetitSet<InputKind, 8>),
     /// A virtual DPad that you can get an [`AxisPair`] from
     VirtualDPad(VirtualDPad),
-}
-
-#[allow(clippy::doc_markdown)] // False alarm because it thinks DPad is an un-quoted item
-/// A virtual DPad that you can get an [`AxisPair`] from
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct VirtualDPad {
-    /// The input that represents the up direction in this virtual DPad
-    pub up: InputKind,
-    /// The input that represents the down direction in this virtual DPad
-    pub down: InputKind,
-    /// The input that represents the left direction in this virtual DPad
-    pub left: InputKind,
-    /// The input that represents the right direction in this virtual DPad
-    pub right: InputKind,
 }
 
 impl UserInput {


### PR DESCRIPTION
Fixes #159.

I've left these relatively minimal to start; the explicit construction isn't too bad.


# Notes to reviewers

I did a bit of shuffling; the user input file was too large and these made sense in `axislike.rs`.

I don't love that users can construct / mutate these types into weird or bad states still. I think that's best left for another PR though, it's not trivial. See #166.