### PR TITLE
Run clippy on examples in CI

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -16,4 +16,9 @@ fn main() {
     cmd!("cargo clippy --workspace --all-features -- -D warnings -A clippy::type_complexity")
         .run()
         .expect("Please fix clippy errors in output above.");
+
+    // Check the examples with clippy
+    cmd!("cargo clippy --examples -D warnings -A clippy::type_complexity")
+        .run()
+        .expect("Please fix clippy errors in the examples.");
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -18,7 +18,7 @@ fn main() {
         .expect("Please fix clippy errors in output above.");
 
     // Check the examples with clippy
-    cmd!("cargo clippy --examples -D warnings -A clippy::type_complexity")
+    cmd!("cargo clippy --examples -- -D warnings -A clippy::type_complexity")
         .run()
         .expect("Please fix clippy errors in the examples.");
 }


### PR DESCRIPTION
Closes #201.

Note that this doesn't _run_ the examples, but I think running clippy on them gives the best ROI.

Actually running may have several disadvantages:

- It's hard to set up, you'd probably need to get a list of all examples somehow.
- It could reduce CI times substantially, depending on the timeout.
- It is flaky, sometimes it might catch an error and sometimes not.

Also note that this way of setting up CI has the disadvantage that it's not run in parallel.
This might not scale well, especially with the examples now.