### PR TITLE
Switch destructured tuple names to match insert signature

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -235,8 +235,8 @@ impl<A: Actionlike> InputMap<A> {
         &mut self,
         input_action_pairs: impl IntoIterator<Item = (impl Into<UserInput>, A)>,
     ) -> &mut Self {
-        for (action, input) in input_action_pairs {
-            self.insert(action, input);
+        for (input, action) in input_action_pairs {
+            self.insert(input, action);
         }
 
         self


### PR DESCRIPTION
This has no functional change, but just switches the names of the destructured tuple values so that when the are passed to `insert` that they match function signature. 