### PR TITLE
Make `DualAxis::right_stick()` use the correct y-axis

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -188,7 +188,7 @@ impl DualAxis {
     pub fn right_stick() -> DualAxis {
         DualAxis::symmetric(
             GamepadAxisType::RightStickX,
-            GamepadAxisType::LeftStickY,
+            GamepadAxisType::RightStickY,
             Self::DEFAULT_DEADZONE,
         )
     }


### PR DESCRIPTION
It was incorrectly using the y-axis from the left stick.