### PR TITLE
examples: Move update_cursor_state_from_window to Update

### DIFF
--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(InputManagerPlugin::<BoxMovement>::default())
         .add_systems(Startup, setup)
         .add_systems(
-            Startup,
+            Update,
             update_cursor_state_from_window
                 .run_if(run_if_enabled::<BoxMovement>)
                 .in_set(InputManagerSystem::ManualControl)


### PR DESCRIPTION
Small but critical fix to one of the examples.

Fixes: #367 