### PR TITLE
Release inputs when InputMap is removed

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,6 +11,7 @@
 ### Usability
 
 - Implemented `Eq` for `Timing` and `InputMap`.
+- Held `ActionState` inputs will now be released when an `InputMap` is removed.
 
 ## Version 0.5
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -105,7 +105,8 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                     release_on_disable::<A>
                         .label(InputManagerSystem::ReleaseOnDisable)
                         .after(InputManagerSystem::Update),
-                );
+                )
+                .add_system_to_stage(CoreStage::PostUpdate, release_on_input_map_removed::<A>);
 
                 #[cfg(feature = "ui")]
                 app.add_system_to_stage(


### PR DESCRIPTION
Fixes #244

Adds a system that runs on PostUpdate that will release all inputs on an ActionState if a corresponding InputMap was removed.

Uses removal detection as described in https://bevy-cheatbook.github.io/programming/removal-detection.html 