### PR TITLE
Make Sure Gampad Axis Value Is Within Deadzone

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerfully direct stateful input manager for the Bevy game engine."
-version = "0.5.1"
+version = "0.5.2"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Version 0.5.2
+
+### Bug fixes
+
+- Fixed gamepad axes not filtering out inputs outside of the axis deadzone.
+- Fixed `DualAxis::right_stick()` returning the y axis for the left stick.
+
 ## Version 0.5.1
 
 ### Bug fixes

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -522,7 +522,7 @@ pub struct ActionStateDriver<A: Actionlike> {
 ///
 /// This struct is principally used as a field on [`ActionData`],
 /// which itself lives inside an [`ActionState`].
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Timing {
     /// The [`Instant`] at which the button was pressed or released
     /// Recorded as the [`Time`](bevy::core::Time) at the start of the tick after the state last changed.

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -73,7 +73,7 @@ use std::marker::PhantomData;
 /// // Removal
 /// input_map.clear_action(Action::Hide);
 ///```
-#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct InputMap<A: Actionlike> {
     /// The raw vector of [PetitSet]s used to store the input mapping,

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -247,9 +247,12 @@ impl<'a> InputStreams<'a> {
                 match single_axis.axis_type {
                     AxisType::Gamepad(axis_type) => {
                         if let Some(gamepad) = self.guess_gamepad() {
-                            self.gamepad_axes
+                            let value = self
+                                .gamepad_axes
                                 .get(GamepadAxis { gamepad, axis_type })
-                                .unwrap_or_default()
+                                .unwrap_or_default();
+
+                            value_in_axis_range(single_axis, value)
                         } else {
                             0.0
                         }


### PR DESCRIPTION
The gamepad axis type wasn't making sure the returned value was within the range of the axis thresholds.