### PR TITLE
Run `cargo check` with no features and default features in CI

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -9,11 +9,21 @@ fn main() {
     // See if any code needs to be formatted
     cmd!("cargo fmt --all -- --check")
         .run()
-        .expect("Please run 'cargo fmt --all' to format your code.");
+        .expect("Please run `cargo fmt --all` to format your code.");
 
     // See if clippy has any complaints.
     // - Type complexity must be ignored because we use huge templates for queries
     cmd!("cargo clippy --workspace --all-features -- -D warnings -A clippy::type_complexity")
         .run()
-        .expect("Please fix clippy errors in output above.");
+        .expect("Please fix `cargo clippy` errors with all features enabled.");
+
+    // Check for errors with no features enabled
+    cmd!("cargo check --workspace --no-default-features")
+        .run()
+        .expect("Please fix `cargo check` errors with no features enabled .");
+
+    // Check for errors with default features enabled
+    cmd!("cargo check --workspace")
+        .run()
+        .expect("Please fix `cargo check` errors with default features enabled.");
 }


### PR DESCRIPTION
Closes #199.

This expands the CI script to also run `cargo check` with no features and default features to catch potential errors with the feature configuration.