### PR TITLE
Derive `Reflect` for `ActionState`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@
 
 - Added custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable.
 - Added `TypeUuid` for `InputMap` to be able use it as asset without wrapper
+- `ActionState` and its fields now implement `Reflect`. The type is automatically registered when the `InputManagerPlugin` is added.
 
 ## Version 0.7.1
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -5,6 +5,7 @@ use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 
 use bevy::ecs::{component::Component, entity::Entity};
 use bevy::prelude::Resource;
+use bevy::reflect::{FromReflect, Reflect};
 use bevy::utils::{Duration, Instant};
 use serde::{Deserialize, Serialize};
 use std::marker::PhantomData;
@@ -12,7 +13,7 @@ use std::marker::PhantomData;
 /// Metadata about an [`Actionlike`] action
 ///
 /// If a button is released, its `reasons_pressed` should be empty.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct ActionData {
     /// Is the action pressed or released?
     pub state: ButtonState,
@@ -80,12 +81,15 @@ pub struct ActionData {
 /// assert!(action_state.released(Action::Jump));
 /// assert!(!action_state.just_released(Action::Jump));
 /// ```
-#[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(
+    Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect, FromReflect,
+)]
 pub struct ActionState<A: Actionlike> {
     /// The [`ActionData`] of each action
     ///
     /// The position in this vector corresponds to [`Actionlike::index`].
     action_data: Vec<ActionData>,
+    #[reflect(ignore)]
     _phantom: PhantomData<A>,
 }
 
@@ -547,7 +551,7 @@ pub struct ActionStateDriver<A: Actionlike> {
 ///
 /// This struct is principally used as a field on [`ActionData`],
 /// which itself lives inside an [`ActionState`].
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct Timing {
     /// The [`Instant`] at which the button was pressed or released
     /// Recorded as the [`Time`](bevy::core::Time) at the start of the tick after the state last changed.

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -8,6 +8,7 @@ use bevy::input::{
     keyboard::KeyCode,
 };
 use bevy::math::Vec2;
+use bevy::reflect::{FromReflect, Reflect};
 use bevy::utils::FloatOrd;
 use serde::{Deserialize, Serialize};
 
@@ -484,7 +485,7 @@ pub struct AxisConversionError;
 ///
 /// This struct should store the processed form of your raw inputs in a device-agnostic fashion.
 /// Any deadzone correction, rescaling or drift-correction should be done at an earlier level.
-#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize, Reflect, FromReflect)]
 pub struct DualAxisData {
     xy: Vec2,
 }

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -1,12 +1,13 @@
 //! Tools for working with button-like user inputs (mouse clicks, gamepad button, keyboard inputs and so on)
 //!
+use bevy::reflect::{FromReflect, Reflect};
 use serde::{Deserialize, Serialize};
 
 /// The current state of a particular button,
 /// usually corresponding to a single [`Actionlike`] action.
 ///
 /// By default, buttons are [`ButtonState::Released`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum ButtonState {
     /// The button was pressed since the most recent tick
     JustPressed,

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,6 +1,7 @@
 //! Contains main plugin exported by this crate.
 
 use crate::clashing_inputs::ClashStrategy;
+use crate::prelude::ActionState;
 use crate::Actionlike;
 use core::hash::Hash;
 use core::marker::PhantomData;
@@ -144,8 +145,9 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
             }
         };
 
-        // Resources
-        app.init_resource::<ToggleActions<A>>()
+        app.register_type::<ActionState<A>>()
+            // Resources
+            .init_resource::<ToggleActions<A>>()
             .init_resource::<ClashStrategy>();
     }
 }


### PR DESCRIPTION
Makes it possible to inspect:

![image](https://user-images.githubusercontent.com/2620557/206831513-a1534feb-95e5-4ace-bf34-3d4f16ffd73b.png)

And also necessary for `ActionState` to be rolled back by bevy_ggrs.