### PR TITLE
Fix clippy warnings to also derive `Eq`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,10 @@
 - Improve `ToggleActions`.
   - Make `_phantom` field public and rename into `phantom`.
   - Add `ToggleActions::ENABLED` and `ToggleActions::DISABLED`.
-- Implement `Eq` for `Timing` and `InputMap`.
+
+### Usability
+
+- Implemented `Eq` for `Timing` and `InputMap`.
 
 ## Version 0.5
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 - Improve `ToggleActions`.
   - Make `_phantom` field public and rename into `phantom`.
   - Add `ToggleActions::ENABLED` and `ToggleActions::DISABLED`.
+- Implement `Eq` for `Timing` and `InputMap`.
 
 ## Version 0.5
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -548,7 +548,7 @@ pub struct ActionStateDriver<A: Actionlike> {
 ///
 /// This struct is principally used as a field on [`ActionData`],
 /// which itself lives inside an [`ActionState`].
-#[derive(Debug, Clone, PartialEq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub struct Timing {
     /// The [`Instant`] at which the button was pressed or released
     /// Recorded as the [`Time`](bevy::core::Time) at the start of the tick after the state last changed.

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -73,7 +73,7 @@ use std::marker::PhantomData;
 /// // Removal
 /// input_map.clear_action(Action::Hide);
 ///```
-#[derive(Component, Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Component, Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(default)]
 pub struct InputMap<A: Actionlike> {
     /// The raw vector of [PetitSet]s used to store the input mapping,


### PR DESCRIPTION
Clippy now emits warnings when you derive `PartialEq`, but not `Eq` when it is possible.
In the `cargo run -p ci` script, those warnings become errors.

This PR fixes these warnings and must be merged before #234 and #235.