### PR TITLE
Fix `clippy::default_constructed_unit_structs` lint warnings

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -506,7 +506,7 @@ impl<A: Actionlike> Default for ActionState<A> {
     fn default() -> ActionState<A> {
         ActionState {
             action_data: A::variants().map(|_| ActionData::default()).collect(),
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -193,7 +193,7 @@ impl<A: Actionlike> Clash<A> {
             index_b: action_b.index(),
             inputs_a: Vec::default(),
             inputs_b: Vec::default(),
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 
@@ -205,7 +205,7 @@ impl<A: Actionlike> Clash<A> {
             index_b,
             inputs_a: Vec::default(),
             inputs_b: Vec::default(),
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ impl<A: Actionlike> Default for ActionIter<A> {
     fn default() -> Self {
         ActionIter {
             index: 0,
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
         }
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -52,7 +52,7 @@ pub struct InputManagerPlugin<A: Actionlike> {
 impl<A: Actionlike> Default for InputManagerPlugin<A> {
     fn default() -> Self {
         Self {
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
             machine: Machine::Client,
         }
     }
@@ -67,7 +67,7 @@ impl<A: Actionlike> InputManagerPlugin<A> {
     #[must_use]
     pub fn server() -> Self {
         Self {
-            _phantom: PhantomData::default(),
+            _phantom: PhantomData,
             machine: Machine::Server,
         }
     }


### PR DESCRIPTION
The lint `clippy::default_constructed_unit_structs` has reached stable and is making CI fail.
This PR fixes those warnings.