### PR TITLE
Add Inversion to SingleAxis, DualAxis, and VirtualDPad

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,7 @@
 
 - Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver 
 to update multiple entities if needed.
+- Added builder-style functions to `SingleAxis`, `DualAxis`, and `VirtualDPad` that invert their output values, allowing, for example, binding inverted camera controls.
 
 ### Docs
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -28,6 +28,8 @@ pub struct SingleAxis {
     pub positive_low: f32,
     /// Any axis value lower than this will trigger the input.
     pub negative_low: f32,
+    /// Whether to invert output values from this axis.
+    pub inverted: bool,
     /// The target value for this input, used for input mocking.
     ///
     /// WARNING: this field is ignored for the sake of [`Eq`] and [`Hash`](std::hash::Hash)
@@ -42,6 +44,7 @@ impl SingleAxis {
             axis_type: axis_type.into(),
             positive_low: threshold,
             negative_low: -threshold,
+            inverted: false,
             value: None,
         }
     }
@@ -56,6 +59,7 @@ impl SingleAxis {
             axis_type: axis_type.into(),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
             value: Some(value),
         }
     }
@@ -67,6 +71,7 @@ impl SingleAxis {
             axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
             positive_low: 0.,
             negative_low: 0.,
+            inverted: false,
             value: None,
         }
     }
@@ -78,6 +83,7 @@ impl SingleAxis {
             axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
             positive_low: 0.,
             negative_low: 0.,
+            inverted: false,
             value: None,
         }
     }
@@ -89,6 +95,7 @@ impl SingleAxis {
             axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
             positive_low: 0.,
             negative_low: 0.,
+            inverted: false,
             value: None,
         }
     }
@@ -100,6 +107,7 @@ impl SingleAxis {
             axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
             positive_low: 0.,
             negative_low: 0.,
+            inverted: false,
             value: None,
         }
     }
@@ -112,6 +120,7 @@ impl SingleAxis {
             axis_type: axis_type.into(),
             negative_low: threshold,
             positive_low: f32::MAX,
+            inverted: false,
             value: None,
         }
     }
@@ -124,6 +133,7 @@ impl SingleAxis {
             axis_type: axis_type.into(),
             negative_low: f32::MIN,
             positive_low: threshold,
+            inverted: false,
             value: None,
         }
     }
@@ -133,6 +143,13 @@ impl SingleAxis {
     pub fn with_deadzone(mut self, deadzone: f32) -> SingleAxis {
         self.negative_low = -deadzone;
         self.positive_low = deadzone;
+        self
+    }
+
+    /// Returns this [`SingleAxis`] inverted.
+    #[must_use]
+    pub fn inverted(mut self) -> Self {
+        self.inverted = !self.inverted;
         self
     }
 }
@@ -248,6 +265,28 @@ impl DualAxis {
     pub fn with_deadzone(mut self, deadzone: f32) -> DualAxis {
         self.x = self.x.with_deadzone(deadzone);
         self.y = self.y.with_deadzone(deadzone);
+        self
+    }
+
+    /// Returns this [`DualAxis`] with an inverted X-axis.
+    #[must_use]
+    pub fn inverted_x(mut self) -> DualAxis {
+        self.x = self.x.inverted();
+        self
+    }
+
+    /// Returns this [`DualAxis`] with an inverted Y-axis.
+    #[must_use]
+    pub fn inverted_y(mut self) -> DualAxis {
+        self.y = self.y.inverted();
+        self
+    }
+
+    /// Returns this [`DualAxis`] with inverted axes.
+    #[must_use]
+    pub fn inverted(mut self) -> DualAxis {
+        self.x = self.x.inverted();
+        self.y = self.y.inverted();
         self
     }
 }
@@ -404,6 +443,13 @@ impl VirtualAxis {
             negative: InputKind::GamepadButton(GamepadButtonType::DPadDown),
             positive: InputKind::GamepadButton(GamepadButtonType::DPadUp),
         }
+    }
+
+    /// Returns this [`VirtualAxis`] but with flipped positive/negative inputs.
+    #[must_use]
+    pub fn inverted(mut self) -> Self {
+        std::mem::swap(&mut self.positive, &mut self.negative);
+        self
     }
 }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -378,6 +378,25 @@ impl VirtualDPad {
             right: InputKind::MouseMotion(MouseMotionDirection::Right),
         }
     }
+
+    /// Returns this [`VirtualDPad`] but with `up` and `down` swapped.
+    pub fn inverted_y(mut self) -> Self {
+        std::mem::swap(&mut self.up, &mut self.down);
+        self
+    }
+
+    /// Returns this [`VirtualDPad`] but with `left` and `right` swapped.
+    pub fn inverted_x(mut self) -> Self {
+        std::mem::swap(&mut self.left, &mut self.right);
+        self
+    }
+
+    /// Returns this [`VirtualDPad`] but with inverted inputs.
+    pub fn inverted(mut self) -> Self {
+        std::mem::swap(&mut self.up, &mut self.down);
+        std::mem::swap(&mut self.left, &mut self.right);
+        self
+    }
 }
 
 /// A virtual Axis that you can get a value between -1 and 1 from.

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -282,7 +282,7 @@ impl DualAxis {
         self
     }
 
-    /// Returns this [`DualAxis`] with inverted axes.
+    /// Returns this [`DualAxis`] with both axes inverted.
     #[must_use]
     pub fn inverted(mut self) -> DualAxis {
         self.x = self.x.inverted();

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -261,12 +261,10 @@ impl<'a> InputStreams<'a> {
         let value_in_axis_range = |axis: &SingleAxis, value: f32| -> f32 {
             if value >= axis.negative_low && value <= axis.positive_low {
                 0.0
+            } else if axis.inverted {
+                -value
             } else {
-                if axis.inverted {
-                    -value
-                } else {
-                    value
-                }
+                value
             }
         };
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -262,7 +262,11 @@ impl<'a> InputStreams<'a> {
             if value >= axis.negative_low && value <= axis.positive_low {
                 0.0
             } else {
-                value
+                if axis.inverted {
+                    -value
+                } else {
+                    value
+                }
             }
         };
 

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -79,6 +79,7 @@ fn game_pad_single_axis_mocking() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
 
     app.send_input(input);
@@ -98,12 +99,14 @@ fn game_pad_dual_axis_mocking() {
             value: Some(1.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
         y: SingleAxis {
             axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
             value: Some(0.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
     };
     app.send_input(input);
@@ -132,6 +135,7 @@ fn game_pad_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -144,6 +148,7 @@ fn game_pad_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -156,6 +161,7 @@ fn game_pad_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -168,6 +174,7 @@ fn game_pad_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -181,6 +188,7 @@ fn game_pad_single_axis() {
         // Usually a small deadzone threshold will be set
         positive_low: 0.1,
         negative_low: 0.1,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -193,6 +201,7 @@ fn game_pad_single_axis() {
         value: None,
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -74,6 +74,7 @@ fn mouse_motion_single_axis_mocking() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
 
     app.send_input(input);
@@ -93,12 +94,14 @@ fn mouse_motion_dual_axis_mocking() {
             value: Some(1.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
         y: SingleAxis {
             axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
             value: Some(0.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
     };
     app.send_input(input);
@@ -166,6 +169,7 @@ fn mouse_motion_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -178,6 +182,7 @@ fn mouse_motion_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -190,6 +195,7 @@ fn mouse_motion_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -202,6 +208,7 @@ fn mouse_motion_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -215,6 +222,7 @@ fn mouse_motion_single_axis() {
         // Usually a small deadzone threshold will be set
         positive_low: 0.1,
         negative_low: 0.1,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -227,6 +235,7 @@ fn mouse_motion_single_axis() {
         value: None,
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -74,6 +74,7 @@ fn mouse_wheel_single_axis_mocking() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
 
     app.send_input(input);
@@ -93,12 +94,14 @@ fn mouse_wheel_dual_axis_mocking() {
             value: Some(1.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
         y: SingleAxis {
             axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
             value: Some(0.),
             positive_low: 0.0,
             negative_low: 0.0,
+            inverted: false,
         },
     };
     app.send_input(input);
@@ -166,6 +169,7 @@ fn mouse_wheel_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -178,6 +182,7 @@ fn mouse_wheel_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -190,6 +195,7 @@ fn mouse_wheel_single_axis() {
         value: Some(1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -202,6 +208,7 @@ fn mouse_wheel_single_axis() {
         value: Some(-1.),
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -215,6 +222,7 @@ fn mouse_wheel_single_axis() {
         // Usually a small deadzone threshold will be set
         positive_low: 0.1,
         negative_low: 0.1,
+        inverted: false,
     };
     app.send_input(input);
     app.update();
@@ -227,6 +235,7 @@ fn mouse_wheel_single_axis() {
         value: None,
         positive_low: 0.0,
         negative_low: 0.0,
+        inverted: false,
     };
     app.send_input(input);
     app.update();


### PR DESCRIPTION
Fixes #247.

Adds `inverted`, `inverted_x`, and `inverted_y` builder-style functions for `SingleAxis`, `DualAxis`, and `VirtualDPad`, where appropriate. The `SingleAxis` implementation uses an `inverted` field, the `DualAxis` implementation just inverts its internal axes, and the `VirtualDPad` implementation swaps the relevant inputs.

Current tests pass, but I haven't written any yet to test inversion.

## Todo
- [ ] Write tests
- [ ] Better documentation?