### PR TITLE
Make `UserInput` generic over the maximum number of chord inputs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,13 @@
 ### Usability
 
 - Implemented `Eq` for `Timing` and `InputMap`.
+- `UserInput` is now generic over the maximum size of inputs for a `Chord` (the default is still `8`).
+  - If an iterator with too many inputs is passed to `UserInput::chord`, the rest of the inputs are now ignored instead of panicing.
+  - If you want to react to this case, the new `UserInput::try_make_chord` function returns a `Result` instead.
+
+### Breaking changes
+
+- `UserInput::chord` does not panic anymore if you provide an iterator with more inputs than the maximum allowed number. Instead, the rest of the elements are silently ignored.
 
 ## Version 0.5
 


### PR DESCRIPTION
Closes #21.

`UserInput` is now generic over the maximum number of inputs that fit in a chord. The default is still `8`.

Furthermore, `UserInput::chord` doesn't panic anymore if the iterator contains more elements than the maximum size; instead, the rest of the inputs are ignored (**breaking change**).

Additionally, a `UserInput::try_make_chord` function does the same thing, but returns a `Result` and fails when too many inputs were provided. Not sure if this is the best name for this function :P