### PR TITLE
Implement PressScheduler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ petitset = {version = "0.2.1", features = ["serde_compat"]}
 derive_more = {version = "0.99", default-features = false, features = ["display", "error"]}
 itertools = "0.10"
 serde = {version = "1.0", features = ["derive"]}
+fixedbitset  = "0.4.2"
 
 [dev-dependencies]
 bevy = {version = "0.9", default-features = false, features = ["bevy_asset", "bevy_sprite", "bevy_text", "bevy_ui", "bevy_render", "bevy_core_pipeline", "x11"]}

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,6 +7,7 @@
 - Added custom implementation of the `Serialize` and `Deserialize` traits for `InputMap` to make the format more human readable.
 - Added `TypeUuid` for `InputMap` to be able use it as asset without wrapper
 - `ActionState` and its fields now implement `Reflect`. The type is automatically registered when the `InputManagerPlugin` is added.
+- Added `PressScheduler`.
 
 ## Version 0.7.1
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,7 @@ pub mod input_mocking;
 pub mod input_streams;
 pub mod orientation;
 pub mod plugin;
+pub mod press_scheduler;
 pub mod systems;
 pub mod user_input;
 

--- a/src/press_scheduler.rs
+++ b/src/press_scheduler.rs
@@ -1,4 +1,9 @@
 //! This module contains [`PressScheduler`] and its supporting methods and impls.
+//!
+//! The [`PressScheduler`] is an optional addition to an [`InputManagerBundle`](crate::InputManagerBundle),
+//! which allows for a system that runs in [`CoreStage::Update`] later to correctly press an action.
+//! Directly using [`ActionState::press`] would not work, as inputs submitted late would be wiped out by the input manager systems.
+//! With this type, the action is pressed on the next time said systems run, making it so other systems can react to it correctly.
 
 use std::marker::PhantomData;
 

--- a/src/press_scheduler.rs
+++ b/src/press_scheduler.rs
@@ -1,0 +1,39 @@
+//! This module contains [`PressScheduler`] and its supporting methods and impls.
+
+use std::marker::PhantomData;
+
+use bevy::prelude::*;
+use fixedbitset::FixedBitSet;
+
+use crate::{prelude::ActionState, Actionlike};
+
+/// Allows for scheduling an action to be pressed for the next frame
+#[derive(Component, Resource)]
+pub struct PressScheduler<A: Actionlike> {
+    bitset: FixedBitSet,
+    _phantom: PhantomData<A>,
+}
+
+impl<A: Actionlike> Default for PressScheduler<A> {
+    fn default() -> Self {
+        Self {
+            bitset: FixedBitSet::with_capacity(A::N_VARIANTS),
+            _phantom: Default::default(),
+        }
+    }
+}
+
+impl<A: Actionlike> PressScheduler<A> {
+    /// Schedule a press for this action for the next frame
+    /// The action will be pressed the next time [`systems::`]
+    pub fn schedule_press(&mut self, action: A) {
+        self.bitset.set(action.index(), true);
+    }
+
+    /// Applies the scheduled presses to the given [`ActionState`]
+    pub fn apply(&mut self, action_state: &mut ActionState<A>) {
+        for i in self.bitset.ones() {
+            action_state.press(A::get_at(i).unwrap())
+        }
+    }
+}

--- a/src/press_scheduler.rs
+++ b/src/press_scheduler.rs
@@ -35,5 +35,6 @@ impl<A: Actionlike> PressScheduler<A> {
         for i in self.bitset.ones() {
             action_state.press(A::get_at(i).unwrap())
         }
+        self.bitset.clear();
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -71,7 +71,7 @@ pub fn update_action_state<A: Actionlike>(
     mouse_wheel: Option<Res<Events<MouseWheel>>>,
     mouse_motion: Res<Events<MouseMotion>>,
     clash_strategy: Res<ClashStrategy>,
-    // #[cfg(feature = "egui")] maybe_egui: Option<ResMut<EguiContext>>,
+    #[cfg(feature = "egui")] maybe_egui: Option<ResMut<EguiContext>>,
     action_state: Option<ResMut<ActionState<A>>>,
     input_map: Option<Res<InputMap<A>>>,
     press_scheduler: Option<ResMut<PressScheduler<A>>>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,6 +2,7 @@
 use bevy::ecs::query::ChangeTrackers;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
+use leafwing_input_manager::press_scheduler::PressScheduler;
 
 #[derive(Actionlike, Clone, Copy, Debug)]
 enum Action {
@@ -324,4 +325,44 @@ fn duration() {
         .world
         .resource::<ActionState<Action>>()
         .pressed(Action::PayRespects));
+}
+
+#[test]
+fn schedule_presses() {
+    use bevy::input::InputPlugin;
+
+    let mut app = App::new();
+
+    app.add_plugins(MinimalPlugins)
+        .add_plugin(InputPlugin)
+        .add_plugin(InputManagerPlugin::<Action>::default())
+        .init_resource::<ActionState<Action>>()
+        .insert_resource(InputMap::<Action>::new([(KeyCode::F, Action::PayRespects)]))
+        .init_resource::<PressScheduler<Action>>();
+
+    // Initializing
+    app.update();
+
+    // Press
+    app.world
+        .resource_mut::<PressScheduler<Action>>()
+        .schedule_press(Action::PayRespects);
+
+    assert!(app
+        .world
+        .resource::<ActionState<Action>>()
+        .released(Action::PayRespects));
+
+    // Check
+    app.update();
+    assert!(app
+        .world
+        .resource::<ActionState<Action>>()
+        .just_pressed(Action::PayRespects));
+
+    app.update();
+    assert!(app
+        .world
+        .resource::<ActionState<Action>>()
+        .just_released(Action::PayRespects));
 }


### PR DESCRIPTION
## What was the problem?

Introduce an easy way to trigger action presses from within the update loop (e.g. a UI implemented with egui)

## How did you fix it?

Implement the optional PressScheduler helper which lets users easily schedule presses that are realized on the next frame

## \[Optional\] What needs special attention?

I added some preliminary documentation, but I'm sure it could be improved.