### PR TITLE
Add InputKind information to ActionData

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -359,6 +359,9 @@ impl<A: Actionlike> InputMap<A> {
             if !inputs.is_empty() {
                 action_data[action.index()].state = ButtonState::JustPressed;
             }
+
+            // Clone the raw input data into the action_data. This is useful for inspecting what input originated a particular action if you have more than one input mapped to a single action.
+            action_data[action.index()].inputs = inputs.clone();
         }
 
         // Handle clashing inputs, possibly removing some pressed actions from the list

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -144,6 +144,42 @@ impl UserInput {
         }
     }
 
+    /// Whether the underlying InputKind(s) contain mouse input. This includes MouseButton, MouseMotion, and MouseWheel InputKinds. For UserInput Chords, this function returns true if any InputKinds in the chord involve mouse input.
+    pub fn contains_mouse_input(&self) -> bool {
+        match self {
+            UserInput::Single(ik) => {
+                ik.is_mouse_input()
+            },
+            UserInput::Chord(set) => {
+                set.iter().any(|ik| ik.is_mouse_input())
+            },
+            UserInput::VirtualDPad(VirtualDPad { up, down, left, right }) => {
+                [up, down, left, right].iter().any(|ik| ik.is_mouse_input())
+            },
+            UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
+                [negative, positive].iter().any(|ik| ik.is_mouse_input())
+            },
+        }
+    }
+
+    /// Whether the underlying InputKind(s) contain the specified InputKind. For UserInput Chords, this function returns true if any InputKinds in the chord involve the InputKind. VirtualDPad and VirtualAxis inputs also have their underlying InputKinds checked.
+    pub fn contains(&self, input_kind: InputKind) -> bool {
+        match self {
+            UserInput::Single(ik) => {
+                *ik == input_kind
+            },
+            UserInput::Chord(set) => {
+                set.iter().any(|ik| *ik == input_kind)
+            },
+            UserInput::VirtualDPad(VirtualDPad { up, down, left, right }) => {
+                [up, down, left, right].iter().any(|ik| **ik == input_kind)
+            },
+            UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
+                [negative, positive].iter().any(|ik| **ik == input_kind)
+            },
+        }
+    }
+
     /// Returns the raw inputs that make up this [`UserInput`]
     pub fn raw_inputs(&self) -> RawInputs {
         let mut raw_inputs = RawInputs::default();
@@ -358,6 +394,22 @@ pub enum InputKind {
     MouseWheel(MouseWheelDirection),
     /// A discretized mouse movement
     MouseMotion(MouseMotionDirection),
+}
+
+impl InputKind {
+    /// Returns true if this InputKind comes from a MouseButton, MouseWheel, or MouseMotion.
+    pub fn is_mouse_input(&self) -> bool {
+        match self {
+            InputKind::GamepadButton(_) =>  false,
+            InputKind::SingleAxis(_) =>     false,
+            InputKind::DualAxis(_) =>       false,
+            InputKind::Keyboard(_) =>       false,
+            InputKind::Modifier(_) =>       false,
+            InputKind::Mouse(_) =>          true,
+            InputKind::MouseWheel(_) =>     true,
+            InputKind::MouseMotion(_) =>    true,
+        }
+    }
 }
 
 impl From<DualAxis> for InputKind {


### PR DESCRIPTION
# What is the problem?
If an InputMap is configured to funnel actions from different sources (keyboard, mouse, controller) into singular Actions, information about the source of an Action is lost by the time you have a system that takes ActionState<Actionlike>. Under many circumstances this is fine, and as-intended, to maintain a clean input abstraction.

In my situation, I'm building a UI navigation library that supports switching between mouse-based UI control and gamepad- or keyboard-based UI control. I'm using leafwing-input-manager as a dependency, and I rely on querying ActionStates to receive events like moving the selection cursor, and confirming or cancelling the current selection or context.

Having some information about the InputKind(s) that triggered an Action is important because, for example, when the user switches from mouse control to gamepad control, the application has to activate a selection cursor and jump to a nearby UI element so the gamepad has something to manipulate. Since my application's entire input abstraction is leafwing-input-manager's ActionState, I want to be able to ask the ActionState for a given Actionlike (e.g. Confirm, or NavigateUp, or Cancel) what InputKind fired it, so I can ask: "Did this action involve mouse-based input?"

# What is the solution?

A quick solution is to add a field `inputs: Vec<UserInput>` to `ActionData`. It's just a copy of the inputs that were used to generate the Action in the first place. It's not intended to be a simple API; but it enables the user to still use the helpful ActionState abstraction everywhere without losing the ability to do more advanced logic later on in development.

To make answering the most useful questions ("is it mouse" / "does it have X InputKind") easier, I added `involved_mouse_input(action)` and `involved_input_kind(action, input_kind)` to `action_state.rs` by way of some additional methods in `user_input.rs`.

Downstream, consumer code can look like this:
```rust
pub fn my_system(query_input: Query<&ActionState<MenuInput>>) {
    // input = query_input.get() ...
    let is_mouse_click = input.involved_mouse_input(MenuInput::Confirm);
}
```
Or, consumers can get fancier by iterating over `input.action_data[action.index()].inputs`. For example, a game might want to detect a keyboard vs. a gamepad button press and display different tooltip button graphics.

## What are the drawbacks to this solution?

- `Vec<UserInput>` adds heap allocation to `ActionData` and could be seen as a sledgehammer-to-nail situation. Maybe we could use `PetitSet` or some other construction to keep the data more lightweight.
- Because `UserInput` doesn't implement Reflect/FromReflect, I had to annotate the field with `#[reflect(ignore)]` to get it to compile. However, I think that if this information *is OK* to be in ActionData, it should probably also support reflection; I'm assuming that reflection is required for a feature like artificial input playback, which should absolutely support methods like "involved_mouse_input()".
    - I'd be willing to look deeper into getting UserInput to have Reflect/FromReflect, but it looks like it might be a large change, so I wanted buy-in first.

## Are there alternative solutions?

- Alternative 1. Just use Bevy's raw Input system.
    - I first tried this and I realized it was not very feasible. You need to add a new very specific Input<MouseButton> SystemParam to each system that newly needs to ask "is it mouse". This is a headache for one thing, but it also adds another Input abstraction dependency to your systems, and you have to remember that those two dependencies (ActionState, Input<Mouse___>) are inter-related.
    - Using raw Bevy input prevents you from using a utility method to ask the question "was this a gamepad input of some kind?" and to ask that question of a System, you need to add up to four (4) SystemParams:
    ```
    raw_bevy_gamepads: Res<Gamepads>,
    raw_bevy_gamepad_button_inputs: Res<Input<GamepadButton>>,
    raw_bevy_gamepad_button_axes: Res<Axis<GamepadButton>>,
    raw_bevy_gamepad_axes: Res<Axis<GamepadAxis>>,
    ```
    - Using Bevy raw Input would break compatibility with artificial input.
- Alternative 2. Use some other SystemParam to get information about the InputKinds that caused an Actionlike to trigger.
    - I don't know if leafwing-input-manager provides an alternative means to get this information given just an Actionlike.
