### PR TITLE
Update deadzone docs

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -704,7 +704,9 @@ impl From<DualAxisData> for Vec2 {
 
 /// The shape of the deadzone for a [`DualAxis`] input.
 ///
-/// Input values that are on the line of the shape are counted as inside
+/// Input values that are on the line of the shape are counted as inside.
+/// 
+/// Values should be in the range `0.0..=1.0`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum DeadZoneShape {
     /// Deadzone with the shape of a cross.

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -705,7 +705,7 @@ impl From<DualAxisData> for Vec2 {
 /// The shape of the deadzone for a [`DualAxis`] input.
 ///
 /// Input values that are on the line of the shape are counted as inside.
-/// 
+///
 /// Deadzone values should be in the range `0.0..=1.0`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum DeadZoneShape {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -706,7 +706,7 @@ impl From<DualAxisData> for Vec2 {
 ///
 /// Input values that are on the line of the shape are counted as inside.
 /// 
-/// Values should be in the range `0.0..=1.0`.
+/// Deadzone values should be in the range `0.0..=1.0`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
 pub enum DeadZoneShape {
     /// Deadzone with the shape of a cross.


### PR DESCRIPTION
There might be some confusion as to what range values should be used with `DeadZoneShape`. This added doc explains that the values should be in the range `0..=1.0`.