### PR TITLE
Control available input types using cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,16 @@ opt-level = 3
 members = ["./", "tools/ci", "macros"]
 
 [features]
-default = ['ui']
+default = ['ui', 'gamepad', 'keyboard', 'mouse', 'touch']
+# Enables gamepad inputs
+gamepad = []
+# Enable keyboard inputs
+keyboard = []
+# Enable mouse inputs
+mouse = []
+# Enable touch inputs (not yet implemented)
+touch = []
+# Add support for [`bevy_ui`] integration
 ui = ['bevy_ui']
 
 [dependencies]

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -34,6 +34,9 @@
 - Converting from a `Direction` (which uses a `Vec2` of `f32`'s internally) to a `Rotation` (which uses exact decidegrees) now has special cases to ensure all eight cardinal directions result in exact degrees.
   - For example, a unit vector pointing to the Northeast now always converts to a `Direction` with exactly 1350 decidegrees.
   - Rounding errors may still occur when converting from arbitrary directions to the other 3592 discrete decidegrees.
+- `InputStreams` and `MutableInputStreams` no longer store e.g. `Option<Res<Input<MouseButton>>>`, and instead simply store `Res<Input<MouseButton>>`
+  - This makes them much easier to work with.
+  - If you are on a platform or project where you don't care about certain input streams, disable the newly added `gamepad` / `keyboard` /  `mouse` / `touch` features to meet your needs.
 
 ## Version 0.4.1
 


### PR DESCRIPTION
Fixes #183. Well, attempts to.

There are some gnarly challenges here:

1. We need to run more tests in CI, one for each input feature enabled in isolation.
2. Returned tuple types (like in `UserInput::raw_inputs`) cannot have their values ignored using the cfg flags.
3. If you ignore too many fields on `InputStreams`, you get unused lifetime errors.
4. We need to make sure that tests and examples are all using the correct features.

Overall, I think this is a decent direction, but it's a hell of a yak shave. Like the label says, if you want to try your hand at this, feel free!

Cc: @mockersf (who may have good suggestions, or choose to open the closed `Option<EventReader> issue), who suggested this direction to me 😅 