### PR TITLE
Add negative_only and positive_only constructors to SingleAxis

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -101,6 +101,30 @@ impl SingleAxis {
             value: None,
         }
     }
+
+    /// Creates a [`SingleAxis`] with the `axis_type` and `negative_low` set to `threshold`.
+    ///
+    /// Positive values will not trigger the input.
+    pub fn negative_only(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
+        SingleAxis {
+            axis_type: axis_type.into(),
+            negative_low: threshold,
+            positive_low: f32::MAX,
+            value: None,
+        }
+    }
+
+    /// Creates a [`SingleAxis`] with the `axis_type` and `positive_low` set to `threshold`.
+    ///
+    /// Negative values will not trigger the input.
+    pub fn positive_only(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
+        SingleAxis {
+            axis_type: axis_type.into(),
+            negative_low: f32::MIN,
+            positive_low: threshold,
+            value: None,
+        }
+    }
 }
 
 impl PartialEq for SingleAxis {


### PR DESCRIPTION
I'm working on a game where movement occurs on a single axis, and the throttle is on/off. This works out great with the d-pad, but one player wanted to use a stick.

I found that I could us an a stick in the same way I am using buttons by doing this: 
```rust
input_map.insert_multiple([
    (
        SingleAxis {
            axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
            negative_low: -0.3,
            positive_low: f32::MAX,
            value: None,
        },
        Action::Left,
    ),
    (
        SingleAxis {
            axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
            negative_low: f32::MIN,
            positive_low: 0.3,
            value: None,
        },
        Action::Right,
    ),
]);
```
Which works great, but is pretty verbose. This PR adds a couple new constructors to `SingleAxis` and the result is this:
```rust
input_map.insert_multiple([
    (
        SingleAxis::negative_only(AxisType::Gamepad(GamepadAxisType::LeftStickX), -0.3),
        Action::Left,
    ),
    (
        SingleAxis::positive_only(AxisType::Gamepad(GamepadAxisType::LeftStickX), 0.3),
        Action::Right,
    ),
]);
```
Which seems a bit tidier.