### PR TITLE
Fix axis inputs in a `Chord` being read a button

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,6 +4,7 @@
 
 ### Bugs
 - Fixed system order ambiguity between bevy_ui and update_action_state systems
+- Axis inputs in a `Chord` are now read as an axis instead of a button
 
 ### Docs
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -332,22 +332,35 @@ impl<'a> InputStreams<'a> {
             }
             UserInput::Chord(inputs) => {
                 let mut value = 0.0;
+                let mut has_axis = false;
 
-                inputs.iter().for_each(|input| {
+                // Prioritize axis over button input values
+                for input in inputs.iter() {
                     value += match input {
                         InputKind::SingleAxis(axis) => {
+                            has_axis = true;
                             self.input_value(&UserInput::Single(InputKind::SingleAxis(*axis)), true)
                         }
                         InputKind::MouseWheel(axis) => {
+                            has_axis = true;
                             self.input_value(&UserInput::Single(InputKind::MouseWheel(*axis)), true)
                         }
-                        InputKind::MouseMotion(axis) => self
-                            .input_value(&UserInput::Single(InputKind::MouseMotion(*axis)), true),
-                        _ => use_button_value(),
-                    };
-                });
+                        InputKind::MouseMotion(axis) => {
+                            has_axis = true;
+                            self.input_value(
+                                &UserInput::Single(InputKind::MouseMotion(*axis)),
+                                true,
+                            )
+                        }
+                        _ => 0.0,
+                    }
+                }
 
-                value
+                if has_axis {
+                    return value;
+                }
+
+                use_button_value()
             }
             // This is required because upstream bevy::input still waffles about whether triggers are buttons or axes
             UserInput::Single(InputKind::GamepadButton(button_type)) => {

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -330,6 +330,25 @@ impl<'a> InputStreams<'a> {
             UserInput::VirtualDPad { .. } => {
                 self.input_axis_pair(input).unwrap_or_default().length()
             }
+            UserInput::Chord(inputs) => {
+                let mut value = 0.0;
+
+                inputs.iter().for_each(|input| {
+                    value += match input {
+                        InputKind::SingleAxis(axis) => {
+                            self.input_value(&UserInput::Single(InputKind::SingleAxis(*axis)), true)
+                        }
+                        InputKind::MouseWheel(axis) => {
+                            self.input_value(&UserInput::Single(InputKind::MouseWheel(*axis)), true)
+                        }
+                        InputKind::MouseMotion(axis) => self
+                            .input_value(&UserInput::Single(InputKind::MouseMotion(*axis)), true),
+                        _ => use_button_value(),
+                    };
+                });
+
+                value
+            }
             // This is required because upstream bevy::input still waffles about whether triggers are buttons or axes
             UserInput::Single(InputKind::GamepadButton(button_type)) => {
                 if let Some(gamepad) = self.guess_gamepad() {


### PR DESCRIPTION
Fixes #380 

The design, as discussed on Discord, is to prioritize axis inputs being read over button in a `Chord`. Currently, I have it so all axis inputs are added together, as someone might want to have two inputs to affects the input from a chord. I'm not a big fan of the `has_axis` bool, but I couldn't find a nice way to get that information across. Possibly doing a `inputs.iter().find()` on the if statement?