### PR TITLE
Add `ActionState::action_data_mut` for retrieving mutable state for an action

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -190,6 +190,32 @@ impl<A: Actionlike> ActionState<A> {
         self.action_data[action.index()].clone()
     }
 
+    /// Gets a mutable copy of the [`ActionData`] of the corresponding `action`
+    ///
+    /// Generally, it'll be clearer to call `pressed` or so on directly on the [`ActionState`].
+    /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
+    ///
+    /// # Example
+    /// ```rust
+    /// use leafwing_input_manager::prelude::*;
+    ///
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// enum Action {
+    ///     Run,
+    ///     Jump,
+    /// }
+    /// let mut action_state = ActionState::<Action>::default();
+    /// let mut run_data = action_state.action_data_mut(Action::Run);
+    /// run_data.axis_pair = None;
+    ///
+    /// dbg!(run_data);
+    /// ```
+    #[inline]
+    #[must_use]
+    pub fn action_data_mut(&mut self, action: A) -> &mut ActionData {
+        &mut self.action_data[action.index()]
+    }
+
     /// Get the value associated with the corresponding `action`
     ///
     /// Different kinds of bindings have different ways of calculating the value:


### PR DESCRIPTION
Manipulating `ActionData` works well if you want to use one of the methods like `press`, `release`, etc. But it's a bit more challenging if you a) want to do something outside the limited setters and b) don't want to get into the specifics of how `ActionData` should be set up.

This lets me do the following:

```
            let mut direction = Vec2::ZERO;
            if actions.pressed(Action::Forward) {
                direction.x += 1.;
            }
            if actions.pressed(Action::Backward) {
                direction.x -= 1.;
            }
            if actions.pressed(Action::Left) {
                direction.y += 1.;
            }
            if actions.pressed(Action::Right) {
                direction.y -= 1.;
            }
            let mut data = navigation.action_data_mut(NavigationAction::Move);
            if direction.length() != 0. {
                navigation.press(NavigationAction::Move);
                data.axis_pair = Some(direction.into());
            } else {
                navigation.release(NavigationAction::Move);
                data.axis_pair = None;
            }
```

which, assuming I'm right, lets me translate my individual left/right/forward/backward actions to `Move`, which expects `DualAxis` input, without needing a separate setter and without having to get `ActionData` construction right.