### PR TITLE
Mouse Position Example and Multiple Targets for Action State Driver

### DIFF
--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -67,7 +67,7 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
         // This component links the button to the entity with the `ActionState` component
         .insert(ActionStateDriver {
             action: Action::Left,
-            entity: player_entity,
+            targets: player_entity.into(),
         })
         .id();
 
@@ -83,7 +83,7 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
         })
         .insert(ActionStateDriver {
             action: Action::Right,
-            entity: player_entity,
+            targets: player_entity.into(),
         })
         .id();
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -6,8 +6,10 @@ use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 use bevy::ecs::{component::Component, entity::Entity};
 use bevy::prelude::Resource;
 use bevy::reflect::{FromReflect, Reflect};
-use bevy::utils::{Duration, Instant};
+use bevy::utils::hashbrown::hash_set::Iter;
+use bevy::utils::{Duration, HashSet, Instant};
 use serde::{Deserialize, Serialize};
+use std::iter::Once;
 use std::marker::PhantomData;
 
 /// Metadata about an [`Actionlike`] action
@@ -537,7 +539,7 @@ impl<A: Actionlike> Default for ActionState<A> {
 ///     // This component links the button to the entity with the `ActionState` component
 ///     .insert(ActionStateDriver {
 ///         action: DanceDance::Left,
-///         entity: dance_tracker,
+///         targets: dance_tracker.into(),
 ///     });
 ///```
 ///
@@ -545,12 +547,132 @@ impl<A: Actionlike> Default for ActionState<A> {
 /// although this should be reserved for cases where the entity whose value you want to check
 /// is distinct from the entity whose [`ActionState`] you want to set.
 /// Check the source code of [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction) for an example of how this is done.
-#[derive(Component, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Component, Clone, PartialEq, Eq)]
 pub struct ActionStateDriver<A: Actionlike> {
     /// The action triggered by this entity
     pub action: A,
     /// The entity whose action state should be updated
-    pub entity: Entity,
+    pub targets: ActionStateDriverTarget,
+}
+
+/// Represents the entities that an ``ActionStateDriver`` targets.
+#[derive(Component, Clone, PartialEq, Eq)]
+pub enum ActionStateDriverTarget {
+    /// No targets
+    None,
+    /// Single target
+    Single(Entity),
+    /// Multiple targets
+    Multi(HashSet<Entity>),
+}
+
+impl ActionStateDriverTarget {
+    /// Get an iterator for the entities targeted.
+    #[inline(always)]
+    pub fn iter(&self) -> impl Iterator<Item = &Entity> {
+        match self {
+            Self::None => ActionStateDriverTargetIterator::None,
+            Self::Single(entity) => {
+                ActionStateDriverTargetIterator::Single(std::iter::once(entity))
+            }
+            Self::Multi(entities) => ActionStateDriverTargetIterator::Multi(entities.iter()),
+        }
+    }
+
+    /// Insert an entity as a target.
+    #[inline(always)]
+    pub fn insert(&mut self, entity: Entity) {
+        *self = std::mem::replace(self, Self::None).with(entity);
+    }
+
+    /// Remove an entity as a target if it's in the target set.
+    #[inline(always)]
+    pub fn remove(&mut self, entity: Entity) {
+        *self = std::mem::replace(self, Self::None).without(entity);
+    }
+
+    /// Add an entity as a target.
+    #[inline(always)]
+    pub fn add(&mut self, entities: impl Iterator<Item = Entity>) {
+        for entity in entities {
+            self.insert(entity)
+        }
+    }
+
+    /// Get the number of targets.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Single(_) => 1,
+            Self::Multi(targets) => targets.len(),
+        }
+    }
+
+    /// Returns true if there are no targets.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Add an entity as a target using a builder style pattern.
+    #[inline(always)]
+    pub fn with(mut self, entity: Entity) -> Self {
+        match self {
+            Self::None => Self::Single(entity),
+            Self::Single(og) => Self::Multi(HashSet::from([og, entity])),
+            Self::Multi(ref mut targets) => {
+                targets.insert(entity);
+                self
+            }
+        }
+    }
+
+    /// Remove an entity as a target if it's in the set using a builder style pattern.
+    pub fn without(mut self, entity: Entity) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Single(_) => Self::None,
+            Self::Multi(ref mut targets) => {
+                targets.remove(&entity);
+                match targets.len() {
+                    0 => Self::None,
+                    1 => Self::Single(targets.drain().next().unwrap()),
+                    _ => self,
+                }
+            }
+        }
+    }
+}
+
+impl From<Entity> for ActionStateDriverTarget {
+    fn from(value: Entity) -> Self {
+        Self::Single(value)
+    }
+}
+
+impl From<()> for ActionStateDriverTarget {
+    fn from(value: ()) -> Self {
+        Self::None
+    }
+}
+
+enum ActionStateDriverTargetIterator<'a> {
+    None,
+    Single(Once<&'a Entity>),
+    Multi(Iter<'a, Entity>),
+}
+
+impl<'a> Iterator for ActionStateDriverTargetIterator<'a> {
+    type Item = &'a Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::None => None,
+            Self::Single(iter) => iter.next(),
+            Self::Multi(iter) => iter.next(),
+        }
+    }
 }
 
 /// Stores information about when an action was pressed or released

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -153,10 +153,12 @@ pub fn update_action_state_from_interaction<A: Actionlike>(
 ) {
     for (&interaction, action_state_driver) in ui_query.iter() {
         if interaction == Interaction::Clicked {
-            let mut action_state = action_state_query
-                .get_mut(action_state_driver.entity)
-                .expect("Entity does not exist, or does not have an `ActionState` component.");
-            action_state.press(action_state_driver.action.clone());
+            for entity in action_state_driver.targets.iter() {
+                let mut action_state = action_state_query
+                    .get_mut(*entity)
+                    .expect("Entity does not exist, or does not have an `ActionState` component.");
+                action_state.press(action_state_driver.action.clone());
+            }
         }
     }
 }
@@ -275,6 +277,6 @@ pub fn release_on_input_map_removed<A: Actionlike>(
 }
 
 /// Uses the value of [`ToggleActions<A>`] to determine if input manager systems of type `A` should run.
-pub(super) fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> bool {
+pub fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> bool {
     toggle_actions.enabled
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -199,7 +199,7 @@ fn action_state_driver() {
             .insert(Interaction::None)
             .insert(ActionStateDriver::<Action> {
                 action: Action::PayRespects,
-                entity: player_entity,
+                targets: player_entity.into(),
             });
     }
 


### PR DESCRIPTION
# Problem #

A lot of games require mouse position as an input in some way.  However, in games with multiple windows or screens, this is not a straight forward input to get, and how to transform from screen space to world space, or if you need to at all, is a bit dependent on the use case, so it's hard to have a one size fits all axis type.

# Solution #

This crates great design makes it relatively easy to drive a mouse position action from an ActionStateDriver, it just needs a quick example to get the ball rolling for how you can add the capability to your own game, which this PR adds.

This PR also makes a small change to ActionStateDriver to let it drive multiple entities instead of just one.  I think this will be a big win long term for games that will need mouse data, or other driven action data, on many entities.