### PR TITLE
Add direct support for modifier keys

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,6 +9,9 @@
   - Set cooldowns for actions using `Cooldowns::set(action, cooldown)` or `Cooldowns::new`.
   - Use `Cooldowns::ready` with `Cooldowns::trigger` as part of your action evaluation!
   - Cooldowns advance whenever `Cooldowns::tick` is called (this will happen automatically if you add the plugin).
+- Added the `Modifier` enum, to ergonomically capture the notion of "either control/alt/shift/windows key".
+  - The corresponding `InputKind::Modifier` variant was added to match.
+  - You can conveniently construct these using the `InputKind::modified` or `InputMap::insert_modified` methods.
 
 ### Usability
 

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -44,6 +44,7 @@ impl Display for InputKind {
             InputKind::MouseWheel(button) => write!(f, "{button:?}"),
             InputKind::MouseMotion(button) => write!(f, "{button:?}"),
             InputKind::Keyboard(button) => write!(f, "{button:?}"),
+            InputKind::Modifier(button) => write!(f, "{button:?}"),
         }
     }
 }

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -4,7 +4,7 @@ use crate::action_state::ActionData;
 use crate::buttonlike::ButtonState;
 use crate::clashing_inputs::ClashStrategy;
 use crate::input_streams::InputStreams;
-use crate::user_input::{InputKind, UserInput};
+use crate::user_input::{InputKind, Modifier, UserInput};
 use crate::Actionlike;
 
 use bevy::ecs::component::Component;

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -60,15 +60,11 @@ use std::marker::PhantomData;
 /// input_map.insert(MouseButton::Left, Action::Run)
 /// .insert(KeyCode::LShift, Action::Run)
 /// // Chords
-/// .insert_chord([KeyCode::LControl, KeyCode::R], Action::Run)
+/// .insert_modified(Modifier::Control, KeyCode::R, Action::Run)
 /// .insert_chord([InputKind::Keyboard(KeyCode::H),
 ///                InputKind::GamepadButton(GamepadButtonType::South),
 ///                InputKind::Mouse(MouseButton::Middle)],
-///            Action::Run)
-/// .insert_chord([InputKind::Keyboard(KeyCode::H),
-///                InputKind::GamepadButton(GamepadButtonType::South),
-///                InputKind::Mouse(MouseButton::Middle)],
-///            Action::Hide);
+///            Action::Run);
 ///
 /// // Removal
 /// input_map.clear_action(Action::Hide);
@@ -214,6 +210,8 @@ impl<A: Actionlike> InputMap<A> {
     /// Any iterator that can be converted into a [`Button`] can be supplied, but will be converted into a [`PetitSet`] for storage and use.
     /// Chords can also be added with the [insert](Self::insert) method, if the [`UserInput::Chord`] variant is constructed explicitly.
     ///
+    /// When working with keyboard modifier keys, consider using the `insert_modified` method instead.
+    ///
     /// # Panics
     ///
     /// Panics if the map is full and `buttons` is not a duplicate.
@@ -223,6 +221,19 @@ impl<A: Actionlike> InputMap<A> {
         action: A,
     ) -> &mut Self {
         self.insert(UserInput::chord(buttons), action);
+        self
+    }
+
+    /// Inserts a mapping between the simultaneous combination of the [`Modifier`] plus the `input` and the `action` provided.
+    ///
+    /// When working with keyboard modifiers, should be preferred over `insert_chord`.
+    pub fn insert_modified(
+        &mut self,
+        modifier: Modifier,
+        input: impl Into<InputKind>,
+        action: A,
+    ) -> &mut Self {
+        self.insert(UserInput::modified(modifier, input), action);
         self
     }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -317,9 +317,9 @@ impl<'a> InputStreams<'a> {
 
     /// Get the axis pair associated to the user input.
     ///
-    /// If `input` is not a [`DualAxis`] or [`VirtualDPad`], returns [`None`].
+    /// If `input` is not a [`DualAxis`](crate::axislike::DualAxis) or [`VirtualDPad`], returns [`None`].
     ///
-    /// See [`ActionState::action_axis_pair()`] for usage.
+    /// See [`ActionState::action_axis_pair()`](crate::action_state::ActionState) for usage.
     ///
     /// # Warning
     ///

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -487,3 +487,30 @@ impl<'a> From<&'a MutableInputStreams<'a>> for InputStreams<'a> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::MutableInputStreams;
+    use crate::prelude::MockInput;
+    use bevy::input::InputPlugin;
+    use bevy::prelude::*;
+
+    #[test]
+    fn modifier_key_triggered_by_either_input() {
+        use crate::user_input::Modifier;
+        let mut app = App::new();
+        app.add_plugin(InputPlugin);
+
+        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
+        assert!(!input_streams.pressed(Modifier::Control));
+
+        input_streams.send_input(KeyCode::LControl);
+        assert!(input_streams.pressed(Modifier::Control));
+
+        input_streams.reset_inputs();
+        assert!(!input_streams.pressed(Modifier::Control));
+
+        input_streams.send_input(KeyCode::RControl);
+        assert!(input_streams.pressed(Modifier::Control));
+    }
+}

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -140,6 +140,11 @@ impl<'a> InputStreams<'a> {
                 }
             }
             InputKind::Keyboard(keycode) => self.keycode.pressed(keycode),
+            InputKind::Modifier(modifier) => {
+                let key_codes = modifier.key_codes();
+                // Short circuiting is probably not worth the branch here
+                self.keycode.pressed(key_codes[0]) | self.keycode.pressed(key_codes[1])
+            }
             InputKind::Mouse(mouse_button) => self.mouse_button.pressed(mouse_button),
             InputKind::MouseWheel(mouse_wheel_direction) => {
                 let mut total_mouse_wheel_movement = 0.0;

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -505,12 +505,21 @@ mod tests {
         assert!(!input_streams.pressed(Modifier::Control));
 
         input_streams.send_input(KeyCode::LControl);
+        app.update();
+
+        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(input_streams.pressed(Modifier::Control));
 
         input_streams.reset_inputs();
+        app.update();
+
+        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(!input_streams.pressed(Modifier::Control));
 
         input_streams.send_input(KeyCode::RControl);
+        app.update();
+
+        let input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(input_streams.pressed(Modifier::Control));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub mod prelude {
     pub use crate::cooldown::{Cooldown, Cooldowns};
     pub use crate::input_map::InputMap;
     pub use crate::input_mocking::MockInput;
-    pub use crate::user_input::UserInput;
+    pub use crate::user_input::{Modifier, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -275,6 +275,12 @@ impl From<MouseMotionDirection> for UserInput {
     }
 }
 
+impl From<Modifier> for UserInput {
+    fn from(input: Modifier) -> Self {
+        UserInput::Single(InputKind::Modifier(input))
+    }
+}
+
 /// The different kinds of supported input bindings.
 ///
 /// See [`InputMode`] for the value-less equivalent. Commonly stored in the [`UserInput`] enum.
@@ -557,12 +563,16 @@ mod raw_input_tests {
 
         #[test]
         fn modifier_key_decomposes_into_both_inputs() {
-            todo!()
-        }
+            use crate::user_input::Modifier;
+            use bevy::input::keyboard::KeyCode;
 
-        #[test]
-        fn modifier_key_triggered_by_either_input() {
-            todo!()
+            let input = UserInput::modified(Modifier::Control, KeyCode::S);
+            let expected = RawInputs {
+                keycodes: vec![KeyCode::LControl, KeyCode::RControl, KeyCode::S],
+                ..Default::default()
+            };
+            let raw = input.raw_inputs();
+            assert_eq!(expected, raw);
         }
     }
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -28,7 +28,20 @@ pub enum UserInput {
 }
 
 impl UserInput {
-    /// Creates a [`UserInput::Chord`] from an iterator of [`InputKind`]s
+    /// Creates a [`UserInput::Chord`] from a [`Modifier`] and an `input` that can be converted into an [`InputKind`]
+    ///
+    /// When working with keyboard modifiers, should be preferred over manually specifying both the left and right variant.
+    pub fn modified(modifier: Modifier, input: impl Into<InputKind>) -> UserInput {
+        let modifier: InputKind = modifier.into();
+        let input: InputKind = input.into();
+        let mut set: PetitSet<InputKind, 8> = PetitSet::default();
+        set.push(modifier);
+        set.push(input);
+
+        UserInput::Chord(set)
+    }
+
+    /// Creates a [`UserInput::Chord`] from an iterator of inputs of the same type that can be converted into an [`InputKind`]s
     ///
     /// If `inputs` has a length of 1, a [`UserInput::Single`] variant will be returned instead.
     pub fn chord(inputs: impl IntoIterator<Item = impl Into<InputKind>>) -> Self {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -134,6 +134,10 @@ impl UserInput {
                     .push((single_axis.axis_type, single_axis.value)),
                 InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
                 InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
+                InputKind::Modifier(modifier) => {
+                    let key_codes = modifier.key_codes();
+                    raw_inputs.keycodes.push(key_codes[0]).push(key_codes[1]);
+                }
                 InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                 InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
                 InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
@@ -154,6 +158,10 @@ impl UserInput {
                             .push((single_axis.axis_type, single_axis.value)),
                         InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
                         InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
+                        InputKind::Modifier(modifier) => {
+                            let keycodes = modifier.key_codes();
+                            raw_inputs.keycodes.push(key_codes[0]).push(key_codes[1]);
+                        }
                         InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                         InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
                         InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
@@ -181,6 +189,10 @@ impl UserInput {
                             .push((single_axis.axis_type, single_axis.value)),
                         InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
                         InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
+                        InputKind::Modifier(modifier) => {
+                            let key_codes = modifier.key_codes();
+                            raw_input.key_codes.push(key_codes[0]).push(key_codes[1])
+                        }
                         InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                         InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
                         InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
@@ -266,6 +278,8 @@ pub enum InputKind {
     DualAxis(DualAxis),
     /// A button on a keyboard
     Keyboard(KeyCode),
+    /// A keyboard modifier, like `Ctrl` or `Alt`, which doesn't care about which side it's on.
+    Modifier(KeyboardModifier),
     /// A button on a mouse
     Mouse(MouseButton),
     /// A discretized mousewheel movement
@@ -313,6 +327,43 @@ impl From<MouseWheelDirection> for InputKind {
 impl From<MouseMotionDirection> for InputKind {
     fn from(input: MouseMotionDirection) -> Self {
         InputKind::MouseMotion(input)
+    }
+}
+
+impl From<Modifier> for InputKind {
+    fn from(input: Modifier) -> Self {
+        InputKind::Modifier(input)
+    }
+}
+
+/// A keyboard modifier that combines two [`KeyCode`] values into one representation.
+///
+/// This buttonlike input is stored in [`InputKind`], and will be triggered whenever either of these buttons are pressed.
+/// This will be decomposed into both values when converted into [`RawInputs`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Modifier {
+    /// Corresponds to [`KeyCode::LAlt`] and [`KeyCode::RAlt`].
+    Alt,
+    /// Corresponds to [`KeyCode::LControl`] and [`KeyCode::RControl`].
+    Control,
+    /// The key that makes letters capitalized, corresponding to [`KeyCode::LShift`] and [`KeyCode::RShift`]
+    Shift,
+    /// The OS or "Windows" key, corresponding to [`KeyCode::LWin`] and [`KeyCode::RWin`].
+    Win,
+}
+
+impl Modifier {
+    /// Returns the pair of [`KeyCode`] values associated with this modifier.
+    ///
+    /// The left variant will always be in the first position, and the right variant is always in the second position.
+    #[inline]
+    pub fn key_codes(self) -> [KeyCode; 2] {
+        match self {
+            Modifier::Alt => [KeyCode::LAlt, KeyCode::RAlt],
+            Modifier::Control => [KeyCode::LControl, KeyCode::RControl],
+            Modifier::Shift => [KeyCode::LShift, KeyCode::RShift],
+            Modifier::Win => [KeyCode::LWin, KeyCode::RWin],
+        }
     }
 }
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -35,8 +35,8 @@ impl UserInput {
         let modifier: InputKind = modifier.into();
         let input: InputKind = input.into();
         let mut set: PetitSet<InputKind, 8> = PetitSet::default();
-        set.push(modifier);
-        set.push(input);
+        set.insert(modifier);
+        set.insert(input);
 
         UserInput::Chord(set)
     }
@@ -149,7 +149,8 @@ impl UserInput {
                 InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
                 InputKind::Modifier(modifier) => {
                     let key_codes = modifier.key_codes();
-                    raw_inputs.keycodes.push(key_codes[0]).push(key_codes[1]);
+                    raw_inputs.keycodes.push(key_codes[0]);
+                    raw_inputs.keycodes.push(key_codes[1]);
                 }
                 InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                 InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
@@ -172,8 +173,9 @@ impl UserInput {
                         InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
                         InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
                         InputKind::Modifier(modifier) => {
-                            let keycodes = modifier.key_codes();
-                            raw_inputs.keycodes.push(key_codes[0]).push(key_codes[1]);
+                            let key_codes = modifier.key_codes();
+                            raw_inputs.keycodes.push(key_codes[0]);
+                            raw_inputs.keycodes.push(key_codes[1]);
                         }
                         InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                         InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
@@ -204,7 +206,8 @@ impl UserInput {
                         InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
                         InputKind::Modifier(modifier) => {
                             let key_codes = modifier.key_codes();
-                            raw_input.key_codes.push(key_codes[0]).push(key_codes[1])
+                            raw_inputs.keycodes.push(key_codes[0]);
+                            raw_inputs.keycodes.push(key_codes[1]);
                         }
                         InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
                         InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
@@ -292,7 +295,7 @@ pub enum InputKind {
     /// A button on a keyboard
     Keyboard(KeyCode),
     /// A keyboard modifier, like `Ctrl` or `Alt`, which doesn't care about which side it's on.
-    Modifier(KeyboardModifier),
+    Modifier(Modifier),
     /// A button on a mouse
     Mouse(MouseButton),
     /// A discretized mousewheel movement
@@ -353,7 +356,7 @@ impl From<Modifier> for InputKind {
 ///
 /// This buttonlike input is stored in [`InputKind`], and will be triggered whenever either of these buttons are pressed.
 /// This will be decomposed into both values when converted into [`RawInputs`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Modifier {
     /// Corresponds to [`KeyCode::LAlt`] and [`KeyCode::RAlt`].
     Alt,
@@ -550,6 +553,16 @@ mod raw_input_tests {
             let expected = RawInputs::from_keycode(button);
             let raw = UserInput::from(button).raw_inputs();
             assert_eq!(expected, raw);
+        }
+
+        #[test]
+        fn modifier_key_decomposes_into_both_inputs() {
+            todo!()
+        }
+
+        #[test]
+        fn modifier_key_triggered_by_either_input() {
+            todo!()
         }
     }
 


### PR DESCRIPTION
---
name: Pull request
about: Fix a bug, add a feature, improve some docs
title: ''
labels: "S: needs-triage"
assignees: ''
---

## What was the problem?

Specifying chords that involved modifier keys was tedious and error-prone, as keycodes are specific to either the left or right variant.

Fixes #211.

## How did you fix it?

Added the `Modifier` enum, which can be stored in an `InputKind` and maps to both the left and right variants of each modifier.

Several related helper methods have also been added.