### PR TITLE
Remove ActionState::reasons_pressed API

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,16 +2,18 @@
 
 ## Version 0.5
 
-### Changes
-
-- Renamed `InputButton` to `InputKind` to reflect it's ability to represent non-button inputs such as axes.
-
 ### Enhancements
 
 - Added `SingleGamepadAxis` and `DualGamepadAxis` structs that can be supplied to an `InputMap` to trigger on axis inputs.
 - Added `VirtualDPad` struct that can be supplied to an `InputMap` to trigger on four direction-representing inputs.
 - Added `ActionState::action_axis_pair()` which can return an `AxisPair` to containing the analog values of a `SingleGamepadAxis`, `DualGamepadAxis`, or `VirtualDPad`.
 - Added `ActionState::action_value()` which represents the floating point value of any action: `1.0` or `0.0` for pressed or unpressed buttons, a value in the range `-1.0..=1.0` for a single axis representing its analog input, or a value in the range `0.0..=1.0` for a dual axis representing the magnitude (length) of its vector.
+
+### Usability
+
+- Removed the `ActionState::reasons_pressed` API.
+  - This API was quite complex and not terribly useful.
+  - This was not needed for axislike inputs in the end.
 
 ## Version 0.4.1
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -317,7 +317,6 @@ impl<A: Actionlike> InputMap<A> {
                 if input_streams.input_pressed(input) {
                     inputs.push(input.clone());
                     let action = &mut action_data[action.index()];
-                    action.reasons_pressed.push(input.clone());
                     action.value += value;
                     action.value = action.value.clamp(-1.0, 1.0);
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -77,8 +77,6 @@ fn do_nothing() {
         assert!(action_state.released(Action::PayRespects));
         assert!(!action_state.just_released(Action::PayRespects));
 
-        assert_eq!(action_state.reasons_pressed(Action::PayRespects).len(), 0);
-
         assert_eq!(action_state.instant_started(Action::PayRespects), t0);
         assert_eq!(
             action_state.previous_duration(Action::PayRespects),


### PR DESCRIPTION
This was originally intended to be used as part of #151, but turned out not to be needed.

While technically useful for users, it involved significant complexity and computational overhead.