### PR TITLE
Mouse position

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,11 @@ to update multiple entities if needed.
 
 ### Docs
 
-- Added example for getting driving a cursor position action.
+- Added example for driving cursor position action from another entity.
+
+### Usability
+
+- Makes `run_if_enabled` public.
 
 ## Version 0.9.3
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Bugs
+
+- Changed `Rotation` to be stored in millionths of a degree instead of tenths of a degree in order to reduce rounding errors.
+
 ### Usability
 
 - Added `VirtualAxis::horizontal_dpad()` and `VirtualAxis::vertical_dpad()`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,16 @@
 # Release Notes
 
+## Unreleased
+
+### Enhancements
+
+- Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver 
+to update multiple entities if needed.
+
+### Docs
+
+- Added example for getting driving a cursor position action.
+
 ## Version 0.9.3
 
 ### Bugs

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -15,8 +15,6 @@ fn main() {
                 .in_set(InputManagerSystem::ManualControl)
                 .before(InputManagerSystem::ReleaseOnDisable)
                 .after(InputManagerSystem::Tick)
-                // Must run after the system is updated from inputs, or it will be forcibly released due to the inputs
-                // not being pressed
                 .after(InputManagerSystem::Update)
                 .after(InputSystem),
         )
@@ -51,6 +49,7 @@ fn update_cursor_state_from_window<A: Actionlike>(
     window_query: Query<(&Window, &ActionStateDriver<A>)>,
     mut action_state_query: Query<&mut ActionState<A>>,
 ) {
+    // Update each actionstate with the mouse position from the window
     for (window, driver) in window_query.iter() {
         for entity in driver.targets.iter() {
             let mut action_state = action_state_query
@@ -79,8 +78,6 @@ fn pan_camera(
         .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor.xy()))
         .map(|ray| ray.origin.truncate())
     {
-        // Because we're moving the camera, not the object, we want to pan in the opposite direction.
-        // However, UI coordinates are inverted on the y-axis, so we need to flip y a second time.
         box_transform.translation.x = box_pan_vector.x;
         box_transform.translation.y = box_pan_vector.y;
     }

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -1,4 +1,4 @@
-use bevy::{ecs::entity, input::InputSystem, prelude::*, window::PrimaryWindow};
+use bevy::{input::InputSystem, prelude::*, window::PrimaryWindow};
 use leafwing_input_manager::{
     axislike::DualAxisData, plugin::InputManagerSystem, prelude::*, systems::run_if_enabled,
 };

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -1,0 +1,87 @@
+use bevy::{ecs::entity, input::InputSystem, prelude::*, window::PrimaryWindow};
+use leafwing_input_manager::{
+    axislike::DualAxisData, plugin::InputManagerSystem, prelude::*, systems::run_if_enabled,
+};
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins)
+        .add_plugin(InputManagerPlugin::<BoxMovement>::default())
+        .add_startup_system(setup)
+        .add_system(
+            update_cursor_state_from_window::<BoxMovement>
+                .run_if(run_if_enabled::<BoxMovement>)
+                .in_base_set(CoreSet::PreUpdate)
+                .in_set(InputManagerSystem::ManualControl)
+                .before(InputManagerSystem::ReleaseOnDisable)
+                .after(InputManagerSystem::Tick)
+                // Must run after the system is updated from inputs, or it will be forcibly released due to the inputs
+                // not being pressed
+                .after(InputManagerSystem::Update)
+                .after(InputSystem),
+        )
+        .add_system(pan_camera)
+        .run();
+}
+
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
+enum BoxMovement {
+    Pan,
+}
+
+fn setup(mut commands: Commands, window: Query<Entity, With<PrimaryWindow>>) {
+    commands.spawn(Camera2dBundle::default());
+
+    let entity = commands
+        .spawn(SpriteBundle {
+            transform: Transform::from_scale(Vec3::new(100., 100., 1.)),
+            ..default()
+        })
+        .insert(InputManagerBundle::<BoxMovement>::default())
+        // Note: another entity will be driving this input
+        .id();
+
+    commands.entity(window.single()).insert(ActionStateDriver {
+        action: BoxMovement::Pan,
+        targets: entity.into(),
+    });
+}
+
+fn update_cursor_state_from_window<A: Actionlike>(
+    window_query: Query<(&Window, &ActionStateDriver<A>)>,
+    mut action_state_query: Query<&mut ActionState<A>>,
+) {
+    for (window, driver) in window_query.iter() {
+        for entity in driver.targets.iter() {
+            let mut action_state = action_state_query
+                .get_mut(*entity)
+                .expect("Entity does not exist, or does not have an `ActionState` component");
+
+            if let Some(val) = window.cursor_position() {
+                action_state
+                    .action_data_mut(driver.action.clone())
+                    .axis_pair = Some(DualAxisData::from_xy(val));
+            }
+        }
+    }
+}
+
+fn pan_camera(
+    mut query: Query<(&mut Transform, &ActionState<BoxMovement>)>,
+    camera: Query<(&Camera, &GlobalTransform)>,
+) {
+    let (mut box_transform, action_state) = query.single_mut();
+    let (camera, camera_transform) = camera.single();
+
+    // Note: Nothing is stopping us from doing this in the action update system instead!
+    if let Some(box_pan_vector) = action_state
+        .axis_pair(BoxMovement::Pan)
+        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor.xy()))
+        .map(|ray| ray.origin.truncate())
+    {
+        // Because we're moving the camera, not the object, we want to pan in the opposite direction.
+        // However, UI coordinates are inverted on the y-axis, so we need to flip y a second time.
+        box_transform.translation.x = box_pan_vector.x;
+        box_transform.translation.y = box_pan_vector.y;
+    }
+}

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -67,7 +67,7 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
         // This component links the button to the entity with the `ActionState` component
         .insert(ActionStateDriver {
             action: Action::Left,
-            entity: player_entity,
+            targets: player_entity.into(),
         })
         .id();
 
@@ -83,7 +83,7 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
         })
         .insert(ActionStateDriver {
             action: Action::Right,
-            entity: player_entity,
+            targets: player_entity.into(),
         })
         .id();
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -6,8 +6,10 @@ use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 use bevy::ecs::{component::Component, entity::Entity};
 use bevy::prelude::Resource;
 use bevy::reflect::{FromReflect, Reflect};
-use bevy::utils::{Duration, Instant};
+use bevy::utils::hashbrown::hash_set::Iter;
+use bevy::utils::{Duration, HashSet, Instant};
 use serde::{Deserialize, Serialize};
+use std::iter::Once;
 use std::marker::PhantomData;
 
 /// Metadata about an [`Actionlike`] action
@@ -537,7 +539,7 @@ impl<A: Actionlike> Default for ActionState<A> {
 ///     // This component links the button to the entity with the `ActionState` component
 ///     .insert(ActionStateDriver {
 ///         action: DanceDance::Left,
-///         entity: dance_tracker,
+///         targets: dance_tracker.into(),
 ///     });
 ///```
 ///
@@ -545,12 +547,132 @@ impl<A: Actionlike> Default for ActionState<A> {
 /// although this should be reserved for cases where the entity whose value you want to check
 /// is distinct from the entity whose [`ActionState`] you want to set.
 /// Check the source code of [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction) for an example of how this is done.
-#[derive(Component, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Component, Clone, PartialEq, Eq)]
 pub struct ActionStateDriver<A: Actionlike> {
     /// The action triggered by this entity
     pub action: A,
     /// The entity whose action state should be updated
-    pub entity: Entity,
+    pub targets: ActionStateDriverTarget,
+}
+
+/// Represents the entities that an ``ActionStateDriver`` targets.
+#[derive(Component, Clone, PartialEq, Eq)]
+pub enum ActionStateDriverTarget {
+    /// No targets
+    None,
+    /// Single target
+    Single(Entity),
+    /// Multiple targets
+    Multi(HashSet<Entity>),
+}
+
+impl ActionStateDriverTarget {
+    /// Get an iterator for the entities targeted.
+    #[inline(always)]
+    pub fn iter(&self) -> impl Iterator<Item = &Entity> {
+        match self {
+            Self::None => ActionStateDriverTargetIterator::None,
+            Self::Single(entity) => {
+                ActionStateDriverTargetIterator::Single(std::iter::once(entity))
+            }
+            Self::Multi(entities) => ActionStateDriverTargetIterator::Multi(entities.iter()),
+        }
+    }
+
+    /// Insert an entity as a target.
+    #[inline(always)]
+    pub fn insert(&mut self, entity: Entity) {
+        *self = std::mem::replace(self, Self::None).with(entity);
+    }
+
+    /// Remove an entity as a target if it's in the target set.
+    #[inline(always)]
+    pub fn remove(&mut self, entity: Entity) {
+        *self = std::mem::replace(self, Self::None).without(entity);
+    }
+
+    /// Add an entity as a target.
+    #[inline(always)]
+    pub fn add(&mut self, entities: impl Iterator<Item = Entity>) {
+        for entity in entities {
+            self.insert(entity)
+        }
+    }
+
+    /// Get the number of targets.
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        match self {
+            Self::None => 0,
+            Self::Single(_) => 1,
+            Self::Multi(targets) => targets.len(),
+        }
+    }
+
+    /// Returns true if there are no targets.
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Add an entity as a target using a builder style pattern.
+    #[inline(always)]
+    pub fn with(mut self, entity: Entity) -> Self {
+        match self {
+            Self::None => Self::Single(entity),
+            Self::Single(og) => Self::Multi(HashSet::from([og, entity])),
+            Self::Multi(ref mut targets) => {
+                targets.insert(entity);
+                self
+            }
+        }
+    }
+
+    /// Remove an entity as a target if it's in the set using a builder style pattern.
+    pub fn without(mut self, entity: Entity) -> Self {
+        match self {
+            Self::None => Self::None,
+            Self::Single(_) => Self::None,
+            Self::Multi(ref mut targets) => {
+                targets.remove(&entity);
+                match targets.len() {
+                    0 => Self::None,
+                    1 => Self::Single(targets.drain().next().unwrap()),
+                    _ => self,
+                }
+            }
+        }
+    }
+}
+
+impl From<Entity> for ActionStateDriverTarget {
+    fn from(value: Entity) -> Self {
+        Self::Single(value)
+    }
+}
+
+impl From<()> for ActionStateDriverTarget {
+    fn from(value: ()) -> Self {
+        Self::None
+    }
+}
+
+enum ActionStateDriverTargetIterator<'a> {
+    None,
+    Single(Once<&'a Entity>),
+    Multi(Iter<'a, Entity>),
+}
+
+impl<'a> Iterator for ActionStateDriverTargetIterator<'a> {
+    type Item = &'a Entity;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::None => None,
+            Self::Single(iter) => iter.next(),
+            Self::Multi(iter) => iter.next(),
+        }
+    }
 }
 
 /// Stores information about when an action was pressed or released

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -652,7 +652,7 @@ impl From<Entity> for ActionStateDriverTarget {
 }
 
 impl From<()> for ActionStateDriverTarget {
-    fn from(value: ()) -> Self {
+    fn from(_value: ()) -> Self {
         Self::None
     }
 }

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -30,14 +30,15 @@ mod orientation_trait {
         /// Asserts that `self` is approximately equal to `other`
         ///
         /// # Panics
-        /// Panics if the distance between `self` and `other` is greater than 2 deci-degrees.
+        /// Panics if the distance between `self` and `other` is greater than a hundredth of a degree.
+        #[track_caller]
         fn assert_approx_eq(self, other: impl Orientation) {
             let self_rotation: Rotation = self.into();
             let other_rotation: Rotation = other.into();
 
             let distance: Rotation = self_rotation.distance(other_rotation);
             assert!(
-                distance <= Rotation::new(2),
+                distance <= Rotation::new(Rotation::DEGREE / 100),
                 "{self:?} (converted to {self_rotation}) was {distance} away from {other:?} (converted to {other_rotation})."
             );
         }
@@ -67,7 +68,8 @@ mod orientation_trait {
 
             let rotation_to = target_rotation - self_rotation;
 
-            if rotation_to.deci_degrees == 0 || rotation_to.deci_degrees >= 1800 {
+            if rotation_to.micro_degrees == 0 || rotation_to.micro_degrees >= Rotation::HALF_CIRCLE
+            {
                 RotationDirection::Clockwise
             } else {
                 RotationDirection::CounterClockwise
@@ -87,7 +89,7 @@ mod orientation_trait {
         /// assert_eq!(rotation, Rotation::WEST);
         ///
         /// // With a `max_rotation`, we don't get all the way there
-        /// rotation.rotate_towards(Rotation::SOUTH, Some(Rotation::new(450)));
+        /// rotation.rotate_towards(Rotation::SOUTH, Some(Rotation::from_degrees_int(45)));
         /// assert_eq!(rotation, Rotation::SOUTHWEST);
         /// ```
         #[inline]
@@ -114,19 +116,19 @@ mod orientation_trait {
     impl Orientation for Rotation {
         #[inline]
         fn distance(&self, other: Rotation) -> Rotation {
-            let initial_distance = if self.deci_degrees >= other.deci_degrees {
-                self.deci_degrees - other.deci_degrees
+            let initial_distance = if self.micro_degrees >= other.micro_degrees {
+                self.micro_degrees - other.micro_degrees
             } else {
-                other.deci_degrees - self.deci_degrees
+                other.micro_degrees - self.micro_degrees
             };
 
             if initial_distance <= Rotation::FULL_CIRCLE / 2 {
                 Rotation {
-                    deci_degrees: initial_distance,
+                    micro_degrees: initial_distance,
                 }
             } else {
                 Rotation {
-                    deci_degrees: Rotation::FULL_CIRCLE - initial_distance,
+                    micro_degrees: Rotation::FULL_CIRCLE - initial_distance,
                 }
             }
         }
@@ -223,7 +225,7 @@ mod rotation {
 
     /// A discretized 2-dimensional rotation
     ///
-    /// Internally, these are stored in tenths of a degree, and so can be cleanly added
+    /// Internally, these are stored in millionths of a degree, and so can be cleanly added
     /// and reversed without accumulating error.
     ///
     /// # Example
@@ -250,59 +252,65 @@ mod rotation {
     /// ```
     #[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Default, Display)]
     pub struct Rotation {
-        /// Tenths of a degree, measured clockwise from midnight (x=0, y=1)
+        /// Millionths of a degree, measured clockwise from midnight (x=0, y=1)
         ///
-        /// 3600 make up a full circle
-        pub(crate) deci_degrees: u16,
+        /// `360_000_000` make up a full circle
+        pub(crate) micro_degrees: u32,
     }
 
     // Useful methods
     impl Rotation {
-        /// Creates a new [`Rotation`] from a whole number of tenths of a degree
+        /// Creates a new [`Rotation`] from a whole number of millionths of a degree
         ///
         /// Measured clockwise from midnight.
         #[inline]
         #[must_use]
-        pub const fn new(deci_degrees: u16) -> Rotation {
+        pub const fn new(micro_degrees: u32) -> Rotation {
             Rotation {
-                deci_degrees: deci_degrees % Rotation::FULL_CIRCLE,
+                micro_degrees: micro_degrees % Rotation::FULL_CIRCLE,
             }
         }
 
-        /// Returns the exact internal measurement, stored in tenths of a degree
+        /// Returns the exact internal measurement, stored in millionths of a degree
         ///
         /// Measured clockwise from midnight (x=0, y=1).
-        /// 3600 make up a full circle.
+        /// `360_000_000` make up a full circle.
         #[inline]
         #[must_use]
-        pub const fn deci_degrees(&self) -> u16 {
-            self.deci_degrees
+        pub const fn micro_degrees(&self) -> u32 {
+            self.micro_degrees
         }
     }
 
     // Constants
     impl Rotation {
-        /// The number of deci-degrees that make up a full circle
-        pub const FULL_CIRCLE: u16 = 3600;
+        /// The number of micro-degrees in one degree
+        pub const DEGREE: u32 = 1_000_000;
+
+        /// The number of micro-degrees that make up a half circle
+        pub const HALF_CIRCLE: u32 = 180 * Rotation::DEGREE;
+
+        /// The number of micro-degrees that make up a full circle
+        pub const FULL_CIRCLE: u32 = 360 * Rotation::DEGREE;
 
         /// The direction that points straight up
-        pub const NORTH: Rotation = Rotation { deci_degrees: 900 };
+        pub const NORTH: Rotation = Rotation::from_degrees_int(90);
 
         /// The direction that points straight right
-        pub const EAST: Rotation = Rotation { deci_degrees: 0 };
+        pub const EAST: Rotation = Rotation::from_degrees_int(0);
         /// The direction that points straight down
-        pub const SOUTH: Rotation = Rotation { deci_degrees: 2700 };
+        pub const SOUTH: Rotation = Rotation::from_degrees_int(270);
         /// The direction that points straight left
-        pub const WEST: Rotation = Rotation { deci_degrees: 1800 };
+        pub const WEST: Rotation = Rotation::from_degrees_int(180);
 
         /// The direction that points halfway between up and right
-        pub const NORTHEAST: Rotation = Rotation { deci_degrees: 450 };
+        pub const NORTHEAST: Rotation = Rotation::from_degrees_int(45);
         /// The direction that points halfway between down and right
-        pub const SOUTHEAST: Rotation = Rotation { deci_degrees: 3150 };
+        pub const SOUTHEAST: Rotation = Rotation::from_degrees_int(315);
         /// The direction that points halfway between down and left
-        pub const SOUTHWEST: Rotation = Rotation { deci_degrees: 2250 };
+        pub const SOUTHWEST: Rotation = Rotation::from_degrees_int(225);
         /// The direction that points halfway between left and up
-        pub const NORTHWEST: Rotation = Rotation { deci_degrees: 1350 };
+        pub const NORTHWEST: Rotation = Rotation::from_degrees_int(135);
     }
 
     // Conversion methods
@@ -345,7 +353,7 @@ mod rotation {
             let normalized_radians = radians.into().rem_euclid(TAU);
 
             Rotation {
-                deci_degrees: (normalized_radians * (3600. / TAU)) as u16,
+                micro_degrees: (normalized_radians * (Rotation::FULL_CIRCLE as f32 / TAU)) as u32,
             }
         }
 
@@ -353,7 +361,7 @@ mod rotation {
         #[inline]
         #[must_use]
         pub fn into_radians(self) -> f32 {
-            self.deci_degrees as f32 * TAU / 3600.
+            self.micro_degrees as f32 * (TAU / Rotation::FULL_CIRCLE as f32)
         }
 
         /// Construct a [`Direction`](crate::orientation::Direction) from degrees, measured counterclockwise from the positive x axis
@@ -363,7 +371,16 @@ mod rotation {
             let normalized_degrees: f32 = degrees.into().rem_euclid(360.0);
 
             Rotation {
-                deci_degrees: (normalized_degrees * 10.0) as u16,
+                micro_degrees: (normalized_degrees * Rotation::DEGREE as f32) as u32,
+            }
+        }
+
+        /// Construct a [`Direction`](crate::orientation::Direction) from a whole number of degrees, measured counterclockwise from the positive x axis
+        #[must_use]
+        #[inline]
+        pub const fn from_degrees_int(degrees: u32) -> Rotation {
+            Rotation {
+                micro_degrees: degrees.rem_euclid(360) * Rotation::DEGREE,
             }
         }
 
@@ -371,41 +388,42 @@ mod rotation {
         #[inline]
         #[must_use]
         pub fn into_degrees(self) -> f32 {
-            self.deci_degrees as f32 / 10.
+            self.micro_degrees as f32 / Rotation::DEGREE as f32
         }
     }
 
     impl Add for Rotation {
         type Output = Rotation;
         fn add(self, rhs: Self) -> Rotation {
-            Rotation::new(self.deci_degrees + rhs.deci_degrees)
+            Rotation::new(self.micro_degrees + rhs.micro_degrees)
         }
     }
 
     impl Sub for Rotation {
         type Output = Rotation;
         fn sub(self, rhs: Self) -> Rotation {
-            if self.deci_degrees >= rhs.deci_degrees {
-                Rotation::new(self.deci_degrees - rhs.deci_degrees)
+            if self.micro_degrees >= rhs.micro_degrees {
+                Rotation::new(self.micro_degrees - rhs.micro_degrees)
             } else {
-                Rotation::new(self.deci_degrees + Rotation::FULL_CIRCLE - rhs.deci_degrees)
+                Rotation::new(self.micro_degrees + Rotation::FULL_CIRCLE - rhs.micro_degrees)
             }
         }
     }
 
     impl AddAssign for Rotation {
         fn add_assign(&mut self, rhs: Self) {
-            self.deci_degrees = (self.deci_degrees + rhs.deci_degrees) % Rotation::FULL_CIRCLE;
+            self.micro_degrees = (self.micro_degrees + rhs.micro_degrees) % Rotation::FULL_CIRCLE;
         }
     }
 
     impl SubAssign for Rotation {
         fn sub_assign(&mut self, rhs: Self) {
             // Be sure to avoid overflow when subtracting
-            if self.deci_degrees >= rhs.deci_degrees {
-                self.deci_degrees = self.deci_degrees - rhs.deci_degrees;
+            if self.micro_degrees >= rhs.micro_degrees {
+                self.micro_degrees = self.micro_degrees - rhs.micro_degrees;
             } else {
-                self.deci_degrees = Rotation::FULL_CIRCLE - (rhs.deci_degrees - self.deci_degrees);
+                self.micro_degrees =
+                    Rotation::FULL_CIRCLE - (rhs.micro_degrees - self.micro_degrees);
             }
         }
     }
@@ -414,7 +432,7 @@ mod rotation {
         type Output = Rotation;
         fn neg(self) -> Rotation {
             Rotation {
-                deci_degrees: Rotation::FULL_CIRCLE - self.deci_degrees,
+                micro_degrees: Rotation::FULL_CIRCLE - self.micro_degrees,
             }
         }
     }
@@ -627,7 +645,7 @@ mod conversions {
         fn from(direction: Direction) -> Rotation {
             let radians = direction.unit_vector.y.atan2(direction.unit_vector.x);
             // This dirty little trick helps us nudge the two (of eight) cardinal directions onto
-            // the correct decidegree. 32-bit floating point math rounds to the wrong decidegree,
+            // the correct microdegree. 32-bit floating point math rounds to the wrong microdegree,
             // which usually isn't a big deal, but can result in unexpected surprises when people
             // are dealing only with cardinal directions. The underlying problem is that f32 values
             // for 1.0 and -1.0 can't be represented exactly, so our unit vectors start with an
@@ -636,9 +654,9 @@ mod conversions {
             const APPROX_SOUTH: f32 = -1.5707964;
             const APPROX_NORTHWEST: f32 = 2.3561945;
             if radians == APPROX_NORTHWEST {
-                Rotation::new(1350)
+                Rotation::from_degrees_int(135)
             } else if radians == APPROX_SOUTH {
-                Rotation::new(2700)
+                Rotation::from_degrees_int(270)
             } else {
                 Rotation::from_radians(radians)
             }
@@ -763,50 +781,50 @@ mod test {
         let north_rot: Rotation = Direction::NORTH.into();
         assert_eq!(
             north_rot,
-            Rotation::new(900),
-            "we want north to end up exact in decidegrees"
+            Rotation::from_degrees_int(90),
+            "we want north to end up exact in microdegrees"
         );
         let northeast_rot: Rotation = Direction::NORTHEAST.into();
         assert_eq!(
             northeast_rot,
-            Rotation::new(450),
-            "we want northeast to end up exact in decidegrees"
+            Rotation::from_degrees_int(45),
+            "we want northeast to end up exact in microdegrees"
         );
         let northwest_rot: Rotation = Direction::NORTHWEST.into();
         assert_eq!(
             northwest_rot,
-            Rotation::new(1350),
-            "we want northwest to end up exact in decidegrees"
+            Rotation::from_degrees_int(135),
+            "we want northwest to end up exact in microdegrees"
         );
         let south_rot: Rotation = Direction::SOUTH.into();
         assert_eq!(
             south_rot,
-            Rotation::new(2700),
-            "we want south to end up exact in decidegrees"
+            Rotation::from_degrees_int(270),
+            "we want south to end up exact in microdegrees"
         );
         let southeast_rot: Rotation = Direction::SOUTHEAST.into();
         assert_eq!(
             southeast_rot,
-            Rotation::new(3150),
-            "we want southeast to end up exact in decidegrees"
+            Rotation::from_degrees_int(315),
+            "we want southeast to end up exact in microdegrees"
         );
         let southwest_rot: Rotation = Direction::SOUTHWEST.into();
         assert_eq!(
             southwest_rot,
-            Rotation::new(2250),
-            "we want southwest to end up exact in decidegrees"
+            Rotation::from_degrees_int(225),
+            "we want southwest to end up exact in microdegrees"
         );
         let east_rot: Rotation = Direction::EAST.into();
         assert_eq!(
             east_rot,
-            Rotation::new(0),
-            "we want east to end up exact in decidegrees"
+            Rotation::from_degrees_int(0),
+            "we want east to end up exact in microdegrees"
         );
         let west_rot: Rotation = Direction::WEST.into();
         assert_eq!(
             west_rot,
-            Rotation::new(1800),
-            "we want west to end up exact in decidegrees"
+            Rotation::from_degrees_int(180),
+            "we want west to end up exact in microdegrees"
         );
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -153,10 +153,12 @@ pub fn update_action_state_from_interaction<A: Actionlike>(
 ) {
     for (&interaction, action_state_driver) in ui_query.iter() {
         if interaction == Interaction::Clicked {
-            let mut action_state = action_state_query
-                .get_mut(action_state_driver.entity)
-                .expect("Entity does not exist, or does not have an `ActionState` component.");
-            action_state.press(action_state_driver.action.clone());
+            for entity in action_state_driver.targets.iter() {
+                let mut action_state = action_state_query
+                    .get_mut(*entity)
+                    .expect("Entity does not exist, or does not have an `ActionState` component.");
+                action_state.press(action_state_driver.action.clone());
+            }
         }
     }
 }
@@ -275,6 +277,6 @@ pub fn release_on_input_map_removed<A: Actionlike>(
 }
 
 /// Uses the value of [`ToggleActions<A>`] to determine if input manager systems of type `A` should run.
-pub(super) fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> bool {
+pub fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> bool {
     toggle_actions.enabled
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -199,7 +199,7 @@ fn action_state_driver() {
             .insert(Interaction::None)
             .insert(ActionStateDriver::<Action> {
                 action: Action::PayRespects,
-                entity: player_entity,
+                targets: player_entity.into(),
             });
     }
 


### PR DESCRIPTION
Problem
A lot of games require mouse position as an input in some way. However, in games with multiple windows or screens, this is not a straight forward input to get, and how to transform from screen space to world space, or if you need to at all, is a bit dependent on the use case, so it's hard to have a one size fits all axis type.

Solution
This crates great design makes it relatively easy to drive a mouse position action from an ActionStateDriver, it just needs a quick example to get the ball rolling for how you can add the capability to your own game, which this PR adds.

This PR also makes a small change to ActionStateDriver to let it drive multiple entities instead of just one. I think this will be a big win long term for games that will need mouse data, or other driven action data, on many entities.