### PR TITLE
Add Reflect and FromReflect to UserInput

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// # Warning
 ///
 /// `positive_low` must be greater than or equal to `negative_low` for this type to be validly constructed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct SingleAxis {
     /// The axis that is being checked.
     pub axis_type: AxisType,
@@ -163,7 +163,7 @@ impl std::hash::Hash for SingleAxis {
 /// # Warning
 ///
 /// `positive_low` must be greater than or equal to `negative_low` for both `x` and `y` for this type to be validly constructed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Reflect, FromReflect)]
 pub struct DualAxis {
     /// The axis representing horizontal movement.
     pub x: SingleAxis,
@@ -259,7 +259,7 @@ impl DualAxis {
 /// even though it can be stored as an [`InputKind`].
 ///
 /// Instead, use it directly as [`InputKind::DualAxis`]!
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct VirtualDPad {
     /// The input that represents the up direction in this virtual DPad
     pub up: InputKind,
@@ -347,7 +347,7 @@ impl VirtualDPad {
 /// even though it can be stored as an [`InputKind`].
 ///
 /// Instead, use it directly as [`InputKind::SingleAxis`]!
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub struct VirtualAxis {
     /// The input that represents the negative direction of this virtual axis
     pub negative: InputKind,
@@ -392,7 +392,7 @@ impl VirtualAxis {
 /// The type of axis used by a [`UserInput`](crate::user_input::UserInput).
 ///
 /// This is stored in either a [`SingleAxis`] or [`DualAxis`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum AxisType {
     /// Input associated with a gamepad, such as the triggers or one axis of an analog stick.
     Gamepad(GamepadAxisType),
@@ -405,7 +405,7 @@ pub enum AxisType {
 /// The direction of motion of the mouse wheel.
 ///
 /// Stored in the [`AxisType`] enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum MouseWheelAxisType {
     /// Horizontal movement.
     ///
@@ -420,7 +420,7 @@ pub enum MouseWheelAxisType {
 /// The direction of motion of the mouse.
 ///
 /// Stored in the [`AxisType`] enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum MouseMotionAxisType {
     /// Horizontal movement.
     X,

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -89,7 +89,7 @@ impl ButtonState {
 /// A buttonlike-input triggered by [`MouseWheel`](bevy::input::mouse::MouseWheel) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum MouseWheelDirection {
     /// Corresponds to `+y`
     Up,
@@ -104,7 +104,7 @@ pub enum MouseWheelDirection {
 /// A buttonlike-input triggered by [`MouseMotion`](bevy::input::mouse::MouseMotion) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum MouseMotionDirection {
     /// Corresponds to `+y`
     Up,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -10,7 +10,6 @@ use crate::Actionlike;
 
 use bevy::prelude::Resource;
 use itertools::Itertools;
-use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
 use std::marker::PhantomData;

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -2,6 +2,7 @@
 
 use crate::action_state::ActionData;
 use crate::axislike::{VirtualAxis, VirtualDPad};
+use crate::input_chord::InputChord;
 use crate::input_map::InputMap;
 use crate::input_streams::InputStreams;
 use crate::user_input::{InputKind, UserInput};
@@ -203,7 +204,7 @@ impl<A: Actionlike> Clash<A> {
 
 // Does the `button` clash with the `chord`?
 #[must_use]
-fn button_chord_clash(button: &InputKind, chord: &PetitSet<InputKind, 8>) -> bool {
+fn button_chord_clash(button: &InputKind, chord: &InputChord<8>) -> bool {
     if chord.len() <= 1 {
         return false;
     }
@@ -213,7 +214,7 @@ fn button_chord_clash(button: &InputKind, chord: &PetitSet<InputKind, 8>) -> boo
 
 // Does the `dpad` clash with the `chord`?
 #[must_use]
-fn dpad_chord_clash(dpad: &VirtualDPad, chord: &PetitSet<InputKind, 8>) -> bool {
+fn dpad_chord_clash(dpad: &VirtualDPad, chord: &InputChord<8>) -> bool {
     if chord.len() <= 1 {
         return false;
     }
@@ -266,7 +267,7 @@ fn virtual_axis_dpad_clash(axis: &VirtualAxis, dpad: &VirtualDPad) -> bool {
 }
 
 #[must_use]
-fn virtual_axis_chord_clash(axis: &VirtualAxis, chord: &PetitSet<InputKind, 8>) -> bool {
+fn virtual_axis_chord_clash(axis: &VirtualAxis, chord: &InputChord<8>) -> bool {
     if chord.len() <= 1 {
         return false;
     }
@@ -284,7 +285,7 @@ fn virtual_axis_virtual_axis_clash(axis1: &VirtualAxis, axis2: &VirtualAxis) -> 
 
 /// Does the `chord_a` clash with `chord_b`?
 #[must_use]
-fn chord_chord_clash(chord_a: &PetitSet<InputKind, 8>, chord_b: &PetitSet<InputKind, 8>) -> bool {
+fn chord_chord_clash(chord_a: &InputChord<8>, chord_b: &InputChord<8>) -> bool {
     if chord_a.len() <= 1 || chord_b.len() <= 1 {
         return false;
     }

--- a/src/input_chord.rs
+++ b/src/input_chord.rs
@@ -8,31 +8,28 @@ use serde::{Deserialize, Serialize};
 
 use crate::user_input::InputKind;
 
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
-pub struct InputChord<const CAP: usize>(pub PetitSet<InputKind, CAP>);
-
-/// The `Ok` result of a successful [`InputChord`] insertion operation
+/// The result of a successful [`InputChord`] insertion operatio.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
-pub enum SuccesfulSetInsertion {
-    /// This is a newly inserted [`InputKind`] stored at the provided index
-    NovelElenent(usize),
+pub enum SuccessfulChordInsertion {
+    /// A newly inserted [`InputKind`] stored at the contained index.
+    Novel(usize),
 
-    /// This [`InputKind`] was already in the set: it is stored at the provided index
-    ExtantElement(usize),
+    /// An [`InputKind`] that was already in the chord at the contained index.
+    Extant(usize),
 }
 
-impl From<petitset::SuccesfulSetInsertion> for SuccesfulSetInsertion {
+impl From<petitset::SuccesfulSetInsertion> for SuccessfulChordInsertion {
     fn from(value: petitset::SuccesfulSetInsertion) -> Self {
         match value {
-            petitset::SuccesfulSetInsertion::NovelElenent(index) => Self::NovelElenent(index),
-            petitset::SuccesfulSetInsertion::ExtantElement(index) => Self::ExtantElement(index),
+            petitset::SuccesfulSetInsertion::NovelElenent(index) => Self::Novel(index),
+            petitset::SuccesfulSetInsertion::ExtantElement(index) => Self::Extant(index),
         }
     }
 }
 
 /// An error returned when attempting to insert into a full [`InputChord`].
 ///
-/// It contains the element that could not be inserted.
+/// It contains the [`InputKind`] that could not be inserted.
 #[derive(PartialEq, Eq, Clone, Copy)]
 pub struct CapacityError(pub InputKind);
 
@@ -54,91 +51,154 @@ impl From<petitset::CapacityError<InputKind>> for CapacityError {
     }
 }
 
+/// Represents a combination of [`InputKind`], representing a singular action
+/// when activated simultaneously.
+#[derive(Debug, Default, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct InputChord<const CAP: usize>(pub PetitSet<InputKind, CAP>);
+
 impl<const CAP: usize> InputChord<CAP> {
+    /// The current number of inputs in the chord.
     pub fn len(&self) -> usize {
         self.0.len()
     }
 
+    /// The capacity of the [`InputChord`].
     pub fn capacity(&self) -> usize {
         self.0.capacity()
     }
 
-    pub fn contains(&self, element: &InputKind) -> bool {
-        self.0.contains(element)
+    /// Whether or not the chord contains the input.
+    pub fn contains(&self, kind: &InputKind) -> bool {
+        self.0.contains(kind)
     }
 
+    /// Returns an iterator over the inputs in the chord.
     pub fn iter(&self) -> impl Iterator<Item = &InputKind> {
         self.0.iter()
     }
 
+    /// Whether or not the chord is a subset of another chord.
     pub fn is_subset<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
         self.0.is_subset(&other.0)
     }
 
+    /// Whether or not the chord is a superset of another chord.
     pub fn is_superset<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
         self.0.is_superset(&other.0)
     }
 
+    /// Whether or not the two chords contain common inputs.
     pub fn is_disjoint<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
         self.0.is_disjoint(&other.0)
     }
 
+    /// Whether or not the chord contains *no* inputs.
     pub fn is_empty(&self) -> bool {
         self.0.is_empty()
     }
 
+    /// Whether or not the chord is full.
     pub fn is_full(&self) -> bool {
         self.0.is_full()
     }
 
+    /// Gets the [`InputKind`] at a given index in the [`InputChord`].
     pub fn get_at(&self, index: usize) -> Option<&InputKind> {
         self.0.get_at(index)
     }
 
+    /// Mutably gets the [`InputKind`] at a given index in the [`InputChord`].
     pub fn get_at_mut(&mut self, index: usize) -> Option<&mut InputKind> {
         self.0.get_at_mut(index)
     }
 
+    /// Clears the chord of all inputs.
     pub fn clear(&mut self) {
         self.0.clear()
     }
 
-    pub fn remove(&mut self, element: &InputKind) -> Option<usize> {
-        self.0.remove(element)
+    /// Removes the [`InputKind`] at a given index in the [`InputChord`] and returns it, if one exists.
+    pub fn remove(&mut self, kind: &InputKind) -> Option<usize> {
+        self.0.remove(kind)
     }
 
+    /// Removes the [`InputKind`] at a given index in the [`InputChord`] and returns whether or not one existed.
     pub fn remove_at(&mut self, index: usize) -> bool {
         self.0.remove_at(index)
     }
 
-    pub fn take(&mut self, element: &InputKind) -> Option<(usize, InputKind)> {
-        self.0.take(element)
+    /// Removes the [`InputKind`] in the [`InputChord`] if it exists.
+    /// If it existed, this returns both the removed [`InputKind`] and the index it
+    /// was removed from.
+    pub fn take(&mut self, kind: &InputKind) -> Option<(usize, InputKind)> {
+        self.0.take(kind)
     }
 
+    /// Removes the [`InputKind`] in the [`InputChord`] at a given index, if it exists.
+    /// If it existed, this returns the removed [`InputKind`].
     pub fn take_at(&mut self, index: usize) -> Option<InputKind> {
         self.0.take_at(index)
     }
 
+    /// Whether or not the chord is identical in both inputs and input order.
     pub fn identical(&self, other: Self) -> bool {
         self.0.identical(other.0)
     }
 
-    pub fn insert(&mut self, element: InputKind) -> SuccesfulSetInsertion {
-        self.0.insert(element).into()
+    /// Insert a new [`InputKind`] to the chord in the first available slot.
+    ///
+    /// Returns a [`SuccessfulChordInsertion`], containing both the index at
+    /// which the [`InputKind`] is stored and whether it was already present.
+    ///
+    /// # Panics
+    /// Panics if the chord is full and the [`InputKind`] is not a duplicate.
+    pub fn insert(&mut self, kind: InputKind) -> SuccessfulChordInsertion {
+        self.0.insert(kind).into()
     }
 
+    /// Attempt to insert a new [`InputKind`] to the chord in the first available slot.
+    ///
+    /// Inserts the [`InputKind`] if able, then returns either a [`SuccesfulSetInsertion`]
+    /// upon success or a [`CapacityError`] upon error.
     pub fn try_insert(
         &mut self,
-        element: InputKind,
-    ) -> Result<SuccesfulSetInsertion, CapacityError> {
-        match self.0.try_insert(element) {
+        kind: InputKind,
+    ) -> Result<SuccessfulChordInsertion, CapacityError> {
+        match self.0.try_insert(kind) {
             Ok(success) => Ok(success.into()),
             Err(error) => Err(error.into()),
         }
     }
 
-    pub fn insert_at(&mut self, element: InputKind, index: usize) -> Option<InputKind> {
-        self.0.insert_at(element, index)
+    /// Insert a new [`InputKind`] to the chord at the given index.
+    ///
+    /// If a matching [`InputKind`] already existed in the chord, it will be moved to the supplied index.
+    /// Any [`InputKind`] that was previously there will be moved to the matching [`InputKind`]'s original index.
+    ///
+    /// Returns `Some(T)` of any [`InputKind`] removed by this operation.
+    ///
+    /// # Panics
+    /// Panics if the given index is larger than CAP.
+    pub fn insert_at(&mut self, kind: InputKind, index: usize) -> Option<InputKind> {
+        self.0.insert_at(kind, index)
+    }
+
+    /// Constructs a new chord by consuming [`InputKind`] values from an iterator.
+    ///
+    /// The consumed values will be stored in order, with duplicate [`InputKind`] discarded.
+    ///
+    /// Returns an error if the iterator produces more than `CAP` distinct [`InputKind`].
+    /// The returned error will include the [`InputKind`] that could not be inserted.
+    pub fn try_from_iter<I: IntoIterator<Item = InputKind>>(
+        input_iter: I,
+    ) -> Result<Self, CapacityError> {
+        let try_set = PetitSet::try_from_iter(input_iter);
+
+        match try_set {
+            Ok(set) => Ok(Self(set)),
+            Err(error) => Err(CapacityError(error.0 .1)),
+        }
     }
 }
 
@@ -267,5 +327,47 @@ impl<const CAP: usize> GetTypeRegistration for InputChord<CAP> {
         let mut registration = TypeRegistration::of::<InputChord<CAP>>();
         registration.insert::<ReflectFromPtr>(FromType::<InputChord<CAP>>::from_type());
         registration
+    }
+}
+
+impl<const CAP: usize> FromIterator<InputKind> for InputChord<CAP> {
+    /// Panics if the iterator contains more than `CAP` distinct [`InputKind`]s.
+    fn from_iter<I: IntoIterator<Item = InputKind>>(iter: I) -> Self {
+        Self(PetitSet::try_from_iter(iter).unwrap())
+    }
+}
+
+impl<const CAP: usize> IntoIterator for InputChord<CAP> {
+    type Item = InputKind;
+    type IntoIter = InputChordIter<CAP>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        InputChordIter {
+            chord: self,
+            cursor: 0,
+        }
+    }
+}
+
+/// An [`Iterator`] struct for [`InputChord`].
+#[derive(Clone, Debug)]
+pub struct InputChordIter<const CAP: usize> {
+    pub(crate) chord: InputChord<CAP>,
+    cursor: usize,
+}
+
+impl<const CAP: usize> Iterator for InputChordIter<CAP> {
+    type Item = InputKind;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(index) = self.chord.0.next_filled_index(self.cursor) {
+            self.cursor = index + 1;
+            let result = self.chord.take_at(index);
+            debug_assert!(result.is_some());
+            result
+        } else {
+            self.cursor = CAP;
+            None
+        }
     }
 }

--- a/src/input_chord.rs
+++ b/src/input_chord.rs
@@ -1,0 +1,271 @@
+use bevy::reflect::{
+    array_apply, utility::GenericTypeInfoCell, Array, ArrayInfo, ArrayIter, FromReflect, FromType,
+    GetTypeRegistration, Reflect, ReflectFromPtr, ReflectMut, ReflectOwned, ReflectRef,
+    TypeRegistration, Typed,
+};
+use petitset::PetitSet;
+use serde::{Deserialize, Serialize};
+
+use crate::user_input::InputKind;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct InputChord<const CAP: usize>(pub PetitSet<InputKind, CAP>);
+
+/// The `Ok` result of a successful [`InputChord`] insertion operation
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+pub enum SuccesfulSetInsertion {
+    /// This is a newly inserted [`InputKind`] stored at the provided index
+    NovelElenent(usize),
+
+    /// This [`InputKind`] was already in the set: it is stored at the provided index
+    ExtantElement(usize),
+}
+
+impl From<petitset::SuccesfulSetInsertion> for SuccesfulSetInsertion {
+    fn from(value: petitset::SuccesfulSetInsertion) -> Self {
+        match value {
+            petitset::SuccesfulSetInsertion::NovelElenent(index) => Self::NovelElenent(index),
+            petitset::SuccesfulSetInsertion::ExtantElement(index) => Self::ExtantElement(index),
+        }
+    }
+}
+
+/// An error returned when attempting to insert into a full [`InputChord`].
+///
+/// It contains the element that could not be inserted.
+#[derive(PartialEq, Eq, Clone, Copy)]
+pub struct CapacityError(pub InputKind);
+
+impl core::fmt::Debug for CapacityError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("A `InputChord` has overflowed.").finish()
+    }
+}
+
+impl core::fmt::Display for CapacityError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        core::fmt::Debug::fmt(self, f)
+    }
+}
+
+impl From<petitset::CapacityError<InputKind>> for CapacityError {
+    fn from(value: petitset::CapacityError<InputKind>) -> Self {
+        Self(value.0)
+    }
+}
+
+impl<const CAP: usize> InputChord<CAP> {
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.0.capacity()
+    }
+
+    pub fn contains(&self, element: &InputKind) -> bool {
+        self.0.contains(element)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &InputKind> {
+        self.0.iter()
+    }
+
+    pub fn is_subset<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
+        self.0.is_subset(&other.0)
+    }
+
+    pub fn is_superset<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
+        self.0.is_superset(&other.0)
+    }
+
+    pub fn is_disjoint<const OTHER_CAP: usize>(&self, other: &InputChord<OTHER_CAP>) -> bool {
+        self.0.is_disjoint(&other.0)
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    pub fn is_full(&self) -> bool {
+        self.0.is_full()
+    }
+
+    pub fn get_at(&self, index: usize) -> Option<&InputKind> {
+        self.0.get_at(index)
+    }
+
+    pub fn get_at_mut(&mut self, index: usize) -> Option<&mut InputKind> {
+        self.0.get_at_mut(index)
+    }
+
+    pub fn clear(&mut self) {
+        self.0.clear()
+    }
+
+    pub fn remove(&mut self, element: &InputKind) -> Option<usize> {
+        self.0.remove(element)
+    }
+
+    pub fn remove_at(&mut self, index: usize) -> bool {
+        self.0.remove_at(index)
+    }
+
+    pub fn take(&mut self, element: &InputKind) -> Option<(usize, InputKind)> {
+        self.0.take(element)
+    }
+
+    pub fn take_at(&mut self, index: usize) -> Option<InputKind> {
+        self.0.take_at(index)
+    }
+
+    pub fn identical(&self, other: Self) -> bool {
+        self.0.identical(other.0)
+    }
+
+    pub fn insert(&mut self, element: InputKind) -> SuccesfulSetInsertion {
+        self.0.insert(element).into()
+    }
+
+    pub fn try_insert(
+        &mut self,
+        element: InputKind,
+    ) -> Result<SuccesfulSetInsertion, CapacityError> {
+        match self.0.try_insert(element) {
+            Ok(success) => Ok(success.into()),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub fn insert_at(&mut self, element: InputKind, index: usize) -> Option<InputKind> {
+        self.0.insert_at(element, index)
+    }
+}
+
+impl<const CAP: usize> From<PetitSet<InputKind, CAP>> for InputChord<CAP> {
+    fn from(value: PetitSet<InputKind, CAP>) -> Self {
+        Self(value)
+    }
+}
+
+impl<const CAP: usize> Typed for InputChord<CAP> {
+    fn type_info() -> &'static bevy::reflect::TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+
+        CELL.get_or_insert::<Self, _>(|| {
+            bevy::reflect::TypeInfo::Array(ArrayInfo::new::<Self, InputKind>(CAP))
+        })
+    }
+}
+
+impl<const CAP: usize> Array for InputChord<CAP> {
+    fn get(&self, index: usize) -> Option<&dyn Reflect> {
+        self.0
+            .get_at(index)
+            .map(|input_kind| input_kind as &dyn Reflect)
+    }
+
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        self.0
+            .get_at_mut(index)
+            .map(|input_kind| input_kind as &mut dyn Reflect)
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn iter(&self) -> bevy::reflect::ArrayIter {
+        ArrayIter::new(self)
+    }
+
+    fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
+        self.0
+            .into_iter()
+            .map(|value| Box::new(value) as Box<dyn Reflect>)
+            .collect()
+    }
+}
+
+impl<const CAP: usize> Reflect for InputChord<CAP> {
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_type_info(&self) -> &'static bevy::reflect::TypeInfo {
+        <Self as Typed>::type_info()
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        array_apply(self, value)
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> bevy::reflect::ReflectRef {
+        ReflectRef::Array(self)
+    }
+
+    fn reflect_mut(&mut self) -> bevy::reflect::ReflectMut {
+        ReflectMut::Array(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> bevy::reflect::ReflectOwned {
+        ReflectOwned::Array(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+}
+
+impl<const CAP: usize> FromReflect for InputChord<CAP> {
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        if let ReflectRef::Array(ref_array) = reflect.reflect_ref() {
+            let mut new_petitset = PetitSet::new();
+
+            for (index, field) in ref_array.iter().enumerate() {
+                new_petitset.insert_at(<InputKind>::from_reflect(field)?, index);
+            }
+
+            Some(InputChord(new_petitset))
+        } else {
+            None
+        }
+    }
+}
+
+impl<const CAP: usize> GetTypeRegistration for InputChord<CAP> {
+    fn get_type_registration() -> bevy::reflect::TypeRegistration {
+        let mut registration = TypeRegistration::of::<InputChord<CAP>>();
+        registration.insert::<ReflectFromPtr>(FromType::<InputChord<CAP>>::from_type());
+        registration
+    }
+}

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -11,12 +11,15 @@ use petitset::PetitSet;
 use bevy::ecs::prelude::{Events, ResMut, World};
 use bevy::ecs::system::SystemState;
 
-use crate::axislike::{
-    AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis, VirtualAxis,
-    VirtualDPad,
-};
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::user_input::{InputKind, UserInput};
+use crate::{
+    axislike::{
+        AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis, VirtualAxis,
+        VirtualDPad,
+    },
+    input_chord::InputChord,
+};
 
 /// A collection of [`Input`] structs, which can be used to update an [`InputMap`](crate::input_map::InputMap).
 ///
@@ -224,7 +227,7 @@ impl<'a> InputStreams<'a> {
 
     /// Are all of the `buttons` pressed?
     #[must_use]
-    pub fn all_buttons_pressed(&self, buttons: &PetitSet<InputKind, 8>) -> bool {
+    pub fn all_buttons_pressed(&self, buttons: &InputChord<8>) -> bool {
         for &button in buttons.iter() {
             // If any of the appropriate inputs failed to match, the action is considered pressed
             if !self.button_pressed(button) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod common_conditions;
 mod display_impl;
 pub mod dynamic_action;
 pub mod errors;
+mod input_chord;
 pub mod input_map;
 pub mod input_mocking;
 pub mod input_streams;

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -5,7 +5,6 @@ use bevy::input::{gamepad::GamepadButtonType, keyboard::KeyCode, mouse::MouseBut
 use bevy::prelude::ScanCode;
 use bevy::reflect::{FromReflect, Reflect};
 use bevy::utils::HashSet;
-use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
 use crate::axislike::VirtualAxis;
@@ -43,11 +42,11 @@ impl UserInput {
     pub fn modified(modifier: Modifier, input: impl Into<InputKind>) -> UserInput {
         let modifier: InputKind = modifier.into();
         let input: InputKind = input.into();
-        let mut set: PetitSet<InputKind, 8> = PetitSet::default();
-        set.insert(modifier);
-        set.insert(input);
+        let mut chord: InputChord<8> = InputChord::default();
+        chord.insert(modifier);
+        chord.insert(input);
 
-        UserInput::Chord(set.into())
+        UserInput::Chord(chord)
     }
 
     /// Creates a [`UserInput::Chord`] from an iterator of inputs of the same type that can be converted into an [`InputKind`]s
@@ -57,15 +56,15 @@ impl UserInput {
         // We can't just check the length unless we add an ExactSizeIterator bound :(
         let mut length: u8 = 0;
 
-        let mut set: PetitSet<InputKind, 8> = PetitSet::default();
+        let mut chord: InputChord<8> = InputChord::default();
         for button in inputs {
             length += 1;
-            set.insert(button.into());
+            chord.insert(button.into());
         }
 
         match length {
-            1 => UserInput::Single(set.into_iter().next().unwrap()),
-            _ => UserInput::Chord(set.into()),
+            1 => UserInput::Single(chord.into_iter().next().unwrap()),
+            _ => UserInput::Chord(chord),
         }
     }
 
@@ -77,7 +76,7 @@ impl UserInput {
     pub fn len(&self) -> usize {
         match self {
             UserInput::Single(_) => 1,
-            UserInput::Chord(button_set) => button_set.len(),
+            UserInput::Chord(chord) => chord.len(),
             UserInput::VirtualDPad { .. } => 1,
             UserInput::VirtualAxis { .. } => 1,
         }

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -3,16 +3,20 @@
 use bevy::input::{gamepad::GamepadButtonType, keyboard::KeyCode, mouse::MouseButton};
 
 use bevy::prelude::ScanCode;
+use bevy::reflect::{FromReflect, Reflect};
 use bevy::utils::HashSet;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
 use crate::axislike::VirtualAxis;
+use crate::input_chord::InputChord;
 use crate::scan_codes::QwertyScanCode;
 use crate::{
     axislike::{AxisType, DualAxis, SingleAxis, VirtualDPad},
     buttonlike::{MouseMotionDirection, MouseWheelDirection},
 };
+
+pub use crate::input_chord::*;
 
 /// Some combination of user input, which may cross [`Input`]-mode boundaries
 ///
@@ -25,7 +29,7 @@ pub enum UserInput {
     ///
     /// Up to 8 (!!) buttons can be chorded together at once.
     /// Chords are considered to belong to all of the [InputMode]s of their constituent buttons.
-    Chord(PetitSet<InputKind, 8>),
+    Chord(InputChord<8>),
     /// A virtual DPad that you can get an [`AxisPair`] from
     VirtualDPad(VirtualDPad),
     /// A virtual axis that you can get a [`SingleAxis`] from
@@ -43,7 +47,7 @@ impl UserInput {
         set.insert(modifier);
         set.insert(input);
 
-        UserInput::Chord(set)
+        UserInput::Chord(set.into())
     }
 
     /// Creates a [`UserInput::Chord`] from an iterator of inputs of the same type that can be converted into an [`InputKind`]s
@@ -61,7 +65,7 @@ impl UserInput {
 
         match length {
             1 => UserInput::Single(set.into_iter().next().unwrap()),
-            _ => UserInput::Chord(set),
+            _ => UserInput::Chord(set.into()),
         }
     }
 
@@ -358,7 +362,7 @@ impl From<Modifier> for UserInput {
 ///
 /// Please contact the maintainers if you need support for another type!
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum InputKind {
     /// A button on a gamepad
     GamepadButton(GamepadButtonType),
@@ -452,7 +456,7 @@ impl From<Modifier> for InputKind {
 ///
 /// This buttonlike input is stored in [`InputKind`], and will be triggered whenever either of these buttons are pressed.
 /// This will be decomposed into both values when converted into [`RawInputs`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect)]
 pub enum Modifier {
     /// Corresponds to [`KeyCode::LAlt`] and [`KeyCode::RAlt`].
     Alt,


### PR DESCRIPTION
Related to the contributing guidelines: I note that the `dev` branch is _very_ stale and I couldn't find any recent PRs against it, so I made this against `main`. I can adjust this if necessary.

## General

This PR adds `Reflect` and `FromReflect` to `UserInput` via adding it to the entire chain of types under its variants that also needed them. It was mentioned in a few places that this was desired, notably in https://github.com/Leafwing-Studios/leafwing-input-manager/pull/308, and I also would like to see this. (It kinda feels like any type that is intended to be a bevy component should have them by default and _not having_ them be opt-out, but I digress.)

## PetitSet ...

The big hang up here was that `PetitSet` does not implement either of said traits. I naively newtype-d it and delegated a majority of its features, but I would imagine there could be a need to have more careful thought put into this. It currently is just a poor veneer over `PetitSet`

`PetitSet` is currently exposed as API surface in a couple of places; so, this is kind of a big change. I can imagine a world where its not, though, and that the functionality of an input chord is much more pared down, or perhaps looks entirely different than a front for `PetitSet`, and this would perhaps force that thought into the light earlier than expected.

A perhaps less obtrusive approach would be to only do this behind the scenes and maintain `PetitSet` as the forward API. You all own both crates so I defer all decisions!

Last thing on the newtype: it's added to a separate module, but reexported through `user_input`-- this was entirely a "idk lmao" decision.