### PR TITLE
Remove Actionlike TypePath trait requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,3 +67,5 @@ harness = false
 name = "leafwing_input_manager"
 path = "src/lib.rs"
 
+[patch.crates-io]
+bevy = { git = "https://github.com/paul-hansen/bevy.git", rev = "d7ba279f"}

--- a/benches/action_state.rs
+++ b/benches/action_state.rs
@@ -1,4 +1,3 @@
-use bevy::prelude::Reflect;
 use criterion::{criterion_group, criterion_main, Criterion};
 use leafwing_input_manager::{
     action_state::{ActionData, Timing},
@@ -7,7 +6,7 @@ use leafwing_input_manager::{
     Actionlike,
 };
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum TestAction {
     A,
     B,

--- a/benches/input_map.rs
+++ b/benches/input_map.rs
@@ -1,4 +1,3 @@
-use bevy::prelude::Reflect;
 use bevy::{
     input::InputPlugin,
     prelude::{App, KeyCode},
@@ -11,7 +10,7 @@ use leafwing_input_manager::{
     Actionlike,
 };
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum TestAction {
     A,
     B,

--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -28,7 +28,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Hash, Copy, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Hash, Copy)]
 enum Slot {
     Primary,
     Secondary,
@@ -39,7 +39,7 @@ enum Slot {
 }
 
 // The list of possible abilities is typically longer than the list of slots
-#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Copy, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Debug, Copy)]
 enum Ability {
     Slash,
     Shoot,

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -14,7 +14,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Move,
     Throttle,

--- a/examples/binding_menu.rs
+++ b/examples/binding_menu.rs
@@ -188,7 +188,7 @@ fn binding_window_system(
         });
 }
 
-#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Display, Reflect)]
+#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Display)]
 pub(crate) enum ControlAction {
     // Movement
     Forward,
@@ -204,7 +204,7 @@ pub(crate) enum ControlAction {
     Ultimate,
 }
 
-#[derive(Actionlike, Debug, PartialEq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, PartialEq, Clone, Copy)]
 pub(crate) enum UiAction {
     Back,
 }

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -18,7 +18,7 @@ fn main() {
         .run()
 }
 
-#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+#[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 enum TestAction {
     One,
     Two,

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -29,7 +29,7 @@ fn main() {
         .run()
 }
 
-#[derive(Actionlike, Debug, Clone, Reflect)]
+#[derive(Actionlike, Debug, Clone)]
 enum MenuAction {
     CloseWindow,
     OpenMainMenu,

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -15,7 +15,7 @@ fn main() {
 }
 
 // This is the list of "things in the game I want to be able to do based on input"
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Run,
     Jump,

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -10,7 +10,7 @@ fn main() {
         .run()
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
 enum CameraMovement {
     Pan,
 }

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -22,7 +22,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
 enum BoxMovement {
     MousePosition,
 }

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -11,7 +11,7 @@ fn main() {
         .run()
 }
 
-#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Reflect)]
+#[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq)]
 enum CameraMovement {
     Zoom,
     PanLeft,

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -9,7 +9,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Left,
     Right,

--- a/examples/physical_key_bindings.rs
+++ b/examples/physical_key_bindings.rs
@@ -26,7 +26,7 @@ fn main() {
 }
 
 // This is the list of "things in the game I want to be able to do based on input"
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Forward,
     Left,

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -20,7 +20,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Left,
     Right,

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -15,7 +15,7 @@ use leafwing_input_manager::systems::{generate_action_diffs, process_action_diff
 
 use std::fmt::Debug;
 
-#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 enum FpsAction {
     MoveLeft,
     MoveRight,

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -20,7 +20,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum ArpgAction {
     // Movement
     Up,

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -14,7 +14,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, Component, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, Component, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Left,
     Right,

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -14,7 +14,7 @@ fn main() {
         .run();
 }
 
-#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
+#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug)]
 enum Action {
     Move,
 }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -5,7 +5,8 @@ use crate::{axislike::DualAxisData, buttonlike::ButtonState};
 
 use bevy::ecs::{component::Component, entity::Entity};
 use bevy::prelude::{Event, Resource};
-use bevy::reflect::Reflect;
+use bevy::reflect::utility::GenericTypePathCell;
+use bevy::reflect::{Reflect, TypePath};
 use bevy::utils::hashbrown::hash_set::Iter;
 use bevy::utils::{Duration, HashSet, Instant};
 use serde::{Deserialize, Serialize};
@@ -47,7 +48,7 @@ pub struct ActionData {
 /// use leafwing_input_manager::prelude::*;
 /// use bevy::utils::Instant;
 ///
-/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Debug, Reflect)]
+/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Debug)]
 /// enum Action {
 ///     Left,
 ///     Right,
@@ -83,6 +84,7 @@ pub struct ActionData {
 /// assert!(!action_state.just_released(Action::Jump));
 /// ```
 #[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
+#[reflect(type_path = false)]
 pub struct ActionState<A: Actionlike> {
     /// The [`ActionData`] of each action
     ///
@@ -90,6 +92,17 @@ pub struct ActionState<A: Actionlike> {
     action_data: Vec<ActionData>,
     #[reflect(ignore)]
     _phantom: PhantomData<A>,
+}
+
+impl<A: Actionlike> TypePath for ActionState<A> {
+    fn type_path() -> &'static str {
+        std::any::type_name::<Self>()
+    }
+
+    fn short_type_path() -> &'static str {
+        static CELL: GenericTypePathCell = GenericTypePathCell::new();
+        CELL.get_or_insert::<Self, _>(|| bevy::utils::get_short_name(std::any::type_name::<Self>()))
+    }
 }
 
 impl<A: Actionlike> ActionState<A> {
@@ -122,12 +135,11 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
-    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     /// use leafwing_input_manager::buttonlike::ButtonState;
     /// use bevy::utils::Instant;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -177,10 +189,9 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
-    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -203,10 +214,9 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
-    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -291,16 +301,15 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// # Example
     /// ```rust
-    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum AbilitySlot {
     ///     Slot1,
     ///     Slot2,
     /// }
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -369,10 +378,9 @@ impl<A: Actionlike> ActionState<A> {
     /// # Example
     ///
     /// ```rust
-    /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     /// enum Action {
     ///     Eat,
     ///     Sleep,
@@ -522,7 +530,7 @@ impl<A: Actionlike> Default for ActionState<A> {
 /// use bevy::prelude::*;
 /// use leafwing_input_manager::prelude::*;
 ///
-/// #[derive(Actionlike, Clone, Copy, Reflect)]
+/// #[derive(Actionlike, Clone, Copy)]
 /// enum DanceDance {
 ///     Left,
 ///     Right,
@@ -780,12 +788,12 @@ pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
 mod tests {
     use crate as leafwing_input_manager;
     use crate::input_mocking::MockInput;
-    use bevy::prelude::{Entity, Reflect};
+    use bevy::prelude::Entity;
     use leafwing_input_manager_macros::Actionlike;
 
     use super::ActionStateDriverTarget;
 
-    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug, Reflect)]
+    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Debug)]
     enum Action {
         Run,
         Jump,

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -408,10 +408,9 @@ mod tests {
     use crate as leafwing_input_manager;
     use bevy::app::App;
     use bevy::input::keyboard::KeyCode::*;
-    use bevy::prelude::Reflect;
     use leafwing_input_manager_macros::Actionlike;
 
-    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
+    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]
     enum Action {
         One,
         Two,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -44,7 +44,7 @@ use std::marker::PhantomData;
 ///
 /// // You can Run!
 /// // But you can't Hide :(
-/// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+/// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
 /// enum Action {
 ///     Run,
 ///     Hide,
@@ -104,9 +104,8 @@ impl<A: Actionlike> InputMap<A> {
     /// use leafwing_input_manager::input_map::InputMap;
     /// use leafwing_input_manager::Actionlike;
     /// use bevy::input::keyboard::KeyCode;
-    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -142,9 +141,8 @@ impl<A: Actionlike> InputMap<A> {
     /// use leafwing_input_manager::prelude::*;
 
     /// use bevy::input::keyboard::KeyCode;
-    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
     /// enum Action {
     ///     Run,
     ///     Jump,
@@ -479,9 +477,8 @@ impl<A: Actionlike> From<HashMap<A, Vec<UserInput>>> for InputMap<A> {
     /// use bevy::input::keyboard::KeyCode;
     ///
     /// use std::collections::HashMap;
-    /// use bevy::prelude::Reflect;
     ///
-    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
+    /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash)]
     /// enum Action {
     ///     Run,
     ///     Jump,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 use crate::action_state::ActionState;
 use crate::input_map::InputMap;
 use bevy::ecs::prelude::*;
-use bevy::reflect::TypePath;
 use std::marker::PhantomData;
 
 pub mod action_state;
@@ -60,10 +59,9 @@ pub mod prelude {
 ///
 /// # Example
 /// ```rust
-/// use bevy::prelude::Reflect;
 /// use leafwing_input_manager::Actionlike;
 ///
-/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Reflect)]
+/// #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash)]
 /// enum PlayerAction {
 ///    // Movement
 ///    Up,
@@ -78,7 +76,7 @@ pub mod prelude {
 ///    Ultimate,
 /// }
 /// ```
-pub trait Actionlike: Send + Sync + Clone + TypePath + 'static {
+pub trait Actionlike: Send + Sync + Clone + 'static {
     /// The number of variants of this action type
     fn n_variants() -> usize;
 

--- a/tests/actionlike_derive.rs
+++ b/tests/actionlike_derive.rs
@@ -1,31 +1,30 @@
 //! When debugging this file, `cargo expand` is invaluable.
 //! See: https://github.com/dtolnay/cargo-expand
 //! use `cargo expand --test actionlike_derive`
-use bevy::prelude::Reflect;
 use leafwing_input_manager::Actionlike;
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 enum UnitAction {}
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 enum OneAction {
     Jump,
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 enum SimpleAction {
     Zero,
     One,
     Two,
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 enum UnnamedFieldVariantsAction {
     Run,
     Jump(usize),
 }
 
-#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy, Reflect)]
+#[derive(Actionlike, Debug, Hash, PartialEq, Eq, Clone, Copy)]
 enum NamedFieldVariantsAction {
     Run { x: usize, y: usize },
     Jump,

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -15,7 +15,7 @@ fn test_app() -> App {
     app
 }
 
-#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug)]
 enum Action {
     One,
     Two,

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -6,7 +6,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::axislike::{AxisType, DualAxisData};
 use leafwing_input_manager::prelude::*;
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -14,7 +14,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum AxislikeTestAction {
     X,
     Y,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::press_scheduler::PressScheduler;
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum Action {
     PayRespects,
 }

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -6,7 +6,7 @@ use leafwing_input_manager::buttonlike::MouseMotionDirection;
 use leafwing_input_manager::prelude::*;
 use leafwing_input_manager::user_input::InputKind;
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -14,7 +14,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum AxislikeTestAction {
     X,
     Y,

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -4,7 +4,7 @@ use bevy::prelude::*;
 use leafwing_input_manager::axislike::{AxisType, DualAxisData, MouseWheelAxisType};
 use leafwing_input_manager::prelude::*;
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum ButtonlikeTestAction {
     Up,
     Down,
@@ -12,7 +12,7 @@ enum ButtonlikeTestAction {
     Right,
 }
 
-#[derive(Actionlike, Clone, Copy, Debug, Reflect)]
+#[derive(Actionlike, Clone, Copy, Debug)]
 enum AxislikeTestAction {
     X,
     Y,


### PR DESCRIPTION
There's a [PR open with Bevy](https://github.com/bevyengine/bevy/pull/9140) that allows opting out of the derrived TypePath implementation from Reflect which allows us to implement it manually, this allows us to remove the TypePath restriction we had to add for the Bevy 0.11 update.

## TODO
- [ ] Remove patch once https://github.com/bevyengine/bevy/pull/9140 is merged and released. 
- [ ] Change bevy dependency to require the patch that includes 9140 so people that pin the 0.11.0 Bevy release must update Bevy first.