### PR TITLE
Improve ToggleActions

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,14 @@
 # Release Notes
 
+## Unreleased
+
+### Enhancements
+
+- Improve `ToggleActions`.
+  - Make `_phantom` field public and rename into `phantom`.
+  - Add `ToggleActions::new`.
+  - Add `ToggleActions::ENABLED` and `ToggleActions::DISABLED`.
+
 ## Version 0.5
 
 ### Enhancements

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,7 +6,6 @@
 
 - Improve `ToggleActions`.
   - Make `_phantom` field public and rename into `phantom`.
-  - Add `ToggleActions::new`.
   - Add `ToggleActions::ENABLED` and `ToggleActions::DISABLED`.
 
 ## Version 0.5

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -147,16 +147,26 @@ pub struct ToggleActions<A: Actionlike> {
     ///
     /// When this is set to false, all corresponding [`ActionState`]s are released
     pub enabled: bool,
-    _phantom: PhantomData<A>,
+    /// Marker that stores the type of action to toggle
+    pub phantom: PhantomData<A>,
+}
+
+impl<A: Actionlike> ToggleActions<A> {
+    /// A [`ToggleActions`] in enabled state.
+    pub const ENABLED: ToggleActions::<A> = ToggleActions::<A>::new(true);
+    /// A [`ToggleActions`] in disabled state.
+    pub const DISABLED: ToggleActions::<A> = ToggleActions::<A>::new(false);
+
+    /// Constructs a new [`ToggleActions`] with a specific state.
+    pub const fn new(enabled: bool) -> Self {
+        Self { enabled, phantom: PhantomData::<A>, }
+    }
 }
 
 // Implement manually to not require [`Default`] for `A`
 impl<A: Actionlike> Default for ToggleActions<A> {
     fn default() -> Self {
-        Self {
-            enabled: true,
-            _phantom: PhantomData::<A>,
-        }
+        Self::new(true)
     }
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -153,20 +153,24 @@ pub struct ToggleActions<A: Actionlike> {
 
 impl<A: Actionlike> ToggleActions<A> {
     /// A [`ToggleActions`] in enabled state.
-    pub const ENABLED: ToggleActions::<A> = ToggleActions::<A>::new(true);
+    pub const ENABLED: ToggleActions<A> = ToggleActions::<A> {
+        enabled: true,
+        phantom: PhantomData::<A>,
+    };
     /// A [`ToggleActions`] in disabled state.
-    pub const DISABLED: ToggleActions::<A> = ToggleActions::<A>::new(false);
-
-    /// Constructs a new [`ToggleActions`] with a specific state.
-    pub const fn new(enabled: bool) -> Self {
-        Self { enabled, phantom: PhantomData::<A>, }
-    }
+    pub const DISABLED: ToggleActions<A> = ToggleActions::<A> {
+        enabled: false,
+        phantom: PhantomData::<A>,
+    };
 }
 
 // Implement manually to not require [`Default`] for `A`
 impl<A: Actionlike> Default for ToggleActions<A> {
     fn default() -> Self {
-        Self::new(true)
+        Self {
+            enabled: true,
+            phantom: PhantomData::<A>,
+        }
     }
 }
 


### PR DESCRIPTION
I added the following as was suggested in #227:

- Make `_phantom` field public and rename into `phantom`.
- Add `ToggleActions::new`.
- Add `ToggleActions::ENABLED` and `ToggleActions::DISABLED`. Do we really need them? :thinking: