### PR TITLE
Depend on Bevy directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ ui = ['bevy/bevy_ui']
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.5" }
 
-bevy = {git = "https://github.com/bevyengine/bevy", default-features = false}
+bevy = {git = "https://github.com/bevyengine/bevy", default-features = false, features = ["serialize"]}
 
 petitset = {version = "0.2.1", features = ["serde_compat"]}
 derive_more = {version = "0.99", default-features = false, features = ["display", "error"]}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,21 +19,12 @@ members = ["./", "tools/ci", "macros"]
 
 [features]
 default = ['ui']
-ui = ['bevy_ui']
+ui = ['bevy/bevy_ui']
 
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.5" }
 
-bevy_app = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_core = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_transform = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_ecs = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_input = {git = "https://github.com/bevyengine/bevy", default-features = false, features = ["serialize"]}
-bevy_math = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_time = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_utils = {git = "https://github.com/bevyengine/bevy", default-features = false}
-bevy_ui = {git = "https://github.com/bevyengine/bevy", default-features = false, optional = true}
-bevy_window = {git = "https://github.com/bevyengine/bevy", default-features = false}
+bevy = {git = "https://github.com/bevyengine/bevy", default-features = false}
 
 petitset = {version = "0.2.1", features = ["serde_compat"]}
 derive_more = {version = "0.99", default-features = false, features = ["display", "error"]}

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -6,7 +6,7 @@
 //! between two distinct [`ActionState`] components.
 
 use bevy::prelude::*;
-use bevy_utils::HashMap;
+use bevy::utils::HashMap;
 use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::prelude::*;
 

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -1,7 +1,7 @@
 //! Demonstrates how to "consume" actions, so they can only be responded to by a single system
 
+use bevy::ecs::system::Resource;
 use bevy::prelude::*;
-use bevy_ecs::system::Resource;
 use leafwing_input_manager::prelude::*;
 
 use menu_mocking::*;

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -6,9 +6,9 @@
 //! Note that [`ActionState`] can also be serialized and sent directly.
 //! This approach will be less bandwidth efficient, but involve less complexity and CPU work.
 
+use bevy::ecs::event::{Events, ManualEventReader};
+use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use bevy_ecs::event::{Events, ManualEventReader};
-use bevy_input::InputPlugin;
 use leafwing_input_manager::action_state::ActionDiff;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::systems::{generate_action_diffs, process_action_diffs};

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -1,4 +1,4 @@
-//! Demonstrates how to connect `bevy_ui` buttons to [`ActionState`] components using the [`ActionStateDriver`] component on your button
+//! Demonstrates how to connect `bevy::ui` buttons to [`ActionState`] components using the [`ActionStateDriver`] component on your button
 
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -3,8 +3,8 @@
 use crate::Actionlike;
 use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 
-use bevy_ecs::{component::Component, entity::Entity};
-use bevy_utils::{Duration, Instant};
+use bevy::ecs::{component::Component, entity::Entity};
+use bevy::utils::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
 
@@ -42,7 +42,7 @@ pub struct ActionData {
 /// # Example
 /// ```rust
 /// use leafwing_input_manager::prelude::*;
-/// use bevy_utils::Instant;
+/// use bevy::utils::Instant;
 ///
 /// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Debug)]
 /// enum Action {
@@ -120,7 +120,7 @@ impl<A: Actionlike> ActionState<A> {
     /// ```rust
     /// use leafwing_input_manager::prelude::*;
     /// use leafwing_input_manager::buttonlike::ButtonState;
-    /// use bevy_utils::Instant;
+    /// use bevy::utils::Instant;
     ///
     /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
@@ -473,7 +473,7 @@ impl<A: Actionlike> Default for ActionState<A> {
 /// # Examples
 ///
 /// By default, [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction) uses this component
-/// in order to connect `bevy_ui` buttons to the corresponding `ActionState`.
+/// in order to connect `bevy::ui` buttons to the corresponding `ActionState`.
 ///
 /// ```rust
 /// use bevy::prelude::*;
@@ -610,7 +610,7 @@ mod tests {
         use crate::input_map::InputMap;
         use crate::input_streams::InputStreams;
         use bevy::prelude::*;
-        use bevy_utils::{Duration, Instant};
+        use bevy::utils::{Duration, Instant};
 
         // Action state
         let mut action_state = ActionState::<Action>::default();
@@ -675,7 +675,7 @@ mod tests {
     #[test]
     fn time_tick_ticks_away() {
         use crate::action_state::ActionState;
-        use bevy_utils::{Duration, Instant};
+        use bevy::utils::{Duration, Instant};
 
         let mut action_state = ActionState::<Action>::default();
 
@@ -699,7 +699,7 @@ mod tests {
     #[test]
     fn durations() {
         use crate::action_state::ActionState;
-        use bevy_utils::{Duration, Instant};
+        use bevy::utils::{Duration, Instant};
 
         let mut action_state = ActionState::<Action>::default();
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -3,12 +3,12 @@
 use crate::buttonlike::MouseWheelDirection;
 use crate::orientation::{Direction, Rotation};
 use crate::user_input::InputKind;
-use bevy_input::{
+use bevy::input::{
     gamepad::{GamepadAxisType, GamepadButtonType},
     keyboard::KeyCode,
 };
-use bevy_math::Vec2;
-use bevy_utils::FloatOrd;
+use bevy::math::Vec2;
+use bevy::utils::FloatOrd;
 use serde::{Deserialize, Serialize};
 
 /// A single directional axis with a configurable trigger zone.
@@ -58,7 +58,7 @@ impl SingleAxis {
         }
     }
 
-    /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseWheel`](bevy_input::mouse::MouseWheel) movement
+    /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
     #[must_use]
     pub const fn mouse_wheel_x() -> SingleAxis {
         SingleAxis {
@@ -69,7 +69,7 @@ impl SingleAxis {
         }
     }
 
-    /// Creates a [`SingleAxis`] corresponding to vertical [`MouseWheel`](bevy_input::mouse::MouseWheel) movement
+    /// Creates a [`SingleAxis`] corresponding to vertical [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
     #[must_use]
     pub const fn mouse_wheel_y() -> SingleAxis {
         SingleAxis {
@@ -80,7 +80,7 @@ impl SingleAxis {
         }
     }
 
-    /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseMotion`](bevy_input::mouse::MouseMotion) movement
+    /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseMotion`](bevy::input::mouse::MouseMotion) movement
     #[must_use]
     pub const fn mouse_motion_x() -> SingleAxis {
         SingleAxis {
@@ -91,7 +91,7 @@ impl SingleAxis {
         }
     }
 
-    /// Creates a [`SingleAxis`] corresponding to vertical [`MouseMotion`](bevy_input::mouse::MouseMotion) movement
+    /// Creates a [`SingleAxis`] corresponding to vertical [`MouseMotion`](bevy::input::mouse::MouseMotion) movement
     #[must_use]
     pub const fn mouse_motion_y() -> SingleAxis {
         SingleAxis {
@@ -193,7 +193,7 @@ impl DualAxis {
         )
     }
 
-    /// Creates a [`DualAxis`] corresponding to horizontal and vertical [`MouseWheel`](bevy_input::mouse::MouseWheel) movement
+    /// Creates a [`DualAxis`] corresponding to horizontal and vertical [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
     pub const fn mouse_wheel() -> DualAxis {
         DualAxis {
             x: SingleAxis::mouse_wheel_x(),
@@ -201,7 +201,7 @@ impl DualAxis {
         }
     }
 
-    /// Creates a [`DualAxis`] corresponding to horizontal and vertical [`MouseMotion`](bevy_input::mouse::MouseMotion) movement
+    /// Creates a [`DualAxis`] corresponding to horizontal and vertical [`MouseMotion`](bevy::input::mouse::MouseMotion) movement
     pub const fn mouse_motion() -> DualAxis {
         DualAxis {
             x: SingleAxis::mouse_motion_x(),

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -88,7 +88,7 @@ impl Default for ButtonState {
     }
 }
 
-/// A buttonlike-input triggered by [`MouseWheel`](bevy_input::mouse::MouseWheel) events
+/// A buttonlike-input triggered by [`MouseWheel`](bevy::input::mouse::MouseWheel) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -103,7 +103,7 @@ pub enum MouseWheelDirection {
     Left,
 }
 
-/// A buttonlike-input triggered by [`MouseMotion`](bevy_input::mouse::MouseMotion) events
+/// A buttonlike-input triggered by [`MouseMotion`](bevy::input::mouse::MouseMotion) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -361,7 +361,7 @@ fn resolve_clash<A: Actionlike>(
 mod tests {
     use super::*;
     use crate as leafwing_input_manager;
-    use bevy_input::keyboard::KeyCode::*;
+    use bevy::input::keyboard::KeyCode::*;
     use leafwing_input_manager_macros::Actionlike;
 
     #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,7 +5,7 @@ use derive_more::{Display, Error};
 /// The supplied vector-like struct was too close to zero to be converted into a rotation-like type
 ///
 /// This error is produced when attempting to convert into a rotation-like type
-/// such as a [`Rotation`] or [`Quat`](bevy_math::Quat) from a vector-like type
+/// such as a [`Rotation`] or [`Quat`](bevy::math::Quat) from a vector-like type
 /// such as a [`Vec2`].
 ///
 /// In almost all cases, the correct way to handle this error is to simply not change the rotation.

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -7,8 +7,8 @@ use crate::input_streams::InputStreams;
 use crate::user_input::{InputKind, UserInput};
 use crate::Actionlike;
 
-use bevy_ecs::component::Component;
-use bevy_input::gamepad::Gamepad;
+use bevy::ecs::component::Component;
+use bevy::input::gamepad::Gamepad;
 
 use core::fmt::Debug;
 use petitset::PetitSet;
@@ -104,7 +104,7 @@ impl<A: Actionlike> InputMap<A> {
     /// ```rust
     /// use leafwing_input_manager::input_map::InputMap;
     /// use leafwing_input_manager::Actionlike;
-    /// use bevy_input::keyboard::KeyCode;
+    /// use bevy::input::keyboard::KeyCode;
     ///
     /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
     /// enum Action {
@@ -141,7 +141,7 @@ impl<A: Actionlike> InputMap<A> {
     /// ```rust
     /// use leafwing_input_manager::prelude::*;
 
-    /// use bevy_input::keyboard::KeyCode;
+    /// use bevy::input::keyboard::KeyCode;
     ///
     /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
     /// enum Action {
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn insertion_idempotency() {
-        use bevy_input::keyboard::KeyCode;
+        use bevy::input::keyboard::KeyCode;
         use petitset::PetitSet;
 
         let mut input_map = InputMap::<Action>::default();
@@ -450,7 +450,7 @@ mod tests {
     #[test]
     fn multiple_insertion() {
         use crate::user_input::UserInput;
-        use bevy_input::keyboard::KeyCode;
+        use bevy::input::keyboard::KeyCode;
         use petitset::PetitSet;
 
         let mut input_map_1 = InputMap::<Action>::default();
@@ -473,7 +473,7 @@ mod tests {
     #[test]
     fn chord_singleton_coercion() {
         use crate::input_map::UserInput;
-        use bevy_input::keyboard::KeyCode;
+        use bevy::input::keyboard::KeyCode;
 
         // Single items in a chord should be coerced to a singleton
         let mut input_map_1 = InputMap::<Action>::default();
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn input_clearing() {
-        use bevy_input::keyboard::KeyCode;
+        use bevy::input::keyboard::KeyCode;
 
         let mut input_map = InputMap::<Action>::default();
         input_map.insert(KeyCode::Space, Action::Run);
@@ -513,7 +513,7 @@ mod tests {
 
     #[test]
     fn merging() {
-        use bevy_input::{gamepad::GamepadButtonType, keyboard::KeyCode};
+        use bevy::input::{gamepad::GamepadButtonType, keyboard::KeyCode};
 
         let mut input_map = InputMap::default();
         let mut default_keyboard_map = InputMap::default();
@@ -534,7 +534,7 @@ mod tests {
 
     #[test]
     fn gamepad_swapping() {
-        use bevy_input::gamepad::Gamepad;
+        use bevy::input::gamepad::Gamepad;
 
         let mut input_map = InputMap::<Action>::default();
         assert_eq!(input_map.gamepad(), None);

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -4,24 +4,24 @@ use crate::axislike::{AxisType, MouseMotionAxisType, MouseWheelAxisType};
 use crate::input_streams::{InputStreams, MutableInputStreams};
 use crate::user_input::UserInput;
 
-use bevy_app::App;
-use bevy_ecs::event::Events;
-use bevy_ecs::system::{ResMut, SystemState};
-use bevy_ecs::world::World;
+use bevy::app::App;
+use bevy::ecs::event::Events;
+use bevy::ecs::system::{ResMut, SystemState};
+use bevy::ecs::world::World;
 #[cfg(feature = "ui")]
-use bevy_ecs::{component::Component, query::With, system::Query};
-use bevy_input::mouse::MouseScrollUnit;
-use bevy_input::{
+use bevy::ecs::{component::Component, query::With, system::Query};
+use bevy::input::mouse::MouseScrollUnit;
+use bevy::input::{
     gamepad::{Gamepad, GamepadAxis, GamepadButton, GamepadEvent, Gamepads},
     keyboard::{KeyCode, KeyboardInput},
     mouse::{MouseButton, MouseButtonInput, MouseMotion, MouseWheel},
     touch::{TouchInput, Touches},
     Input,
 };
-use bevy_math::Vec2;
+use bevy::math::Vec2;
 #[cfg(feature = "ui")]
-use bevy_ui::Interaction;
-use bevy_window::CursorMoved;
+use bevy::ui::Interaction;
+use bevy::window::CursorMoved;
 
 /// Send fake input events for testing purposes
 ///
@@ -109,13 +109,13 @@ pub trait MockInput {
     /// as well as any [`Interaction`] components and all input [`Events`].
     fn reset_inputs(&mut self);
 
-    /// Presses all `bevy_ui` buttons with the matching `Marker` component
+    /// Presses all `bevy::ui` buttons with the matching `Marker` component
     ///
     /// Changes their [`Interaction`] component to [`Interaction::Clicked`]
     #[cfg(feature = "ui")]
     fn click_button<Marker: Component>(&mut self);
 
-    /// Hovers over all `bevy_ui` buttons with the matching `Marker` component
+    /// Hovers over all `bevy::ui` buttons with the matching `Marker` component
     ///
     /// Changes their [`Interaction`] component to [`Interaction::Clicked`]
     #[cfg(feature = "ui")]
@@ -464,8 +464,8 @@ mod test {
     #[cfg(feature = "ui")]
     fn ui_inputs() {
         use crate::input_mocking::MockInput;
-        use bevy_ecs::prelude::*;
-        use bevy_ui::Interaction;
+        use bevy::ecs::prelude::*;
+        use bevy::ui::Interaction;
 
         #[derive(Component)]
         struct ButtonMarker;

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -1,6 +1,6 @@
-//! Unified input streams for working with [`bevy_input`] data.
+//! Unified input streams for working with [`bevy::input`] data.
 
-use bevy_input::{
+use bevy::input::{
     gamepad::{Gamepad, GamepadAxis, GamepadButton, Gamepads},
     keyboard::KeyCode,
     mouse::{MouseButton, MouseMotion, MouseWheel},
@@ -8,8 +8,8 @@ use bevy_input::{
 };
 use petitset::PetitSet;
 
-use bevy_ecs::prelude::{Events, Res, ResMut, World};
-use bevy_ecs::system::SystemState;
+use bevy::ecs::prelude::{Events, Res, ResMut, World};
+use bevy::ecs::system::SystemState;
 
 use crate::axislike::{
     AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis, VirtualDPad,
@@ -414,7 +414,7 @@ impl<'a> InputStreams<'a> {
             UserInput::VirtualDPad { .. } => {
                 self.input_axis_pair(input).unwrap_or_default().length()
             }
-            // This is required because upstream bevy_input still waffles about whether triggers are buttons or axes
+            // This is required because upstream bevy::input still waffles about whether triggers are buttons or axes
             UserInput::Single(InputKind::GamepadButton(button_type)) => {
                 if let Some(button_axes) = self.gamepad_button_axes {
                     if let Some(gamepad) = self.associated_gamepad {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 
 use crate::action_state::ActionState;
 use crate::input_map::InputMap;
-use bevy_ecs::prelude::*;
+use bevy::ecs::prelude::*;
 use std::marker::PhantomData;
 
 pub mod action_state;

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -7,8 +7,8 @@ pub use rotation_direction::RotationDirection;
 
 mod orientation_trait {
     use super::{Direction, Rotation, RotationDirection};
-    use bevy_math::Quat;
-    use bevy_transform::components::{GlobalTransform, Transform};
+    use bevy::math::Quat;
+    use bevy::transform::components::{GlobalTransform, Transform};
     use core::fmt::Debug;
 
     /// A type that can represent a orientation in 2D space
@@ -220,8 +220,8 @@ mod rotation_direction {
 
 mod rotation {
     use crate::errors::NearlySingularConversion;
-    use bevy_ecs::prelude::Component;
-    use bevy_math::Vec2;
+    use bevy::ecs::prelude::Component;
+    use bevy::math::Vec2;
     use core::ops::{Add, AddAssign, Div, Mul, Neg, Sub, SubAssign};
     use derive_more::Display;
     use std::f32::consts::TAU;
@@ -319,7 +319,7 @@ mod rotation {
         ///
         /// # Example
         /// ```rust
-        /// use bevy_math::Vec2;
+        /// use bevy::math::Vec2;
         /// use leafwing_input_manager::orientation::Rotation;
         ///
         /// assert_eq!(Rotation::from_xy(Vec2::new(0.0, 1.0)), Ok(Rotation::NORTH));
@@ -454,8 +454,8 @@ mod rotation {
 }
 
 mod direction {
-    use bevy_ecs::prelude::Component;
-    use bevy_math::{Vec2, Vec3};
+    use bevy::ecs::prelude::Component;
+    use bevy::math::{Vec2, Vec3};
     use core::ops::{Add, Div, Mul, Neg, Sub};
     use derive_more::Display;
     use std::f32::consts::SQRT_2;
@@ -467,7 +467,7 @@ mod direction {
     /// # Example
     /// ```rust
     /// use leafwing_input_manager::orientation::Direction;
-    /// use bevy_math::Vec2;
+    /// use bevy::math::Vec2;
     ///
     /// assert_eq!(Direction::NORTH.unit_vector(), Vec2::new(0.0, 1.0));
     /// assert_eq!(Direction::try_from(Vec2::ONE), Ok(Direction::NORTHEAST));
@@ -617,8 +617,8 @@ mod direction {
 mod conversions {
     use super::{Direction, Rotation};
     use crate::errors::NearlySingularConversion;
-    use bevy_math::{Quat, Vec2, Vec3};
-    use bevy_transform::components::{GlobalTransform, Transform};
+    use bevy::math::{Quat, Vec2, Vec3};
+    use bevy::transform::components::{GlobalTransform, Transform};
 
     impl From<Rotation> for Direction {
         fn from(rotation: Rotation) -> Direction {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,11 +6,11 @@ use core::hash::Hash;
 use core::marker::PhantomData;
 use std::fmt::Debug;
 
-use bevy_app::{App, CoreStage, Plugin};
-use bevy_ecs::prelude::*;
-use bevy_input::InputSystem;
+use bevy::app::{App, CoreStage, Plugin};
+use bevy::ecs::prelude::*;
+use bevy::input::InputSystem;
 #[cfg(feature = "ui")]
-use bevy_ui::UiSystem;
+use bevy::ui::UiSystem;
 
 /// A [`Plugin`] that collects [`Input`](bevy::input::Input) from disparate sources, producing an [`ActionState`](crate::action_state::ActionState) that can be conveniently checked
 ///

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -11,18 +11,18 @@ use crate::{
     Actionlike,
 };
 
-use bevy_ecs::{prelude::*, schedule::ShouldRun};
-use bevy_input::{
+use bevy::ecs::{prelude::*, schedule::ShouldRun};
+use bevy::input::{
     gamepad::{GamepadAxis, GamepadButton, Gamepads},
     keyboard::KeyCode,
     mouse::{MouseButton, MouseMotion, MouseWheel},
     Axis, Input,
 };
-use bevy_time::Time;
-use bevy_utils::Instant;
+use bevy::time::Time;
+use bevy::utils::Instant;
 
 #[cfg(feature = "ui")]
-use bevy_ui::Interaction;
+use bevy::ui::Interaction;
 
 /// Advances actions timer.
 ///
@@ -134,7 +134,7 @@ pub fn update_action_state_from_interaction<A: Actionlike>(
     }
 }
 
-/// Generates an [`Events`](bevy_ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
+/// Generates an [`Events`](bevy::ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
 ///
 /// The `ID` generic type should be a stable entity identifer,
 /// suitable to be sent across a network.
@@ -161,7 +161,7 @@ pub fn generate_action_diffs<A: Actionlike, ID: Eq + Clone + Component>(
     }
 }
 
-/// Generates an [`Events`](bevy_ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
+/// Generates an [`Events`](bevy::ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
 ///
 /// The `ID` generic type should be a stable entity identifer,
 /// suitable to be sent across a network.

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -1,8 +1,8 @@
 //! Helpful abstractions over user inputs of all sorts
 
-use bevy_input::{gamepad::GamepadButtonType, keyboard::KeyCode, mouse::MouseButton};
+use bevy::input::{gamepad::GamepadButtonType, keyboard::KeyCode, mouse::MouseButton};
 
-use bevy_utils::HashSet;
+use bevy::utils::HashSet;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
@@ -69,8 +69,8 @@ impl UserInput {
     ///
     /// # Example
     /// ```rust
-    /// use bevy_input::keyboard::KeyCode::*;
-    /// use bevy_utils::HashSet;
+    /// use bevy::input::keyboard::KeyCode::*;
+    /// use bevy::utils::HashSet;
     /// use leafwing_input_manager::user_input::UserInput;
     ///
     /// let buttons = HashSet::from_iter([LControl.into(), LAlt.into()]);

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -1,6 +1,6 @@
+use bevy::ecs::system::SystemState;
 use bevy::prelude::*;
-use bevy_ecs::system::SystemState;
-use bevy_utils::HashSet;
+use bevy::utils::HashSet;
 use leafwing_input_manager::input_streams::InputStreams;
 use leafwing_input_manager::prelude::*;
 
@@ -82,7 +82,7 @@ impl ClashTestExt for App {
 
 #[test]
 fn input_clash_handling() {
-    use bevy_input::InputPlugin;
+    use bevy::input::InputPlugin;
     use leafwing_input_manager::MockInput;
     use Action::*;
     use KeyCode::*;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,6 +1,6 @@
 #![cfg(test)]
+use bevy::ecs::query::ChangeTrackers;
 use bevy::prelude::*;
-use bevy_ecs::query::ChangeTrackers;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::MockInput;
 
@@ -49,8 +49,8 @@ fn spawn_player(mut commands: Commands) {
 
 #[test]
 fn do_nothing() {
-    use bevy_input::InputPlugin;
-    use bevy_utils::Duration;
+    use bevy::input::InputPlugin;
+    use bevy::utils::Duration;
 
     let mut app = App::new();
 
@@ -91,7 +91,7 @@ fn do_nothing() {
 
 #[test]
 fn action_state_change_detection() {
-    use bevy_input::InputPlugin;
+    use bevy::input::InputPlugin;
 
     let mut app = App::new();
 
@@ -125,7 +125,7 @@ fn action_state_change_detection() {
 
 #[test]
 fn disable_input() {
-    use bevy_input::InputPlugin;
+    use bevy::input::InputPlugin;
 
     let mut app = App::new();
 
@@ -166,8 +166,8 @@ fn disable_input() {
 #[test]
 #[cfg(feature = "ui")]
 fn action_state_driver() {
-    use bevy_input::InputPlugin;
-    use bevy_ui::Interaction;
+    use bevy::input::InputPlugin;
+    use bevy::ui::Interaction;
 
     let mut app = App::new();
 
@@ -237,8 +237,8 @@ fn action_state_driver() {
 
 #[test]
 fn duration() {
-    use bevy_input::InputPlugin;
-    use bevy_utils::Duration;
+    use bevy::input::InputPlugin;
+    use bevy::utils::Duration;
 
     const RESPECTFUL_DURATION: Duration = Duration::from_millis(5);
 

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -1,6 +1,6 @@
+use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
+use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use bevy_input::mouse::{MouseScrollUnit, MouseWheel};
-use bevy_input::InputPlugin;
 use leafwing_input_manager::axislike::{DualAxisData, MouseWheelAxisType};
 use leafwing_input_manager::{prelude::*, MockInput};
 


### PR DESCRIPTION
This is a) much cleaner and easier to maintain b) makes it easier for others to patch this crate to a specific version and c) slightly more robust to bevy shuffling code around.