### PR TITLE
Set axis values when mocking user input

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -535,8 +535,6 @@ impl Timing {
     /// Flips the metaphorical hourglass, storing `current_duration` in `previous_duration` and resetting `instant_started`
     ///
     /// This method is called whenever actions are pressed or released
-    ///
-    /// FIXME: Ensure that the timing starts on the same frame that the input is flipped.
     pub fn flip(&mut self) {
         self.previous_duration = self.current_duration;
         self.current_duration = Duration::ZERO;
@@ -673,7 +671,6 @@ mod tests {
         assert!(!action_state.just_pressed(Action::Jump));
     }
 
-    // FIXME: these tests are flaky because floats
     #[test]
     fn durations() {
         use crate::action_state::ActionState;

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -128,7 +128,7 @@ pub struct SingleGamepadAxis {
     pub positive_low: f32,
     /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
-    /// The current or target value for this input
+    /// The target value for this input, used for input mocking
     ///
     /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
     pub value: Option<f32>,
@@ -187,7 +187,7 @@ pub struct DualGamepadAxis {
     pub y_positive_low: f32,
     /// If the stick is moved down more than this amount the input will be triggered.
     pub y_negative_low: f32,
-    /// The current or target value for this input
+    /// The target value for this input, used for input mocking
     ///
     /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
     pub value: Option<Vec2>,

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -128,6 +128,10 @@ pub struct SingleGamepadAxis {
     pub positive_low: f32,
     /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
+    /// The current or target value for this input
+    ///
+    /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
+    pub value: Option<f32>,
 }
 
 impl SingleGamepadAxis {
@@ -138,6 +142,7 @@ impl SingleGamepadAxis {
             axis_type,
             positive_low: threshold,
             negative_low: threshold,
+            value: None,
         }
     }
 }
@@ -182,6 +187,10 @@ pub struct DualGamepadAxis {
     pub y_positive_low: f32,
     /// If the stick is moved down more than this amount the input will be triggered.
     pub y_negative_low: f32,
+    /// The current or target value for this input
+    ///
+    /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
+    pub value: Option<Vec2>,
 }
 
 impl DualGamepadAxis {
@@ -204,6 +213,7 @@ impl DualGamepadAxis {
             x_negative_low: threshold,
             y_positive_low: threshold,
             y_negative_low: threshold,
+            value: None,
         }
     }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -128,7 +128,7 @@ pub struct SingleGamepadAxis {
     pub positive_low: f32,
     /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
-    /// The target value for this input, used for input mocking
+    /// The target value for this input, used for input mocking.
     ///
     /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
     pub value: Option<f32>,
@@ -187,7 +187,7 @@ pub struct DualGamepadAxis {
     pub y_positive_low: f32,
     /// If the stick is moved down more than this amount the input will be triggered.
     pub y_negative_low: f32,
-    /// The target value for this input, used for input mocking
+    /// The target value for this input, used for input mocking.
     ///
     /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
     pub value: Option<Vec2>,

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -645,12 +645,12 @@ impl<'a> InputStreams<'a> {
         };
 
         match input {
-            UserInput::Single(InputKind::SingleGamepadAxis(threshold)) => {
+            UserInput::Single(InputKind::SingleGamepadAxis(single_axis)) => {
                 if let Some(axes) = self.gamepad_axes {
                     if let Some(gamepad) = self.associated_gamepad {
                         axes.get(GamepadAxis {
                             gamepad,
-                            axis_type: threshold.axis_type,
+                            axis_type: single_axis.axis_type,
                         })
                         .unwrap_or_default()
                     // If no gamepad is registered, return the first non-zero input found
@@ -659,7 +659,7 @@ impl<'a> InputStreams<'a> {
                             let value = axes
                                 .get(GamepadAxis {
                                     gamepad,
-                                    axis_type: threshold.axis_type,
+                                    axis_type: single_axis.axis_type,
                                 })
                                 .unwrap_or_default();
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -193,11 +193,11 @@ impl UserInput {
         &self,
     ) -> (
         Vec<GamepadButtonType>,
-        Vec<GamepadAxisType>,
+        Vec<(GamepadAxisType, Option<f32>)>,
         Vec<KeyCode>,
         Vec<MouseButton>,
     ) {
-        let mut gamepad_axes: Vec<GamepadAxisType> = Vec::default();
+        let mut gamepad_axes: Vec<(GamepadAxisType, Option<f32>)> = Vec::default();
         let mut gamepad_buttons: Vec<GamepadButtonType> = Vec::default();
         let mut keyboard_buttons: Vec<KeyCode> = Vec::default();
         let mut mouse_buttons: Vec<MouseButton> = Vec::default();
@@ -205,10 +205,17 @@ impl UserInput {
         match self {
             UserInput::Single(button) => match *button {
                 InputKind::DualGamepadAxis(variant) => {
-                    gamepad_axes.push(variant.x_axis_type);
-                    gamepad_axes.push(variant.y_axis_type);
+                    let (x_value, y_value) = match variant.value {
+                        Some(vec) => (Some(vec.x), Some(vec.y)),
+                        None => (None, None),
+                    };
+
+                    gamepad_axes.push((variant.x_axis_type, x_value));
+                    gamepad_axes.push((variant.y_axis_type, y_value));
                 }
-                InputKind::SingleGamepadAxis(variant) => gamepad_axes.push(variant.axis_type),
+                InputKind::SingleGamepadAxis(variant) => {
+                    gamepad_axes.push((variant.axis_type, variant.value))
+                }
                 InputKind::GamepadButton(variant) => gamepad_buttons.push(variant),
                 InputKind::Keyboard(variant) => keyboard_buttons.push(variant),
                 InputKind::Mouse(variant) => mouse_buttons.push(variant),
@@ -217,11 +224,16 @@ impl UserInput {
                 for button in button_set.iter() {
                     match button {
                         InputKind::DualGamepadAxis(variant) => {
-                            gamepad_axes.push(variant.x_axis_type);
-                            gamepad_axes.push(variant.y_axis_type);
+                            let (x_value, y_value) = match variant.value {
+                                Some(vec) => (Some(vec.x), Some(vec.y)),
+                                None => (None, None),
+                            };
+
+                            gamepad_axes.push((variant.x_axis_type, x_value));
+                            gamepad_axes.push((variant.y_axis_type, y_value));
                         }
                         InputKind::SingleGamepadAxis(variant) => {
-                            gamepad_axes.push(variant.axis_type)
+                            gamepad_axes.push((variant.axis_type, variant.value))
                         }
                         InputKind::GamepadButton(variant) => gamepad_buttons.push(*variant),
                         InputKind::Keyboard(variant) => keyboard_buttons.push(*variant),
@@ -238,11 +250,16 @@ impl UserInput {
                 for button in [up, down, left, right] {
                     match *button {
                         InputKind::DualGamepadAxis(variant) => {
-                            gamepad_axes.push(variant.x_axis_type);
-                            gamepad_axes.push(variant.y_axis_type);
+                            let (x_value, y_value) = match variant.value {
+                                Some(vec) => (Some(vec.x), Some(vec.y)),
+                                None => (None, None),
+                            };
+
+                            gamepad_axes.push((variant.x_axis_type, x_value));
+                            gamepad_axes.push((variant.y_axis_type, y_value));
                         }
                         InputKind::SingleGamepadAxis(variant) => {
-                            gamepad_axes.push(variant.axis_type)
+                            gamepad_axes.push((variant.axis_type, variant.value))
                         }
                         InputKind::GamepadButton(variant) => gamepad_buttons.push(variant),
                         InputKind::Keyboard(variant) => keyboard_buttons.push(variant),


### PR DESCRIPTION
Resolves a FIXME from #151 by @zicklag.

Not *thrilled* with the fact that this is only used for input mocking, but updating the `SingleGamepadAxis` / `DualGamepadAxis` field dynamically is contrary to the general data flow of the library.

Storing the target value in the `UserInput` struct also allows us to avoid polluting the input mocking API for the very rare case.