### PR TITLE
Update Bevy to 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ bevy = { version = "0.11", default-features = false, features = [
   "serialize",
   "bevy_gilrs",
 ] }
-bevy_egui = { version = "0.20", optional = true }
+bevy_egui = { version = "0.21", optional = true }
 
 petitset = { version = "0.2.1", features = ["serde_compat"] }
 derive_more = { version = "0.99", default-features = false, features = [
@@ -42,7 +42,7 @@ fixedbitset = "0.4.2"
 once_cell = "1.17.1"
 
 [dev-dependencies]
-bevy_egui = { version = "0.20" }
+bevy_egui = { version = "0.21" }
 bevy = { version = "0.11", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
@@ -67,5 +67,3 @@ harness = false
 name = "leafwing_input_manager"
 path = "src/lib.rs"
 
-[patch.crates-io]
-bevy_egui = {git="https://github.com/Vrixyz/bevy_egui.git", rev="852b2db"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ egui = ['dep:bevy_egui']
 
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.9" }
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
   "serialize",
   "bevy_gilrs",
 ] }
@@ -43,7 +43,7 @@ once_cell = "1.17.1"
 
 [dev-dependencies]
 bevy_egui = { version = "0.20" }
-bevy = { version = "0.10", default-features = false, features = [
+bevy = { version = "0.11", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "bevy_text",
@@ -66,3 +66,6 @@ harness = false
 [lib]
 name = "leafwing_input_manager"
 path = "src/lib.rs"
+
+[patch.crates-io]
+bevy_egui = {git="https://github.com/Vrixyz/bevy_egui.git", rev="852b2db"}

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ and a single input can result in multiple actions being triggered, which can be 
 - Ergonomic insertion API that seamlessly blends multiple input types for you
   - Can't decide between `input_map.insert(Action::Jump, KeyCode::Space)` and `input_map.insert(Action::Jump, GamepadButtonType::South)`? Have both!
 - Full support for arbitrary button combinations: chord your heart out.
-  - `input_map.insert_chord(Action::Console, [KeyCode::LControl, KeyCode::Shift, KeyCode::C])`
+  - `input_map.insert_chord(Action::Console, [KeyCode::ControlLeft, KeyCode::Shift, KeyCode::C])`
 - Sophisticated input disambiguation with the `ClashStrategy` enum: stop triggering individual buttons when you meant to press a chord!
 - Create an arbitrary number of strongly typed disjoint action sets by adding multiple copies of this plugin: decouple your camera and player state
 - Local multiplayer support: freely bind keys to distinct entities, rather than worrying about singular global state
@@ -62,11 +62,11 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
-        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_plugins(InputManagerPlugin::<Action>::default())
         // The InputMap and ActionState components will be added to any entity with the Player component
-        .add_startup_system(spawn_player)
+        .add_systems(Startup,spawn_player)
         // Read the ActionState in your systems using queries!
-        .add_system(jump)
+        .add_systems(Update, jump)
         .run();
 }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### Usability
+
+- `bevy` dependency has been bumped from 0.10 to 0.11.
+- `ActionLike` now requires Bevy's `TypePath` trait. Your actions will now need to derive `Reflect` or `TypePath`. See [bevy#7184](https://github.com/bevyengine/bevy/pull/7184)
+- `QwertyScanCode` has had its variants renamed to match bevy's `KeyCode` variants.
+  See [bevy#8792](https://github.com/bevyengine/bevy/pull/8792)
+
 ### Enhancements
 
 - Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver 

--- a/benches/action_state.rs
+++ b/benches/action_state.rs
@@ -1,3 +1,4 @@
+use bevy::prelude::Reflect;
 use criterion::{criterion_group, criterion_main, Criterion};
 use leafwing_input_manager::{
     action_state::{ActionData, Timing},
@@ -6,7 +7,7 @@ use leafwing_input_manager::{
     Actionlike,
 };
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 enum TestAction {
     A,
     B,
@@ -44,7 +45,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     let action_state = ActionState::<TestAction>::default();
 
     c.bench_function("action_state_default", |b| {
-        b.iter(|| ActionState::<TestAction>::default())
+        b.iter(ActionState::<TestAction>::default)
     });
     c.bench_function("pressed", |b| b.iter(|| pressed(&action_state)));
     c.bench_function("just_pressed", |b| b.iter(|| just_pressed(&action_state)));

--- a/benches/input_map.rs
+++ b/benches/input_map.rs
@@ -1,3 +1,4 @@
+use bevy::prelude::Reflect;
 use bevy::{
     input::InputPlugin,
     prelude::{App, KeyCode},
@@ -10,7 +11,7 @@ use leafwing_input_manager::{
     Actionlike,
 };
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 enum TestAction {
     A,
     B,
@@ -63,16 +64,16 @@ fn which_pressed(input_streams: &InputStreams, clash_strategy: ClashStrategy) ->
 
 pub fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("construct_input_map_from_iter", |b| {
-        b.iter(|| construct_input_map_from_iter())
+        b.iter(construct_input_map_from_iter)
     });
     c.bench_function("construct_input_map_from_chained_calls", |b| {
-        b.iter(|| construct_input_map_from_chained_calls())
+        b.iter(construct_input_map_from_chained_calls)
     });
     let mut which_pressed_group = c.benchmark_group("which_pressed");
 
     // Constructing our test app / input stream outside of the timed benchmark
     let mut app = App::new();
-    app.add_plugin(InputPlugin);
+    app.add_plugins(InputPlugin);
     app.send_input(KeyCode::A);
     app.send_input(KeyCode::B);
     app.update();

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -14,22 +14,21 @@ fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
         // These are the generic "slots" that make up the player's action bar
-        .add_plugin(InputManagerPlugin::<Slot>::default())
+        .add_plugins(InputManagerPlugin::<Slot>::default())
         // These are the actual abilities used by our characters
-        .add_plugin(InputManagerPlugin::<Ability>::default())
-        .add_startup_system(spawn_player)
+        .add_plugins(InputManagerPlugin::<Ability>::default())
+        .add_systems(Startup, spawn_player)
         // This system coordinates the state of our two actions
-        .add_system(
-            copy_action_state
-                .in_base_set(CoreSet::PreUpdate)
-                .after(InputManagerSystem::ManualControl),
+        .add_systems(
+            PreUpdate,
+            copy_action_state.after(InputManagerSystem::ManualControl),
         )
         // Try it out, using QWER / left click / right click!
-        .add_system(report_abilities_used)
+        .add_systems(Update, report_abilities_used)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Hash, Copy)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Hash, Copy, Reflect)]
 enum Slot {
     Primary,
     Secondary,
@@ -40,7 +39,7 @@ enum Slot {
 }
 
 // The list of possible abilities is typically longer than the list of slots
-#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Copy)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Copy, Reflect)]
 enum Ability {
     Slash,
     Shoot,

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -6,15 +6,15 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
-        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_plugins(InputManagerPlugin::<Action>::default())
         // Spawn an entity with Player, InputMap, and ActionState components
-        .add_startup_system(spawn_player)
+        .add_systems(Startup, spawn_player)
         // Read the ActionState in your systems using queries!
-        .add_system(move_player)
+        .add_systems(Update, move_player)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Move,
     Throttle,

--- a/examples/binding_menu.rs
+++ b/examples/binding_menu.rs
@@ -22,13 +22,18 @@ fn main() {
     App::new()
         .insert_resource(ControlSettings::default())
         .add_plugins(DefaultPlugins)
-        .add_plugin(EguiPlugin)
-        .add_plugin(InputManagerPlugin::<ControlAction>::default())
-        .add_plugin(InputManagerPlugin::<UiAction>::default())
-        .add_startup_system(spawn_player_system)
-        .add_system(controls_window_system)
-        .add_system(buttons_system)
-        .add_system(binding_window_system)
+        .add_plugins(EguiPlugin)
+        .add_plugins(InputManagerPlugin::<ControlAction>::default())
+        .add_plugins(InputManagerPlugin::<UiAction>::default())
+        .add_systems(Startup, spawn_player_system)
+        .add_systems(
+            Update,
+            (
+                controls_window_system,
+                buttons_system,
+                binding_window_system,
+            ),
+        )
         .run();
 }
 
@@ -183,7 +188,7 @@ fn binding_window_system(
         });
 }
 
-#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Display)]
+#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Display, Reflect)]
 pub(crate) enum ControlAction {
     // Movement
     Forward,
@@ -199,7 +204,7 @@ pub(crate) enum ControlAction {
     Ultimate,
 }
 
-#[derive(Actionlike, Debug, PartialEq, Clone, Copy)]
+#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Reflect)]
 pub(crate) enum UiAction {
     Back,
 }
@@ -221,7 +226,7 @@ impl Default for ControlSettings {
             .insert(MouseButton::Left, ControlAction::BaseAttack)
             .insert(KeyCode::Q, ControlAction::Ability1)
             .insert(KeyCode::E, ControlAction::Ability2)
-            .insert(KeyCode::LShift, ControlAction::Ability3)
+            .insert(KeyCode::ShiftLeft, ControlAction::Ability3)
             .insert(KeyCode::R, ControlAction::Ultimate);
         Self { input }
     }

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -10,15 +10,15 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<TestAction>::default())
-        .add_startup_system(spawn_input_map)
-        .add_system(report_pressed_actions)
+        .add_plugins(InputManagerPlugin::<TestAction>::default())
+        .add_systems(Startup, spawn_input_map)
+        .add_systems(Update, report_pressed_actions)
         // Change the value of this resource to change how clashes should be handled in your game
         .insert_resource(ClashStrategy::PrioritizeLongest)
         .run()
 }
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 enum TestAction {
     One,
     Two,

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -9,7 +9,7 @@ use menu_mocking::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<MenuAction>::default())
+        .add_plugins(InputManagerPlugin::<MenuAction>::default())
         .init_resource::<ActionState<MenuAction>>()
         .insert_resource(InputMap::<MenuAction>::new([
             (KeyCode::Escape, MenuAction::CloseWindow),
@@ -18,18 +18,18 @@ fn main() {
         ]))
         .init_resource::<MainMenu>()
         .init_resource::<SubMenu>()
-        .add_system(report_menus)
-        .add_system(open_main_menu)
-        .add_system(open_sub_menu)
+        .add_systems(Update, report_menus)
+        .add_systems(Update, open_main_menu)
+        .add_systems(Update, open_sub_menu)
         // We want to ensure that if both the main menu and submenu are open
         // only the submenu is closed if the user hits (or holds) Escape
-        .add_system(close_menu::<SubMenu>.before(close_menu::<MainMenu>))
+        .add_systems(Update, close_menu::<SubMenu>.before(close_menu::<MainMenu>))
         // We can do this by ordering our systems and using `ActionState::consume`
-        .add_system(close_menu::<MainMenu>)
+        .add_systems(Update, close_menu::<MainMenu>)
         .run()
 }
 
-#[derive(Actionlike, Debug, Clone)]
+#[derive(Actionlike, Debug, Clone, Reflect)]
 enum MenuAction {
     CloseWindow,
     OpenMainMenu,

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -6,16 +6,16 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
-        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_plugins(InputManagerPlugin::<Action>::default())
         // The InputMap and ActionState components will be added to any entity with the Player component
-        .add_startup_system(spawn_player)
+        .add_systems(Startup, spawn_player)
         // Read the ActionState in your systems using queries!
-        .add_system(jump)
+        .add_systems(Update, jump)
         .run();
 }
 
 // This is the list of "things in the game I want to be able to do based on input"
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Run,
     Jump,

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -4,13 +4,13 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<CameraMovement>::default())
-        .add_startup_system(setup)
-        .add_system(pan_camera)
+        .add_plugins(InputManagerPlugin::<CameraMovement>::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, pan_camera)
         .run()
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
 enum CameraMovement {
     Pan,
 }

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -6,23 +6,23 @@ use leafwing_input_manager::{
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<BoxMovement>::default())
-        .add_startup_system(setup)
-        .add_system(
+        .add_plugins(InputManagerPlugin::<BoxMovement>::default())
+        .add_systems(Startup, setup)
+        .add_systems(
+            Startup,
             update_cursor_state_from_window
                 .run_if(run_if_enabled::<BoxMovement>)
-                .in_base_set(CoreSet::PreUpdate)
                 .in_set(InputManagerSystem::ManualControl)
                 .before(InputManagerSystem::ReleaseOnDisable)
                 .after(InputManagerSystem::Tick)
                 .after(InputManagerSystem::Update)
                 .after(InputSystem),
         )
-        .add_system(pan_camera)
+        .add_systems(Update, pan_camera)
         .run();
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
 enum BoxMovement {
     MousePosition,
 }
@@ -59,9 +59,8 @@ fn update_cursor_state_from_window(
                 .expect("Entity does not exist, or does not have an `ActionState` component");
 
             if let Some(val) = window.cursor_position() {
-                action_state
-                    .action_data_mut(driver.action.clone())
-                    .axis_pair = Some(DualAxisData::from_xy(val));
+                action_state.action_data_mut(driver.action).axis_pair =
+                    Some(DualAxisData::from_xy(val));
             }
         }
     }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -4,14 +4,14 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<CameraMovement>::default())
-        .add_startup_system(setup)
-        .add_system(zoom_camera)
-        .add_system(pan_camera.after(zoom_camera))
+        .add_plugins(InputManagerPlugin::<CameraMovement>::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, zoom_camera)
+        .add_systems(Update, pan_camera.after(zoom_camera))
         .run()
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
 enum CameraMovement {
     Zoom,
     PanLeft,

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -4,12 +4,12 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<Action>::default())
-        .add_startup_system(spawn_players)
+        .add_plugins(InputManagerPlugin::<Action>::default())
+        .add_systems(Startup, spawn_players)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Left,
     Right,
@@ -25,7 +25,6 @@ enum Player {
 #[derive(Bundle)]
 struct PlayerBundle {
     player: Player,
-    #[bundle]
     input_manager: InputManagerBundle<Action>,
 }
 

--- a/examples/physical_key_bindings.rs
+++ b/examples/physical_key_bindings.rs
@@ -17,16 +17,16 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_plugins(InputManagerPlugin::<Action>::default())
         // The InputMap and ActionState components will be added to any entity with the Player component
-        .add_startup_system(spawn_player)
+        .add_systems(Startup, spawn_player)
         // Read the ActionState in your systems using queries!
-        .add_system(jump)
+        .add_systems(Update, jump)
         .run();
 }
 
 // This is the list of "things in the game I want to be able to do based on input"
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Forward,
     Left,

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -38,7 +38,6 @@ pub struct Player;
 struct PlayerBundle {
     player: Player,
     velocity: Velocity,
-    #[bundle()]
     input_manager: InputManagerBundle<Action>,
     sprite: SpriteBundle,
 }

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -9,18 +9,18 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<Action>::default())
-        .add_startup_system(spawn_player)
-        .add_startup_system(spawn_camera)
+        .add_plugins(InputManagerPlugin::<Action>::default())
+        .add_systems(Startup, spawn_player)
+        .add_systems(Startup, spawn_camera)
         // This is where the interesting stuff is!
-        .add_system(hold_dash)
-        .add_system(apply_velocity)
-        .add_system(drag)
-        .add_system(wall_collisions)
+        .add_systems(Update, hold_dash)
+        .add_systems(Update, apply_velocity)
+        .add_systems(Update, drag)
+        .add_systems(Update, wall_collisions)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Left,
     Right,
@@ -38,9 +38,8 @@ pub struct Player;
 struct PlayerBundle {
     player: Player,
     velocity: Velocity,
-    #[bundle]
+    #[bundle()]
     input_manager: InputManagerBundle<Action>,
-    #[bundle]
     sprite: SpriteBundle,
 }
 

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -7,20 +7,20 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
-        .add_plugin(InputManagerPlugin::<ArpgAction>::default())
+        .add_plugins(InputManagerPlugin::<ArpgAction>::default())
         // The InputMap and ActionState components will be added to any entity with the Player component
-        .add_startup_system(spawn_player)
+        .add_systems(Startup, spawn_player)
         // The ActionState can be used directly
-        .add_system(cast_fireball)
+        .add_systems(Update, cast_fireball)
         // Or multiple parts of it can be inspected
-        .add_system(player_dash)
+        .add_systems(Update, player_dash)
         // Or it can be used to emit events for later processing
         .add_event::<PlayerWalk>()
-        .add_system(player_walks)
+        .add_systems(Update, player_walks)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum ArpgAction {
     // Movement
     Up,
@@ -63,7 +63,6 @@ struct PlayerBundle {
     player: Player,
     // This bundle must be added to your player entity
     // (or whatever else you wish to control)
-    #[bundle]
     input_manager: InputManagerBundle<ArpgAction>,
 }
 
@@ -152,6 +151,7 @@ fn player_dash(query: Query<&ActionState<ArpgAction>, With<Player>>) {
     }
 }
 
+#[derive(Event)]
 pub struct PlayerWalk {
     pub direction: Direction,
 }

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -6,15 +6,15 @@ use leafwing_input_manager::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(InputManagerPlugin::<Action>::default())
-        .add_startup_system(spawn_player)
-        .add_startup_system(spawn_cameras)
-        .add_startup_system(spawn_ui.in_base_set(StartupSet::PostStartup))
-        .add_system(move_player)
+        .add_plugins(InputManagerPlugin::<Action>::default())
+        .add_systems(Startup, spawn_player)
+        .add_systems(Startup, spawn_cameras)
+        .add_systems(PostStartup, spawn_ui)
+        .add_systems(Update, move_player)
         .run();
 }
 
-#[derive(Actionlike, Component, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, Component, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Left,
     Right,
@@ -58,7 +58,8 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
     let left_button = commands
         .spawn(ButtonBundle {
             style: Style {
-                size: Size::new(Val::Px(150.0), Val::Px(150.0)),
+                width: Val::Px(150.0),
+                height: Val::Px(150.0),
                 ..Default::default()
             },
             background_color: Color::RED.into(),
@@ -75,7 +76,8 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
     let right_button = commands
         .spawn(ButtonBundle {
             style: Style {
-                size: Size::new(Val::Px(150.0), Val::Px(150.0)),
+                width: Val::Px(150.0),
+                height: Val::Px(150.0),
                 ..Default::default()
             },
             background_color: Color::BLUE.into(),
@@ -91,7 +93,8 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
     commands
         .spawn(NodeBundle {
             style: Style {
-                size: Size::new(Val::Percent(100.0), Val::Percent(100.0)),
+                width: Val::Percent(100.0),
+                height: Val::Percent(100.0),
                 justify_content: JustifyContent::SpaceBetween,
                 ..Default::default()
             },

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -6,15 +6,15 @@ fn main() {
         .add_plugins(DefaultPlugins)
         // This plugin maps inputs to an input-type agnostic action-state
         // We need to provide it with an enum which stores the possible actions a player could take
-        .add_plugin(InputManagerPlugin::<Action>::default())
+        .add_plugins(InputManagerPlugin::<Action>::default())
         // Spawn an entity with Player, InputMap, and ActionState components
-        .add_startup_system(spawn_player)
+        .add_systems(Startup, spawn_player)
         // Read the ActionState in your systems using queries!
-        .add_system(move_player)
+        .add_systems(Update, move_player)
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 enum Action {
     Move,
 }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -4,8 +4,8 @@ use crate::Actionlike;
 use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 
 use bevy::ecs::{component::Component, entity::Entity};
-use bevy::prelude::Resource;
-use bevy::reflect::{FromReflect, Reflect};
+use bevy::prelude::{Event, Resource};
+use bevy::reflect::Reflect;
 use bevy::utils::hashbrown::hash_set::Iter;
 use bevy::utils::{Duration, HashSet, Instant};
 use serde::{Deserialize, Serialize};
@@ -15,7 +15,7 @@ use std::marker::PhantomData;
 /// Metadata about an [`Actionlike`] action
 ///
 /// If a button is released, its `reasons_pressed` should be empty.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Reflect, FromReflect)]
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Reflect)]
 pub struct ActionData {
     /// Is the action pressed or released?
     pub state: ButtonState,
@@ -43,10 +43,11 @@ pub struct ActionData {
 ///
 /// # Example
 /// ```rust
+/// use bevy::reflect::Reflect;
 /// use leafwing_input_manager::prelude::*;
 /// use bevy::utils::Instant;
 ///
-/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Debug)]
+/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Debug, Reflect)]
 /// enum Action {
 ///     Left,
 ///     Right,
@@ -81,9 +82,7 @@ pub struct ActionData {
 /// assert!(action_state.released(Action::Jump));
 /// assert!(!action_state.just_released(Action::Jump));
 /// ```
-#[derive(
-    Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect, FromReflect,
-)]
+#[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
 pub struct ActionState<A: Actionlike> {
     /// The [`ActionData`] of each action
     ///
@@ -123,11 +122,12 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
+    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     /// use leafwing_input_manager::buttonlike::ButtonState;
     /// use bevy::utils::Instant;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -177,9 +177,10 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
+    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -202,9 +203,10 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
+    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -289,15 +291,16 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
+    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum AbilitySlot {
     ///     Slot1,
     ///     Slot2,
     /// }
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -366,9 +369,10 @@ impl<A: Actionlike> ActionState<A> {
     /// # Example
     ///
     /// ```rust
+    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     /// enum Action {
     ///     Eat,
     ///     Sleep,
@@ -518,7 +522,7 @@ impl<A: Actionlike> Default for ActionState<A> {
 /// use bevy::prelude::*;
 /// use leafwing_input_manager::prelude::*;
 ///
-/// #[derive(Actionlike, Clone, Copy)]
+/// #[derive(Actionlike, Clone, Copy, Reflect)]
 /// enum DanceDance {
 ///     Left,
 ///     Right,
@@ -702,7 +706,7 @@ impl<'a> Iterator for ActionStateDriverTargetIterator<'a> {
 ///
 /// This struct is principally used as a field on [`ActionData`],
 /// which itself lives inside an [`ActionState`].
-#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Reflect, FromReflect)]
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize, Deserialize, Reflect)]
 pub struct Timing {
     /// The [`Instant`] at which the button was pressed or released
     /// Recorded as the [`Time`](bevy::time::Time) at the start of the tick after the state last changed.
@@ -754,7 +758,7 @@ impl Timing {
 ///
 /// `ID` should be a component type that stores a unique stable identifier for the entity
 /// that stores the corresponding [`ActionState`].
-#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize, Event)]
 pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
     /// The action was pressed
     Pressed {
@@ -776,12 +780,12 @@ pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
 mod tests {
     use crate as leafwing_input_manager;
     use crate::input_mocking::MockInput;
-    use bevy::prelude::Entity;
+    use bevy::prelude::{Entity, Reflect};
     use leafwing_input_manager_macros::Actionlike;
 
     use super::ActionStateDriverTarget;
 
-    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
+    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
     enum Action {
         Run,
         Jump,
@@ -799,7 +803,7 @@ mod tests {
         use bevy::utils::{Duration, Instant};
 
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         // Action state
         let mut action_state = ActionState::<Action>::default();

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -9,7 +9,7 @@ use bevy::input::{
     keyboard::KeyCode,
 };
 use bevy::math::Vec2;
-use bevy::reflect::{FromReflect, Reflect};
+use bevy::reflect::Reflect;
 use bevy::utils::FloatOrd;
 use serde::{Deserialize, Serialize};
 
@@ -574,7 +574,7 @@ pub struct AxisConversionError;
 ///
 /// This struct should store the processed form of your raw inputs in a device-agnostic fashion.
 /// Any deadzone correction, rescaling or drift-correction should be done at an earlier level.
-#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize, Reflect, FromReflect)]
+#[derive(Debug, Copy, Clone, PartialEq, Default, Deserialize, Serialize, Reflect)]
 pub struct DualAxisData {
     xy: Vec2,
 }

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -1,15 +1,13 @@
 //! Tools for working with button-like user inputs (mouse clicks, gamepad button, keyboard inputs and so on)
 //!
-use bevy::reflect::{FromReflect, Reflect};
+use bevy::reflect::Reflect;
 use serde::{Deserialize, Serialize};
 
 /// The current state of a particular button,
 /// usually corresponding to a single [`Actionlike`](crate::Actionlike) action.
 ///
 /// By default, buttons are [`ButtonState::Released`].
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, FromReflect, Default,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect, Default)]
 pub enum ButtonState {
     /// The button was pressed since the most recent tick
     JustPressed,

--- a/src/dynamic_action.rs
+++ b/src/dynamic_action.rs
@@ -33,13 +33,14 @@
 //! // In crate `top_level_crate`, which depends on `feature_one` and `feature_two`
 //! let mut app = App::new();
 //! app.insert_resource(DynActionRegistry::get().unwrap())
-//!     .add_plugin(FeatureOnePlugin)
-//!     .add_plugin(FeatureTwoPlugin);
+//!     .add_plugins(FeatureOnePlugin)
+//!     .add_plugins(FeatureTwoPlugin);
 //! app.world.remove_resource::<DynActionRegistry>().unwrap().finish();
 //! ```
 
 use std::any::TypeId;
 
+use bevy::reflect::TypePath;
 use bevy::{
     prelude::{App, Resource},
     utils::HashMap,
@@ -58,7 +59,7 @@ static DYN_ACTION_MAP: OnceCell<HashMap<TypeId, usize>> = OnceCell::new();
 static REGISTRY_CREATED: OnceCell<()> = OnceCell::new();
 
 /// The runtime representation of actions declared via marker types
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, TypePath)]
 pub struct DynAction(usize);
 
 /// Coordinates the registration of dynamic action types

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -44,7 +44,7 @@ use std::marker::PhantomData;
 ///
 /// // You can Run!
 /// // But you can't Hide :(
-/// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
+/// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 /// enum Action {
 ///     Run,
 ///     Hide,
@@ -62,7 +62,7 @@ use std::marker::PhantomData;
 ///
 /// // Insertion
 /// input_map.insert(MouseButton::Left, Action::Run)
-/// .insert(KeyCode::LShift, Action::Run)
+/// .insert(KeyCode::ShiftLeft, Action::Run)
 /// // Chords
 /// .insert_modified(Modifier::Control, KeyCode::R, Action::Run)
 /// .insert_chord([InputKind::Keyboard(KeyCode::H),
@@ -104,15 +104,16 @@ impl<A: Actionlike> InputMap<A> {
     /// use leafwing_input_manager::input_map::InputMap;
     /// use leafwing_input_manager::Actionlike;
     /// use bevy::input::keyboard::KeyCode;
+    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
     /// }
     ///
     /// let input_map = InputMap::new([
-    ///     (KeyCode::LShift, Action::Run),
+    ///     (KeyCode::ShiftLeft, Action::Run),
     ///     (KeyCode::Space, Action::Jump),
     /// ]);
     ///
@@ -141,8 +142,9 @@ impl<A: Actionlike> InputMap<A> {
     /// use leafwing_input_manager::prelude::*;
 
     /// use bevy::input::keyboard::KeyCode;
+    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -477,8 +479,9 @@ impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A> {
     /// use bevy::input::keyboard::KeyCode;
     ///
     /// use std::collections::HashMap;
+    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -486,7 +489,7 @@ impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A> {
     /// let mut map: HashMap<Action, Vec<UserInput>> = HashMap::default();
     /// map.insert(
     ///     Action::Run,
-    ///     vec![KeyCode::LShift.into(), KeyCode::RShift.into()],
+    ///     vec![KeyCode::ShiftLeft.into(), KeyCode::ShiftRight.into()],
     /// );
     /// let input_map = InputMap::from(map);
     /// ```
@@ -593,13 +596,25 @@ where
 }
 
 mod tests {
+    use bevy::prelude::Reflect;
     use serde::{Deserialize, Serialize};
 
     use crate as leafwing_input_manager;
     use crate::prelude::*;
 
     #[derive(
-        Actionlike, Serialize, Deserialize, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug,
+        Actionlike,
+        Serialize,
+        Deserialize,
+        Clone,
+        Copy,
+        PartialEq,
+        Eq,
+        PartialOrd,
+        Ord,
+        Hash,
+        Debug,
+        Reflect,
     )]
     enum Action {
         Run,
@@ -679,7 +694,7 @@ mod tests {
 
         // Remove input at existing index
         input_map.insert(KeyCode::Space, Action::Run);
-        input_map.insert(KeyCode::LShift, Action::Run);
+        input_map.insert(KeyCode::ShiftLeft, Action::Run);
         assert!(input_map.remove_at(Action::Run, 1));
         assert!(
             !input_map.remove_at(Action::Run, 1),
@@ -698,8 +713,8 @@ mod tests {
 
         let mut input_map = InputMap::default();
         let mut default_keyboard_map = InputMap::default();
-        default_keyboard_map.insert(KeyCode::LShift, Action::Run);
-        default_keyboard_map.insert_chord([KeyCode::LControl, KeyCode::H], Action::Hide);
+        default_keyboard_map.insert(KeyCode::ShiftLeft, Action::Run);
+        default_keyboard_map.insert_chord([KeyCode::ControlLeft, KeyCode::H], Action::Hide);
         let mut default_gamepad_map = InputMap::default();
         default_gamepad_map.insert(GamepadButtonType::South, Action::Run);
         default_gamepad_map.insert(GamepadButtonType::East, Action::Hide);
@@ -740,14 +755,14 @@ mod tests {
         map.insert(Action::Jump, vec![UserInput::from(KeyCode::Space)]);
         map.insert(
             Action::Run,
-            vec![KeyCode::LShift.into(), KeyCode::RShift.into()],
+            vec![KeyCode::ShiftLeft.into(), KeyCode::ShiftRight.into()],
         );
 
         let mut input_map = InputMap::default();
         input_map.insert_chord(vec![KeyCode::R, KeyCode::E], Action::Hide);
         input_map.insert(KeyCode::Space, Action::Jump);
-        input_map.insert(KeyCode::LShift, Action::Run);
-        input_map.insert(KeyCode::RShift, Action::Run);
+        input_map.insert(KeyCode::ShiftLeft, Action::Run);
+        input_map.insert(KeyCode::ShiftRight, Action::Run);
 
         assert_eq!(input_map, map.into());
     }
@@ -761,8 +776,8 @@ mod tests {
         let mut input_map = InputMap::default();
         input_map.insert_chord(vec![KeyCode::R, KeyCode::E], Action::Hide);
         input_map.insert(KeyCode::Space, Action::Jump);
-        input_map.insert(KeyCode::LShift, Action::Run);
-        input_map.insert(KeyCode::RShift, Action::Run);
+        input_map.insert(KeyCode::ShiftLeft, Action::Run);
+        input_map.insert(KeyCode::ShiftRight, Action::Run);
 
         assert_tokens(
             &input_map,
@@ -788,7 +803,7 @@ mod tests {
                 },
                 Token::UnitVariant {
                     name: "KeyCode",
-                    variant: "LShift",
+                    variant: "ShiftLeft",
                 },
                 Token::NewtypeVariant {
                     name: "UserInput",
@@ -800,7 +815,7 @@ mod tests {
                 },
                 Token::UnitVariant {
                     name: "KeyCode",
-                    variant: "RShift",
+                    variant: "ShiftRight",
                 },
                 Token::SeqEnd,
                 Token::UnitVariant {

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -132,13 +132,13 @@ pub trait MockInput {
 
     /// Presses all `bevy::ui` buttons with the matching `Marker` component
     ///
-    /// Changes their [`Interaction`] component to [`Interaction::Clicked`]
+    /// Changes their [`Interaction`] component to [`Interaction::Pressed`]
     #[cfg(feature = "ui")]
     fn click_button<Marker: Component>(&mut self);
 
     /// Hovers over all `bevy::ui` buttons with the matching `Marker` component
     ///
-    /// Changes their [`Interaction`] component to [`Interaction::Clicked`]
+    /// Changes their [`Interaction`] component to [`Interaction::Pressed`]
     #[cfg(feature = "ui")]
     fn hover_button<Marker: Component>(&mut self);
 }

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -29,6 +29,7 @@ use bevy::input::{
     Input,
 };
 use bevy::math::Vec2;
+use bevy::prelude::Entity;
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;
 use bevy::window::CursorMoved;
@@ -46,7 +47,7 @@ use bevy::window::CursorMoved;
 ///
 /// // Remember to add InputPlugin so the resources will be there!
 /// let mut app = App::new();
-/// app.add_plugin(InputPlugin);
+/// app.add_plugins(InputPlugin);
 ///
 /// // Pay respects!
 /// app.send_input(KeyCode::F);
@@ -59,7 +60,7 @@ use bevy::window::CursorMoved;
 /// use leafwing_input_manager::{input_mocking::MockInput, user_input::UserInput};
 ///
 /// let mut app = App::new();
-/// app.add_plugin(InputPlugin);
+/// app.add_plugins(InputPlugin);
 ///
 /// // Send inputs one at a time
 /// let B_E_V_Y = [KeyCode::B, KeyCode::E, KeyCode::V, KeyCode::Y];
@@ -158,6 +159,7 @@ impl MockInput for MutableInputStreams<'_> {
                 scan_code: u32::MAX,
                 key_code: Some(button),
                 state: ButtonState::Pressed,
+                window: Entity::PLACEHOLDER,
             });
         }
 
@@ -166,6 +168,7 @@ impl MockInput for MutableInputStreams<'_> {
             self.mouse_button_events.send(MouseButtonInput {
                 button,
                 state: ButtonState::Pressed,
+                window: Entity::PLACEHOLDER,
             });
         }
 
@@ -176,21 +179,25 @@ impl MockInput for MutableInputStreams<'_> {
                     unit: MouseScrollUnit::Pixel,
                     x: -1.0,
                     y: 0.0,
+                    window: Entity::PLACEHOLDER,
                 }),
                 MouseWheelDirection::Right => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 1.0,
                     y: 0.0,
+                    window: Entity::PLACEHOLDER,
                 }),
                 MouseWheelDirection::Up => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: 1.0,
+                    window: Entity::PLACEHOLDER,
                 }),
                 MouseWheelDirection::Down => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: -1.0,
+                    window: Entity::PLACEHOLDER,
                 }),
             }
         }
@@ -246,11 +253,13 @@ impl MockInput for MutableInputStreams<'_> {
                                 unit: MouseScrollUnit::Pixel,
                                 x: position_data,
                                 y: 0.0,
+                                window: Entity::PLACEHOLDER,
                             }),
                             MouseWheelAxisType::Y => self.mouse_wheel.send(MouseWheel {
                                 unit: MouseScrollUnit::Pixel,
                                 x: 0.0,
                                 y: position_data,
+                                window: Entity::PLACEHOLDER,
                             }),
                         }
                     }
@@ -299,6 +308,7 @@ impl MockInput for MutableInputStreams<'_> {
                 scan_code: u32::MAX,
                 key_code: Some(button),
                 state: ButtonState::Released,
+                window: Entity::PLACEHOLDER,
             });
         }
 
@@ -306,6 +316,7 @@ impl MockInput for MutableInputStreams<'_> {
             self.mouse_button_events.send(MouseButtonInput {
                 button,
                 state: ButtonState::Released,
+                window: Entity::PLACEHOLDER,
             });
         }
     }
@@ -429,7 +440,7 @@ impl MockInput for World {
         let mut button_query = self.query_filtered::<&mut Interaction, With<Marker>>();
 
         for mut interaction in button_query.iter_mut(self) {
-            *interaction = Interaction::Clicked;
+            *interaction = Interaction::Pressed;
         }
     }
 
@@ -497,7 +508,7 @@ mod test {
     #[test]
     fn ordinary_button_inputs() {
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         // Test that buttons are unpressed by default
         assert!(!app.pressed(KeyCode::Space));
@@ -527,7 +538,7 @@ mod test {
     #[test]
     fn explicit_gamepad_button_inputs() {
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         let gamepad = Gamepad { id: 0 };
         let mut gamepad_events = app.world.resource_mut::<Events<GamepadEvent>>();
@@ -567,7 +578,7 @@ mod test {
     #[test]
     fn implicit_gamepad_button_inputs() {
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         let gamepad = Gamepad { id: 0 };
         let mut gamepad_events = app.world.resource_mut::<Events<GamepadEvent>>();
@@ -606,7 +617,7 @@ mod test {
         struct ButtonMarker;
 
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         // Marked button
         app.world.spawn((Interaction::None, ButtonMarker));
@@ -620,7 +631,7 @@ mod test {
         let mut interaction_query = app.world.query::<(&Interaction, Option<&ButtonMarker>)>();
         for (interaction, maybe_marker) in interaction_query.iter(&app.world) {
             match maybe_marker {
-                Some(_) => assert_eq!(*interaction, Interaction::Clicked),
+                Some(_) => assert_eq!(*interaction, Interaction::Pressed),
                 None => assert_eq!(*interaction, Interaction::None),
             }
         }

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -545,12 +545,12 @@ mod tests {
     fn modifier_key_triggered_by_either_input() {
         use crate::user_input::Modifier;
         let mut app = App::new();
-        app.add_plugin(InputPlugin);
+        app.add_plugins(InputPlugin);
 
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(!input_streams.pressed(Modifier::Control));
 
-        input_streams.send_input(KeyCode::LControl);
+        input_streams.send_input(KeyCode::ControlLeft);
         app.update();
 
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
@@ -562,7 +562,7 @@ mod tests {
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(!input_streams.pressed(Modifier::Control));
 
-        input_streams.send_input(KeyCode::RControl);
+        input_streams.send_input(KeyCode::ControlRight);
         app.update();
 
         let input_streams = MutableInputStreams::from_world(&mut app.world, None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@
 use crate::action_state::ActionState;
 use crate::input_map::InputMap;
 use bevy::ecs::prelude::*;
+use bevy::reflect::TypePath;
 use std::marker::PhantomData;
 
 pub mod action_state;
@@ -59,9 +60,10 @@ pub mod prelude {
 ///
 /// # Example
 /// ```rust
+/// use bevy::prelude::Reflect;
 /// use leafwing_input_manager::Actionlike;
 ///
-/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash)]
+/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Reflect)]
 /// enum PlayerAction {
 ///    // Movement
 ///    Up,
@@ -76,7 +78,7 @@ pub mod prelude {
 ///    Ultimate,
 /// }
 /// ```
-pub trait Actionlike: Send + Sync + Clone + 'static {
+pub trait Actionlike: Send + Sync + Clone + TypePath + 'static {
     /// The number of variants of this action type
     fn n_variants() -> usize;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -31,7 +31,7 @@ use bevy::ui::UiSystem;
 /// All systems added by this plugin can be dynamically enabled and disabled by setting the value of the [`ToggleActions<A>`] resource is set.
 /// This can be useful when working with states to pause the game, navigate menus or so on.
 ///
-/// **WARNING:** These systems run during [`CoreSet::PreUpdate`].
+/// **WARNING:** These systems run during [`PreUpdate`].
 /// If you have systems that care about inputs and actions that also run during this stage,
 /// you must define an ordering between your systems or behavior will be very erratic.
 /// The stable system sets for these systems are available under [`InputManagerSystem`] enum.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -10,7 +10,7 @@ use std::fmt::Debug;
 use bevy::app::{App, Plugin};
 use bevy::ecs::prelude::*;
 use bevy::input::InputSystem;
-use bevy::prelude::CoreSet;
+use bevy::prelude::{PostUpdate, PreUpdate};
 #[cfg(feature = "ui")]
 use bevy::ui::UiSystem;
 
@@ -85,44 +85,44 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
 
         match self.machine {
             Machine::Client => {
-                app.add_system(
+                app.add_systems(
+                    PreUpdate,
                     tick_action_state::<A>
                         .run_if(run_if_enabled::<A>)
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::Tick)
                         .before(InputManagerSystem::Update),
                 )
-                .add_system(
+                .add_systems(
+                    PreUpdate,
                     release_on_disable::<A>
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::ReleaseOnDisable)
                         .after(InputManagerSystem::Update),
                 )
-                .add_system(release_on_input_map_removed::<A>.in_base_set(CoreSet::PostUpdate));
+                .add_systems(PostUpdate, release_on_input_map_removed::<A>);
 
                 #[cfg(feature = "egui")]
-                app.add_system(
+                app.add_systems(
+                    PreUpdate,
                     update_action_state::<A>
                         .run_if(run_if_enabled::<A>)
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::Update)
                         .after(InputSystem)
                         .after(bevy_egui::EguiSet::ProcessInput),
                 );
                 #[cfg(not(feature = "egui"))]
-                app.add_system(
+                app.add_systems(
+                    PreUpdate,
                     update_action_state::<A>
                         .run_if(run_if_enabled::<A>)
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::Update)
                         .after(InputSystem),
                 );
 
                 #[cfg(feature = "ui")]
-                app.add_system(
+                app.add_systems(
+                    PreUpdate,
                     update_action_state_from_interaction::<A>
                         .run_if(run_if_enabled::<A>)
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::ManualControl)
                         .before(InputManagerSystem::ReleaseOnDisable)
                         .after(InputManagerSystem::Tick)
@@ -134,10 +134,10 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                 );
             }
             Machine::Server => {
-                app.add_system(
+                app.add_systems(
+                    PreUpdate,
                     tick_action_state::<A>
                         .run_if(run_if_enabled::<A>)
-                        .in_base_set(CoreSet::PreUpdate)
                         .in_set(InputManagerSystem::Tick),
                 );
             }

--- a/src/press_scheduler.rs
+++ b/src/press_scheduler.rs
@@ -1,7 +1,7 @@
 //! This module contains [`PressScheduler`] and its supporting methods and impls.
 //!
 //! The [`PressScheduler`] is an optional addition to an [`InputManagerBundle`](crate::InputManagerBundle),
-//! which allows for a system that runs in [`CoreSet::Update`] later to correctly press an action.
+//! which allows for a system that runs in [`Update`] later to correctly press an action.
 //! Directly using [`ActionState::press`] would not work, as inputs submitted late would be wiped out by the input manager systems.
 //! With this type, the action is pressed on the next time said systems run, making it so other systems can react to it correctly.
 

--- a/src/scan_codes/linux.rs
+++ b/src/scan_codes/linux.rs
@@ -57,13 +57,13 @@ pub enum QwertyScanCode {
     /// The location of the `P`  key on the QWERTY keyboard layout.
     P = 25,
     /// The location of the `[`  key on the QWERTY keyboard layout.
-    LBracket = 26,
+    BracketLeft = 26,
     /// The location of the `]`  key on the QWERTY keyboard layout.
-    RBracket = 27,
+    BracketRight = 27,
     /// The location of the Enter/Return key on the QWERTY keyboard layout.
     Enter = 28,
     /// The location of the left Control key on the QWERTY keyboard layout.
-    LControl = 29,
+    ControlLeft = 29,
     /// The location of the `A`  key on the QWERTY keyboard layout.
     A = 30,
     /// The location of the `S`  key on the QWERTY keyboard layout.
@@ -89,7 +89,7 @@ pub enum QwertyScanCode {
     /// The location of the `` ` `` key on the QWERTY keyboard layout.
     Backtick = 41,
     /// The location of the left Shift key on the QWERTY keyboard layout.
-    LShift = 42,
+    ShiftLeft = 42,
     /// The location of the `\` on the QWERTY keyboard layout.
     Backslash = 43,
     /// The location of the `Z` key on the QWERTY keyboard layout.
@@ -113,13 +113,13 @@ pub enum QwertyScanCode {
     /// The location of the `/` key on the QWERTY keyboard layout.
     Slash = 53,
     /// The location of the right Shift key on the QWERTY keyboard layout.
-    RShift = 54,
+    ShiftRight = 54,
     /// The location of the `*` key on the numpad of the QWERTY keyboard layout.
     /// Maps to `NumpadDivide` on Apple keyboards.
     NumpadMultiply = 55,
     /// The location of the left Alt  key on the QWERTY keyboard layout.
     /// Maps to left Option key on Apple keyboards.
-    LAlt = 56,
+    AltLeft = 56,
     /// The location of the Space key on the QWERTY keyboard layout.
     Space = 57,
     /// The location of the caps lock  key on the QWERTY keyboard layout.
@@ -193,7 +193,7 @@ pub enum QwertyScanCode {
     /// The location of the Enter key on the numpad of the QWERTY keyboard layout.
     NumpadEnter = 96,
     /// The location of the right Control key on the QWERTY keyboard layout.
-    RControl = 97,
+    ControlRight = 97,
     /// The location of the `/` key on the numpad of the QWERTY keyboard layout.
     /// Maps to `NumpadEquals` on Apple keyboards.
     NumpadDivide = 98,
@@ -201,7 +201,7 @@ pub enum QwertyScanCode {
     AltSysrq = 99,
     /// The location of the right Alt key on the QWERTY keyboard layout.
     /// Maps to right Option key on Apple keyboards.
-    RAlt = 100,
+    AltRight = 100,
     // KEY_LINEFEED = 101,
     /// The location of the Home key on the QWERTY keyboard layout.
     Home = 102,
@@ -242,9 +242,9 @@ pub enum QwertyScanCode {
     // KEY_YEN = 124,
     /// The location of the left Windows key on the QWERTY keyboard layout.
     /// Maps to the Command key on Apple keyboards.
-    LWin = 125,
+    SuperLeft = 125,
     /// The location of the right Windows key on the QWERTY keyboard layout.
-    RWin = 126,
+    SuperRight = 126,
     // KEY_COMPOSE = 127,
     // KEY_STOP = 128,
     // KEY_AGAIN = 129,

--- a/src/scan_codes/mac_os.rs
+++ b/src/scan_codes/mac_os.rs
@@ -65,13 +65,13 @@ pub enum QwertyScanCode {
     /// The location of the `0` key on the QWERTY keyboard layout.
     Key0 = 0x1d,
     /// The location of the `]`  key on the QWERTY keyboard layout.
-    RBracket = 0x1e,
+    BracketRight = 0x1e,
     /// The location of the `O`  key on the QWERTY keyboard layout.
     O = 0x1f,
     /// The location of the `U`  key on the QWERTY keyboard layout.
     U = 0x20,
     /// The location of the `[`  key on the QWERTY keyboard layout.
-    LBracket = 0x21,
+    BracketLeft = 0x21,
     /// The location of the `I`  key on the QWERTY keyboard layout.
     I = 0x22,
     /// The location of the `P`  key on the QWERTY keyboard layout.
@@ -151,23 +151,23 @@ pub enum QwertyScanCode {
     Escape = 0x35,
     /// The location of the left Windows key on the QWERTY keyboard layout.
     /// Maps to the left Command key on Apple keyboards.
-    LWin = 0x37,
+    SuperLeft = 0x37,
     /// The location of the left Shift key on the QWERTY keyboard layout.
-    LShift = 0x38,
+    ShiftLeft = 0x38,
     /// The location of the Caps Lock key on the QWERTY keyboard layout.
     CapsLock = 0x39,
     /// The location of the left Alt  key on the QWERTY keyboard layout.
     /// Maps to left Option key on Apple keyboards.
-    LAlt = 0x3a,
+    AltLeft = 0x3a,
     /// The location of the left Control key on the QWERTY keyboard layout.
-    LControl = 0x3b,
+    ControlLeft = 0x3b,
     /// The location of the right Shift key on the QWERTY keyboard layout.
-    RShift = 0x3c,
+    ShiftRight = 0x3c,
     /// The location of the right Alt key on the QWERTY keyboard layout.
     /// Maps to right Option key on Apple keyboards.
-    RAlt = 0x3d,
+    AltRight = 0x3d,
     /// The location of the right Control key on the QWERTY keyboard layout.
-    RControl = 0x3e,
+    ControlRight = 0x3e,
     // This is an extra key on mac keyboards: Function = 0x3f,
     // This is an extra key on mac keyboards: F18 = 0x4f,
     // This is an extra key on mac keyboards: F19 = 0x50,
@@ -230,5 +230,5 @@ pub enum QwertyScanCode {
     // Not listed in the provided link, found by manual testing.
     /// The location of the right Windows key on the QWERTY keyboard layout.
     /// Maps to the right Command key on Apple keyboards.
-    RWin = 0x36,
+    SuperRight = 0x36,
 }

--- a/src/scan_codes/wasm.rs
+++ b/src/scan_codes/wasm.rs
@@ -87,9 +87,9 @@ pub enum QwertyScanCode {
     /// The location of the `'`  key on the QWERTY keyboard layout.
     Apostrophe = 0xde,
     /// The location of the `[`  key on the QWERTY keyboard layout.
-    LBracket = 0xdb,
+    BracketLeft = 0xdb,
     /// The location of the `]`  key on the QWERTY keyboard layout.
-    RBracket = 0xdd,
+    BracketRight = 0xdd,
     /// The location of the `` ` `` key on the QWERTY keyboard layout.
     Backtick = 0xc0,
     /// The location of the `\` on the QWERTY keyboard layout.
@@ -100,14 +100,14 @@ pub enum QwertyScanCode {
     Equals = 0xbb,
     /// The location of the left Alt  key on the QWERTY keyboard layout.
     /// Maps to left Option key on Apple keyboards.
-    LAlt = 0x12,
+    AltLeft = 0x12,
     /// The location of the right Alt key on the QWERTY keyboard layout.
     /// Maps to right Option key on Apple keyboards.
     ///
     /// On Wasm, this scan code value maps to the AltGraph key on Linux, if available.
     /// Note the platform specific details here:
     /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#non-printable_keys_function_keys>
-    RAlt = 0xe1,
+    AltRight = 0xe1,
     /// The location of the caps lock  key on the QWERTY keyboard layout.
     ///
     /// On Wasm, note the platform specific details here:
@@ -117,23 +117,23 @@ pub enum QwertyScanCode {
     ///
     /// On Wasm, the right Control key has the same scan code, see:
     /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#non-printable_keys_function_keys>
-    LControl = 0x11,
+    ControlLeft = 0x11,
     /// The location of the left Windows key on the QWERTY keyboard layout.
     /// Maps to the Command key on Apple keyboards.
     ///
     /// On Wasm, note the platform specific details here:
     /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#non-printable_keys_function_keys>
-    LWin = 0x5b,
+    SuperLeft = 0x5b,
     /// The location of the right Windows key on the QWERTY keyboard layout.
     ///
     /// On Wasm, note the platform specific details here:
     /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#non-printable_keys_function_keys>
-    RWin = 0x5c,
+    SuperRight = 0x5c,
     /// The location of the left Shift key on the QWERTY keyboard layout.
     ///
     /// On Wasm, the right Shift key has the same scan code, see:
     /// <https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode#non-printable_keys_function_keys>
-    LShift = 0x10,
+    ShiftLeft = 0x10,
 
     /// The location of the Menu key on the QWERTY keyboard layout.
     ///

--- a/src/scan_codes/windows.rs
+++ b/src/scan_codes/windows.rs
@@ -57,9 +57,9 @@ pub enum QwertyScanCode {
     /// The location of the `P`  key on the QWERTY keyboard layout.
     P = 0x19,
     /// The location of the `[`  key on the QWERTY keyboard layout.
-    LBracket = 0x1a,
+    BracketLeft = 0x1a,
     /// The location of the `]`  key on the QWERTY keyboard layout.
-    RBracket = 0x1b,
+    BracketRight = 0x1b,
     /// The location of the `\` on the QWERTY keyboard layout.
     Backslash = 0x2b,
     /// The location of the caps lock  key on the QWERTY keyboard layout.
@@ -93,7 +93,7 @@ pub enum QwertyScanCode {
     /// The location of the Enter/Return key on the QWERTY keyboard layout.
     Enter = 0x1c,
     /// The location of the left Shift key on the QWERTY keyboard layout.
-    LShift = 0x2a,
+    ShiftLeft = 0x2a,
     /// The location of the `Z` key on the QWERTY keyboard layout.
     Z = 0x2c,
     /// The location of the `X` key on the QWERTY keyboard layout.
@@ -115,19 +115,19 @@ pub enum QwertyScanCode {
     /// The location of the `/` key on the QWERTY keyboard layout.
     Slash = 0x35,
     /// The location of the right Shift key on the QWERTY keyboard layout.
-    RShift = 0x36,
+    ShiftRight = 0x36,
     /// The location of the left Control key on the QWERTY keyboard layout.
-    LControl = 0x1d,
+    ControlLeft = 0x1d,
     /// The location of the left Alt  key on the QWERTY keyboard layout.
     /// Maps to left Option key on Apple keyboards.
-    LAlt = 0x38,
+    AltLeft = 0x38,
     /// The location of the Space key on the QWERTY keyboard layout.
     Space = 0x39,
     /// The location of the right Alt key on the QWERTY keyboard layout.
     /// Maps to right Option key on Apple keyboards.
-    RAlt = 0xe0_e8,
+    AltRight = 0xe0_e8,
     /// The location of the right Control key on the QWERTY keyboard layout.
-    RControl = 0xe0_1d,
+    ControlRight = 0xe0_1d,
     /// The location of the Insert key on the QWERTY keyboard layout.
     /// Maps to the Help key on Apple keyboards.
     Insert = 0xe0_52,
@@ -228,9 +228,9 @@ pub enum QwertyScanCode {
     CtrlBreak = 0xe0_46,
     /// The location of the left Windows key on the QWERTY keyboard layout.
     /// Maps to the Command key on Apple keyboards.
-    LWin = 0xe0_5b,
+    SuperLeft = 0xe0_5b,
     /// The location of the right Windows key on the QWERTY keyboard layout.
-    RWin = 0xe0_5c,
+    SuperRight = 0xe0_5c,
     /// The location of the Menu key on the QWERTY keyboard layout.
     Menu = 0xe0_5d,
     /// The location of the Sleep key on the QWERTY keyboard layout.

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -164,7 +164,7 @@ pub fn update_action_state_from_interaction<A: Actionlike>(
     mut action_state_query: Query<&mut ActionState<A>>,
 ) {
     for (&interaction, action_state_driver) in ui_query.iter() {
-        if interaction == Interaction::Clicked {
+        if interaction == Interaction::Pressed {
             for entity in action_state_driver.targets.iter() {
                 let mut action_state = action_state_query
                     .get_mut(*entity)

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -257,8 +257,8 @@ pub fn release_on_disable<A: Actionlike>(
 
 /// Release all inputs when an [`InputMap<A>`] is removed to prevent them from being held forever.
 ///
-/// By default, [`InputManagerPlugin<A>`](crate::plugin::InputManagerPlugin) will run this on [`CoreSet::PostUpdate`](bevy::prelude::CoreSet::PostUpdate).
-/// For components you must remove the [`InputMap<A>`] before [`CoreSet::PostUpdate`](bevy::prelude::CoreSet::PostUpdate)
+/// By default, [`InputManagerPlugin<A>`](crate::plugin::InputManagerPlugin) will run this on [`PostUpdate`](bevy::prelude::PostUpdate).
+/// For components you must remove the [`InputMap<A>`] before [`PostUpdate`](bevy::prelude::PostUpdate)
 /// or this will not run.
 pub fn release_on_input_map_removed<A: Actionlike>(
     mut removed_components: RemovedComponents<InputMap<A>>,

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -93,10 +93,10 @@ impl UserInput {
     /// use bevy::utils::HashSet;
     /// use leafwing_input_manager::user_input::UserInput;
     ///
-    /// let buttons = HashSet::from_iter([LControl.into(), LAlt.into()]);
+    /// let buttons = HashSet::from_iter([ControlLeft.into(), AltLeft.into()]);
     /// let a: UserInput  = A.into();
-    /// let ctrl_a = UserInput::chord([LControl, A]);
-    /// let ctrl_alt_a = UserInput::chord([LControl, LAlt, A]);
+    /// let ctrl_a = UserInput::chord([ControlLeft, A]);
+    /// let ctrl_alt_a = UserInput::chord([ControlLeft, AltLeft, A]);
     ///
     /// assert_eq!(a.n_matching(&buttons), 0);
     /// assert_eq!(ctrl_a.n_matching(&buttons), 1);
@@ -455,13 +455,13 @@ impl From<Modifier> for InputKind {
 /// This will be decomposed into both values when converted into [`RawInputs`].
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum Modifier {
-    /// Corresponds to [`KeyCode::LAlt`] and [`KeyCode::RAlt`].
+    /// Corresponds to [`KeyCode::AltLeft`] and [`KeyCode::AltRight`].
     Alt,
-    /// Corresponds to [`KeyCode::LControl`] and [`KeyCode::RControl`].
+    /// Corresponds to [`KeyCode::ControlLeft`] and [`KeyCode::ControlRight`].
     Control,
-    /// The key that makes letters capitalized, corresponding to [`KeyCode::LShift`] and [`KeyCode::RShift`]
+    /// The key that makes letters capitalized, corresponding to [`KeyCode::ShiftLeft`] and [`KeyCode::ShiftRight`]
     Shift,
-    /// The OS or "Windows" key, corresponding to [`KeyCode::LWin`] and [`KeyCode::RWin`].
+    /// The OS or "Windows" key, corresponding to [`KeyCode::SuperLeft`] and [`KeyCode::SuperRight`].
     Win,
 }
 
@@ -472,10 +472,10 @@ impl Modifier {
     #[inline]
     pub fn key_codes(self) -> [KeyCode; 2] {
         match self {
-            Modifier::Alt => [KeyCode::LAlt, KeyCode::RAlt],
-            Modifier::Control => [KeyCode::LControl, KeyCode::RControl],
-            Modifier::Shift => [KeyCode::LShift, KeyCode::RShift],
-            Modifier::Win => [KeyCode::LWin, KeyCode::RWin],
+            Modifier::Alt => [KeyCode::AltLeft, KeyCode::AltRight],
+            Modifier::Control => [KeyCode::ControlLeft, KeyCode::ControlRight],
+            Modifier::Shift => [KeyCode::ShiftLeft, KeyCode::ShiftRight],
+            Modifier::Win => [KeyCode::SuperLeft, KeyCode::SuperRight],
         }
     }
 }
@@ -661,7 +661,7 @@ mod raw_input_tests {
 
             let input = UserInput::modified(Modifier::Control, KeyCode::S);
             let expected = RawInputs {
-                keycodes: vec![KeyCode::LControl, KeyCode::RControl, KeyCode::S],
+                keycodes: vec![KeyCode::ControlLeft, KeyCode::ControlRight, KeyCode::S],
                 ..Default::default()
             };
             let raw = input.raw_inputs();

--- a/tests/actionlike_derive.rs
+++ b/tests/actionlike_derive.rs
@@ -1,30 +1,31 @@
 //! When debugging this file, `cargo expand` is invaluable.
 //! See: https://github.com/dtolnay/cargo-expand
 //! use `cargo expand --test actionlike_derive`
+use bevy::prelude::Reflect;
 use leafwing_input_manager::Actionlike;
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 enum UnitAction {}
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 enum OneAction {
     Jump,
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 enum SimpleAction {
     Zero,
     One,
     Two,
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 enum UnnamedFieldVariantsAction {
     Run,
     Jump(usize),
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
 enum NamedFieldVariantsAction {
     Run { x: usize, y: usize },
     Jump,

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -9,13 +9,13 @@ fn test_app() -> App {
     let mut app = App::new();
 
     app.add_plugins(MinimalPlugins)
-        .add_plugin(InputPlugin)
-        .add_plugin(InputManagerPlugin::<Action>::default())
-        .add_startup_system(spawn_input_map);
+        .add_plugins(InputPlugin)
+        .add_plugins(InputManagerPlugin::<Action>::default())
+        .add_systems(Startup, spawn_input_map);
     app
 }
 
-#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]
+#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
 enum Action {
     One,
     Two,
@@ -38,9 +38,9 @@ fn spawn_input_map(mut commands: Commands) {
     input_map.insert_chord([Key1, Key2], OneAndTwo);
     input_map.insert_chord([Key2, Key3], TwoAndThree);
     input_map.insert_chord([Key1, Key2, Key3], OneAndTwoAndThree);
-    input_map.insert_chord([LControl, Key1], CtrlOne);
-    input_map.insert_chord([LAlt, Key1], AltOne);
-    input_map.insert_chord([LControl, LAlt, Key1], CtrlAltOne);
+    input_map.insert_chord([ControlLeft, Key1], CtrlOne);
+    input_map.insert_chord([AltLeft, Key1], AltOne);
+    input_map.insert_chord([ControlLeft, AltLeft, Key1], CtrlAltOne);
 
     commands.spawn(input_map);
 }
@@ -139,7 +139,7 @@ fn modifier_clash_handling() {
     app.send_input(Key1);
     app.send_input(Key2);
     app.send_input(Key3);
-    app.send_input(LControl);
+    app.send_input(ControlLeft);
     app.update();
 
     app.assert_input_map_actions_eq(
@@ -163,8 +163,8 @@ fn multiple_modifiers_clash_handling() {
     // Multiple modifiers
     app.reset_inputs();
     app.send_input(Key1);
-    app.send_input(LControl);
-    app.send_input(LAlt);
+    app.send_input(ControlLeft);
+    app.send_input(AltLeft);
     app.update();
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, CtrlOne, AltOne, CtrlAltOne]);

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::axislike::{AxisType, DualAxisData};
 use leafwing_input_manager::prelude::*;
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -14,7 +14,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum AxislikeTestAction {
     X,
     Y,
@@ -24,9 +24,9 @@ enum AxislikeTestAction {
 fn test_app() -> App {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)
-        .add_plugin(InputPlugin)
-        .add_plugin(InputManagerPlugin::<ButtonlikeTestAction>::default())
-        .add_plugin(InputManagerPlugin::<AxislikeTestAction>::default())
+        .add_plugins(InputPlugin)
+        .add_plugins(InputManagerPlugin::<ButtonlikeTestAction>::default())
+        .add_plugins(InputManagerPlugin::<AxislikeTestAction>::default())
         .init_resource::<ActionState<ButtonlikeTestAction>>()
         .init_resource::<ActionState<AxislikeTestAction>>();
 

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -6,7 +6,7 @@ use leafwing_input_manager::buttonlike::MouseMotionDirection;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::user_input::InputKind;
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -14,7 +14,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum AxislikeTestAction {
     X,
     Y,
@@ -24,9 +24,9 @@ enum AxislikeTestAction {
 fn test_app() -> App {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)
-        .add_plugin(InputPlugin)
-        .add_plugin(InputManagerPlugin::<ButtonlikeTestAction>::default())
-        .add_plugin(InputManagerPlugin::<AxislikeTestAction>::default())
+        .add_plugins(InputPlugin)
+        .add_plugins(InputManagerPlugin::<ButtonlikeTestAction>::default())
+        .add_plugins(InputManagerPlugin::<AxislikeTestAction>::default())
         .init_resource::<ActionState<ButtonlikeTestAction>>()
         .init_resource::<ActionState<AxislikeTestAction>>();
 

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::axislike::{AxisType, DualAxisData, MouseWheelAxisType};
 use leafwing_input_manager::prelude::*;
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -12,7 +12,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug)]
+#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
 enum AxislikeTestAction {
     X,
     Y,
@@ -22,9 +22,9 @@ enum AxislikeTestAction {
 fn test_app() -> App {
     let mut app = App::new();
     app.add_plugins(MinimalPlugins)
-        .add_plugin(InputPlugin)
-        .add_plugin(InputManagerPlugin::<ButtonlikeTestAction>::default())
-        .add_plugin(InputManagerPlugin::<AxislikeTestAction>::default())
+        .add_plugins(InputPlugin)
+        .add_plugins(InputManagerPlugin::<ButtonlikeTestAction>::default())
+        .add_plugins(InputManagerPlugin::<AxislikeTestAction>::default())
         .init_resource::<ActionState<ButtonlikeTestAction>>()
         .init_resource::<ActionState<AxislikeTestAction>>();
 
@@ -44,6 +44,7 @@ fn raw_mouse_wheel_events() {
         unit: MouseScrollUnit::Pixel,
         x: 0.0,
         y: 10.0,
+        window: Entity::PLACEHOLDER,
     });
 
     app.update();


### PR DESCRIPTION
The only thing I wasn't sure about is with input mocking, .11 adds a [`window`](https://docs.rs/bevy/latest/bevy/input/mouse/struct.MouseWheel.html#structfield.window) field to input events that I just populated with Entity::PLACEHOLDER when sending events because our test environment doesn't create a window so all the tests would fail trying to get a window. 