### PR TITLE
Deadzone shapes

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,9 @@
 
 - Fixed invalid example code in README
 
+### Enhancements
+- Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
+
 ## Version 0.10
 
 ### Usability

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -705,9 +705,14 @@ impl From<DualAxisData> for Vec2 {
 }
 
 /// The shape of the deadzone for a [`DualAxis`] input.
+///
+/// Input values that are on the line of the shape are counted as inside
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum DeadZoneShape {
-    /// Deadzone with the shape of a cross. The cross is represented by two rectangles.
+    /// Deadzone with the shape of a cross.
+    ///
+    /// The cross is represented by two rectangles. When using [`DeadZoneShape::Cross`],
+    /// make sure rect_1 and rect_2 do not have the same values, otherwise the shape will be a rectangle
     Cross {
         /// The width of the first rectangle.
         rect_1_width: f32,
@@ -757,7 +762,9 @@ impl DeadZoneShape {
                 *rect_2_height,
             ),
             DeadZoneShape::Rect { width, height } => self.outside_rectangle(x, y, *width, *height),
-            DeadZoneShape::Ellipse { radius_x, radius_y } => self.outside_ellipse(x, y, *radius_x, *radius_y),
+            DeadZoneShape::Ellipse { radius_x, radius_y } => {
+                self.outside_ellipse(x, y, *radius_x, *radius_y)
+            }
         }
     }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -741,7 +741,29 @@ pub enum DeadZoneShape {
 
 impl Eq for DeadZoneShape {}
 impl std::hash::Hash for DeadZoneShape {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {}
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        match self {
+            DeadZoneShape::Cross {
+                rect_1_width,
+                rect_1_height,
+                rect_2_width,
+                rect_2_height,
+            } => {
+                FloatOrd(*rect_1_width).hash(state);
+                FloatOrd(*rect_1_height).hash(state);
+                FloatOrd(*rect_2_width).hash(state);
+                FloatOrd(*rect_2_height).hash(state);
+            }
+            DeadZoneShape::Rect { width, height } => {
+                FloatOrd(*width).hash(state);
+                FloatOrd(*height).hash(state);
+            }
+            DeadZoneShape::Ellipse { radius_x, radius_y } => {
+                FloatOrd(*radius_x).hash(state);
+                FloatOrd(*radius_y).hash(state);
+            }
+        }
+    }
 }
 
 impl DeadZoneShape {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -811,6 +811,6 @@ impl DeadZoneShape {
 
     /// Returns whether the (x, y) input is outside an ellipse.
     fn outside_ellipse(&self, x: f32, y: f32, radius_x: f32, radius_y: f32) -> bool {
-        (x.powi(2) / radius_x.powi(2) + y.powi(2) / radius_y.powi(2)) > 1.0
+        ((x / radius_x).powi(2) + (y / radius_y).powi(2)) > 1.0
     }
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -199,11 +199,9 @@ impl DualAxis {
     /// The default shape of the deadzone used by constructor methods.
     ///
     /// This cannot be changed, but the struct can be easily manually constructed.
-    pub const DEFAULT_DEADZONE_SHAPE: DeadZoneShape = DeadZoneShape::Cross {
-        rect_1_width: Self::DEFAULT_DEADZONE / 2.0,
-        rect_1_height: Self::DEFAULT_DEADZONE,
-        rect_2_width: Self::DEFAULT_DEADZONE,
-        rect_2_height: Self::DEFAULT_DEADZONE / 2.0,
+    pub const DEFAULT_DEADZONE_SHAPE: DeadZoneShape = DeadZoneShape::Ellipse {
+        radius_x: Self::DEFAULT_DEADZONE,
+        radius_y: Self::DEFAULT_DEADZONE,
     };
 
     /// Creates a [`DualAxis`] with both `positive_low` and `negative_low` in both axes set to `threshold` with a `deadzone_shape`.

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -388,7 +388,7 @@ impl<A: Actionlike> InputMap<A> {
                 if input_streams.input_pressed(input) {
                     inputs.push(input.clone());
 
-                    action.value += input_streams.input_value(input);
+                    action.value += input_streams.input_value(input, true);
                 }
             }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -13,7 +13,7 @@ use bevy::ecs::system::SystemState;
 
 use crate::axislike::{
     AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis, VirtualAxis,
-    VirtualDPad, DeadzoneShape,
+    VirtualDPad,
 };
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::prelude::DualAxis;
@@ -259,7 +259,7 @@ impl<'a> InputStreams<'a> {
         // Helper that takes the value returned by an axis and returns 0.0 if it is not within the
         // triggering range.
         let value_in_axis_range = |axis: &SingleAxis, value: f32| -> f32 {
-            if value >= axis.negative_low && value <= axis.positive_low && include_deadzone{
+            if value >= axis.negative_low && value <= axis.positive_low && include_deadzone {
                 0.0
             } else if axis.inverted {
                 -value
@@ -386,39 +386,7 @@ impl<'a> InputStreams<'a> {
     }
 
     fn extract_dual_axis_data(&self, dual_axis: &DualAxis) -> DualAxisData {
-        match dual_axis.deadzone_shape {
-            DeadzoneShape::Cross => {
-                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), true);
-                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), true);
-
-                DualAxisData::new(x, y)
-            },
-            DeadzoneShape::Rect => {
-                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), false);
-                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), false);
-                if x > dual_axis.x.positive_low
-                || x < dual_axis.x.negative_low
-                || y > dual_axis.y.positive_low
-                || y < dual_axis.y.negative_low
-                {
-                    DualAxisData::new(x, y)
-                } else {
-                    DualAxisData::new(0.0, 0.0)
-                }
-            },
-            DeadzoneShape::Circle => {
-                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), false);
-                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), false);
-                let radius = dual_axis.x.positive_low.max(dual_axis.y.positive_low);
-
-                if (x.powi(2) + y.powi(2)).sqrt() >= radius
-                {
-                    DualAxisData::new(x, y)
-                } else {
-                    DualAxisData::new(0.0, 0.0)
-                }
-            },
-        }
+        dual_axis.deadzone_shape.get_dual_axis_data(dual_axis, self)
     }
 }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -129,8 +129,10 @@ impl<'a> InputStreams<'a> {
     pub fn button_pressed(&self, button: InputKind) -> bool {
         match button {
             InputKind::DualAxis(axis) => {
-                self.button_pressed(InputKind::SingleAxis(axis.x))
-                    || self.button_pressed(InputKind::SingleAxis(axis.y))
+                let x_value = self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.x)), false);
+                let y_value = self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.y)), false);
+                
+                axis.deadzone.input_outside_deadzone(x_value, y_value)
             }
             InputKind::SingleAxis(axis) => {
                 let value = self.input_value(&UserInput::Single(button), true);

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -386,7 +386,20 @@ impl<'a> InputStreams<'a> {
     }
 
     fn extract_dual_axis_data(&self, dual_axis: &DualAxis) -> DualAxisData {
-        dual_axis.deadzone_shape.get_dual_axis_data(dual_axis, self)
+        let x = self.input_value(
+            &UserInput::Single(InputKind::SingleAxis(dual_axis.x)),
+            false,
+        );
+        let y = self.input_value(
+            &UserInput::Single(InputKind::SingleAxis(dual_axis.y)),
+            false,
+        );
+
+        if dual_axis.deadzone.input_outside_deadzone(x, y) {
+            DualAxisData::new(x, y)
+        } else {
+            DualAxisData::new(0.0, 0.0)
+        }
     }
 }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -13,7 +13,7 @@ use bevy::ecs::system::SystemState;
 
 use crate::axislike::{
     AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType, SingleAxis, VirtualAxis,
-    VirtualDPad,
+    VirtualDPad, DeadzoneShape,
 };
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::prelude::DualAxis;
@@ -133,7 +133,7 @@ impl<'a> InputStreams<'a> {
                     || self.button_pressed(InputKind::SingleAxis(axis.y))
             }
             InputKind::SingleAxis(axis) => {
-                let value = self.input_value(&UserInput::Single(button));
+                let value = self.input_value(&UserInput::Single(button), true);
 
                 value < axis.negative_low || value > axis.positive_low
             }
@@ -247,7 +247,7 @@ impl<'a> InputStreams<'a> {
     ///
     /// If you need to ensure that this value is always in the range `[-1., 1.]`,
     /// be sure to clamp the returned data.
-    pub fn input_value(&self, input: &UserInput) -> f32 {
+    pub fn input_value(&self, input: &UserInput, include_deadzone: bool) -> f32 {
         let use_button_value = || -> f32 {
             if self.input_pressed(input) {
                 1.0
@@ -259,7 +259,7 @@ impl<'a> InputStreams<'a> {
         // Helper that takes the value returned by an axis and returns 0.0 if it is not within the
         // triggering range.
         let value_in_axis_range = |axis: &SingleAxis, value: f32| -> f32 {
-            if value >= axis.negative_low && value <= axis.positive_low {
+            if value >= axis.negative_low && value <= axis.positive_low && include_deadzone{
                 0.0
             } else if axis.inverted {
                 -value
@@ -317,8 +317,8 @@ impl<'a> InputStreams<'a> {
                 }
             }
             UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
-                self.input_value(&UserInput::Single(*positive)).abs()
-                    - self.input_value(&UserInput::Single(*negative)).abs()
+                self.input_value(&UserInput::Single(*positive), true).abs()
+                    - self.input_value(&UserInput::Single(*negative), true).abs()
             }
             UserInput::Single(InputKind::DualAxis(_)) => {
                 self.input_axis_pair(input).unwrap_or_default().length()
@@ -375,10 +375,10 @@ impl<'a> InputStreams<'a> {
                 left,
                 right,
             }) => {
-                let x = self.input_value(&UserInput::Single(*right)).abs()
-                    - self.input_value(&UserInput::Single(*left)).abs();
-                let y = self.input_value(&UserInput::Single(*up)).abs()
-                    - self.input_value(&UserInput::Single(*down)).abs();
+                let x = self.input_value(&UserInput::Single(*right), true).abs()
+                    - self.input_value(&UserInput::Single(*left), true).abs();
+                let y = self.input_value(&UserInput::Single(*up), true).abs()
+                    - self.input_value(&UserInput::Single(*down), true).abs();
                 Some(DualAxisData::new(x, y))
             }
             _ => None,
@@ -386,17 +386,38 @@ impl<'a> InputStreams<'a> {
     }
 
     fn extract_dual_axis_data(&self, dual_axis: &DualAxis) -> DualAxisData {
-        let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)));
-        let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)));
+        match dual_axis.deadzone_shape {
+            DeadzoneShape::Cross => {
+                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), true);
+                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), true);
 
-        if x > dual_axis.x.positive_low
-            || x < dual_axis.x.negative_low
-            || y > dual_axis.y.positive_low
-            || y < dual_axis.y.negative_low
-        {
-            DualAxisData::new(x, y)
-        } else {
-            DualAxisData::new(0.0, 0.0)
+                DualAxisData::new(x, y)
+            },
+            DeadzoneShape::Rect => {
+                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), false);
+                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), false);
+                if x > dual_axis.x.positive_low
+                || x < dual_axis.x.negative_low
+                || y > dual_axis.y.positive_low
+                || y < dual_axis.y.negative_low
+                {
+                    DualAxisData::new(x, y)
+                } else {
+                    DualAxisData::new(0.0, 0.0)
+                }
+            },
+            DeadzoneShape::Circle => {
+                let x = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.x)), false);
+                let y = self.input_value(&UserInput::Single(InputKind::SingleAxis(dual_axis.y)), false);
+                let radius = dual_axis.x.positive_low.max(dual_axis.y.positive_low);
+
+                if (x.powi(2) + y.powi(2)).sqrt() >= radius
+                {
+                    DualAxisData::new(x, y)
+                } else {
+                    DualAxisData::new(0.0, 0.0)
+                }
+            },
         }
     }
 }

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -129,9 +129,11 @@ impl<'a> InputStreams<'a> {
     pub fn button_pressed(&self, button: InputKind) -> bool {
         match button {
             InputKind::DualAxis(axis) => {
-                let x_value = self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.x)), false);
-                let y_value = self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.y)), false);
-                
+                let x_value =
+                    self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.x)), false);
+                let y_value =
+                    self.input_value(&UserInput::Single(InputKind::SingleAxis(axis.y)), false);
+
                 axis.deadzone.input_outside_deadzone(x_value, y_value)
             }
             InputKind::SingleAxis(axis) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use leafwing_input_manager_macros::Actionlike;
 /// Everything you need to get started
 pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
-    pub use crate::axislike::{DualAxis, MouseWheelAxisType, SingleAxis, VirtualDPad};
+    pub use crate::axislike::{DualAxis, MouseWheelAxisType, SingleAxis, VirtualDPad, DeadZoneShape};
     pub use crate::buttonlike::MouseWheelDirection;
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,9 @@ pub use leafwing_input_manager_macros::Actionlike;
 /// Everything you need to get started
 pub mod prelude {
     pub use crate::action_state::{ActionState, ActionStateDriver};
-    pub use crate::axislike::{DualAxis, MouseWheelAxisType, SingleAxis, VirtualDPad, DeadZoneShape};
+    pub use crate::axislike::{
+        DeadZoneShape, DualAxis, MouseWheelAxisType, SingleAxis, VirtualDPad,
+    };
     pub use crate::buttonlike::MouseWheelDirection;
     pub use crate::clashing_inputs::ClashStrategy;
     pub use crate::input_map::InputMap;

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -26,7 +26,7 @@ pub enum UserInput {
     /// A combination of buttons, pressed simultaneously
     ///
     /// Up to 8 (!!) buttons can be chorded together at once.
-    Chord(PetitSet<InputKind, 8>),
+    Chord(Box<PetitSet<InputKind, 8>>),
     /// A virtual DPad that you can get an [`DualAxis`] from
     VirtualDPad(VirtualDPad),
     /// A virtual axis that you can get a [`SingleAxis`] from
@@ -44,7 +44,7 @@ impl UserInput {
         set.insert(modifier);
         set.insert(input);
 
-        UserInput::Chord(set)
+        UserInput::Chord(Box::new(set))
     }
 
     /// Creates a [`UserInput::Chord`] from an iterator of inputs of the same type that can be converted into an [`InputKind`]s
@@ -62,7 +62,7 @@ impl UserInput {
 
         match length {
             1 => UserInput::Single(set.into_iter().next().unwrap()),
-            _ => UserInput::Chord(set),
+            _ => UserInput::Chord(Box::new(set)),
         }
     }
 

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -3,7 +3,7 @@ use bevy::input::gamepad::{
 };
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::axislike::{AxisType, DualAxisData, DeadZoneShape};
+use leafwing_input_manager::axislike::{AxisType, DeadZoneShape, DualAxisData};
 use leafwing_input_manager::prelude::*;
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect)]
@@ -214,7 +214,12 @@ fn game_pad_single_axis() {
 fn game_pad_dual_axis_cross() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
-        DualAxis::left_stick().with_deadzone(DeadZoneShape::Cross { rect_1_width: 0.1, rect_1_height: 0.05, rect_2_width: 0.05, rect_2_height: 0.1 }),
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Cross {
+            rect_1_width: 0.1,
+            rect_1_height: 0.05,
+            rect_2_width: 0.05,
+            rect_2_height: 0.1,
+        }),
         AxislikeTestAction::XY,
     )]));
 
@@ -259,7 +264,10 @@ fn game_pad_dual_axis_cross() {
 fn game_pad_dual_axis_rect() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
-        DualAxis::left_stick().with_deadzone(DeadZoneShape::Rect { width: 0.1, height: 0.1 }),
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Rect {
+            width: 0.1,
+            height: 0.1,
+        }),
         AxislikeTestAction::XY,
     )]));
 
@@ -304,7 +312,10 @@ fn game_pad_dual_axis_rect() {
 fn game_pad_dual_axis_ellipse() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
-        DualAxis::left_stick().with_deadzone(DeadZoneShape::Ellipse { radius_x: 0.1, radius_y: 0.1 }),
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Ellipse {
+            radius_x: 0.1,
+            radius_y: 0.1,
+        }),
         AxislikeTestAction::XY,
     )]));
 

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -108,7 +108,7 @@ fn game_pad_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
-        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
+        deadzone: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -3,7 +3,7 @@ use bevy::input::gamepad::{
 };
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::axislike::{AxisType, DualAxisData};
+use leafwing_input_manager::axislike::{AxisType, DualAxisData, DeadZoneShape};
 use leafwing_input_manager::prelude::*;
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect)]
@@ -211,36 +211,19 @@ fn game_pad_single_axis() {
 }
 
 #[test]
-fn game_pad_dual_axis() {
+fn game_pad_dual_axis_cross() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
-        DualAxis::left_stick(),
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Cross { rect_1_width: 0.1, rect_1_height: 0.05, rect_2_width: 0.05, rect_2_height: 0.1 }),
         AxislikeTestAction::XY,
     )]));
 
+    // Test that an input inside the cross deadzone is filtered out
     app.send_input(DualAxis::from_value(
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
-        0.8,
-        0.0,
-    ));
-
-    app.update();
-
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
-    assert!(action_state.pressed(AxislikeTestAction::XY));
-    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.8);
-    assert_eq!(
-        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
-        DualAxisData::new(0.8, 0.0)
-    );
-
-    // Test deadzones, assuming the default of 0.1.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
+        0.1,
         0.05,
-        0.0,
     ));
 
     app.update();
@@ -253,23 +236,112 @@ fn game_pad_dual_axis() {
         DualAxisData::new(0.0, 0.0)
     );
 
-    // Test that a single axis below the deadzone is filtered out, assuming the
-    // default deadzone of 0.1.
+    // Test that an input outside the cross deadzone is not filtered out
     app.send_input(DualAxis::from_value(
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
-        0.2,
-        0.05,
+        0.06,
+        0.06,
     ));
 
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(AxislikeTestAction::XY));
-    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.2);
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.084852815);
     assert_eq!(
         action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
-        DualAxisData::new(0.2, 0.0)
+        DualAxisData::new(0.06, 0.06)
+    );
+}
+
+#[test]
+fn game_pad_dual_axis_rect() {
+    let mut app = test_app();
+    app.insert_resource(InputMap::new([(
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Rect { width: 0.1, height: 0.1 }),
+        AxislikeTestAction::XY,
+    )]));
+
+    // Test that an input inside the rect deadzone is filtered out, assuming values of 0.1
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.1,
+        0.1,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.released(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.0);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.0, 0.0)
+    );
+
+    // Test that an input outside the rect deadzone is not filtered out, assuming values of 0.1
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.1,
+        0.2,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.pressed(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.22360681);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.1, 0.2)
+    );
+}
+
+#[test]
+fn game_pad_dual_axis_ellipse() {
+    let mut app = test_app();
+    app.insert_resource(InputMap::new([(
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Ellipse { radius_x: 0.1, radius_y: 0.1 }),
+        AxislikeTestAction::XY,
+    )]));
+
+    // Test that an input inside the ellipse deadzone is filtered out, assuming values of 0.1
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.06,
+        0.06,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.released(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.0);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.0, 0.0)
+    );
+
+    // Test that an input outside the ellipse deadzone is not filtered out, assuming values of 0.1
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.1,
+        0.1,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.pressed(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.14142136);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.1, 0.1)
     );
 }
 

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -108,6 +108,7 @@ fn game_pad_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
+        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -103,6 +103,7 @@ fn mouse_motion_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
+        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -103,7 +103,7 @@ fn mouse_motion_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
-        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
+        deadzone: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -104,7 +104,7 @@ fn mouse_wheel_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
-        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
+        deadzone: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -104,6 +104,7 @@ fn mouse_wheel_dual_axis_mocking() {
             negative_low: 0.0,
             inverted: false,
         },
+        deadzone_shape: DualAxis::DEFAULT_DEADZONE_SHAPE,
     };
     app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();


### PR DESCRIPTION
Currently, the only type of deadzone for a `DualAxis` is a cross shape. This shape is preferred for some instances, like in Rocket League, as the cross-shape deadzone makes directional flipping easier. However, there are instances where a circular or rectangular deadzone is preferred, like a twin-stick shooter.

Adds `DeadzoneShape` to `DualAxis`, which allows the user to choose between a circle, rectangle, and a cross for the deadzone shape.

From manual tests, the shapes appear to be correct and all work. This pr also passed `cargo test`.

### Things to do:
- [x] Add tests to make sure the deadzones shapes are correct
- [x] Implement `Hash` for `DeadZoneShape`
- [x] Change tests that relied on `Cross` snapping
- [x] Improve documentation of `DeadzoneShape` (feels a little convoluted)
- [x] Update `RELEASES.md`

### Questions
1. Is `extract_dual_axis_data()` the correct method to test the different shapes?
2. Adding `include_deadzone: bool` to `input_value()` feels a little gross, but I didn't find a better way to get the input_value of a `SingleAxis` without it running its deadzone. Is there a better, perhaps overlooked, way of doing this?
3. Currently, the shapes diamensions rely on the x and y thresholds in `SingleAxis`. This keeps inverting of the input easy, but might create confusion? `with_deadzone()` has been changed to hopefully make this easy, but there might be a better way.