### PR TITLE
Add `ActionState::consume_all()` to consume all actions.

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Usability
+
+- Added `ActionState::consume_all()` to consume all actions.
+
 ### Enhancements
 
 - The `Actionlike::N_VARIANTS` constant has been changed to a function.

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -401,6 +401,14 @@ impl<A: Actionlike> ActionState<A> {
         self.action_data[index].timing.flip();
     }
 
+    /// Consumes all actions
+    #[inline]
+    pub fn consume_all(&mut self) {
+        for action in A::variants() {
+            self.consume(action);
+        }
+    }
+
     /// Releases all actions
     pub fn release_all(&mut self) {
         for action in A::variants() {


### PR DESCRIPTION
## What was the problem?

Some state transitions (E.g. pause/unpause, menu transitions) need to nuke action states from orbit. It isn't enough to release them since, say, `just_pressed` might trigger if a UI and game action share a binding with a game action. Currently I manually consume actions if a binding to start/exit a menu conflicts with a game action, but this assumes a specific binding and doesn't allow for flexibility.

While disabling actions is also possible, it requires disabling/enabling multiple mappings at multiple transition points. I found it much easier to reason about clearing all action state on game pause/start/resume than ensuring that multiple UI menus manually disable and re-enable multiple action mappings.

## How did you fix it?

`ActionState::consume_all()` can be run at state transitions where action state should have a clean slate (I.e. transitioning from a menu to a game where bindings might be shared, crossing level boundaries where state changes might not correctly handle transitions, etc.)