### PR TITLE
Implement Reflect for InputMap

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ bevy_egui = { version = "0.22", optional = true }
 
 petitset = { version = "0.2.1", features = ["serde_compat"] }
 derive_more = { version = "0.99", default-features = false, features = [
+  "as_ref",
+  "as_mut",
+  "from",
   "display",
   "error",
 ] }

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,6 +16,7 @@
 
 ### Enhancements
 
+- Implement `TypePath` for `InputMap`.
 - Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
 - Added sensitivity for `SingleAxis` and `DualAxis`, allowing you to scale mouse, keypad and gamepad inputs differently for each action.
 - Added a helper `from_keys` to `VirtualAxis` to simplify creating one from two keys

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -16,7 +16,7 @@
 
 ### Enhancements
 
-- Implement `TypePath` for `InputMap`.
+- Implement `Reflect` for `InputMap` and most other types.
 - Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
 - Added sensitivity for `SingleAxis` and `DualAxis`, allowing you to scale mouse, keypad and gamepad inputs differently for each action.
 - Added a helper `from_keys` to `VirtualAxis` to simplify creating one from two keys

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 /// # Warning
 ///
 /// `positive_low` must be greater than or equal to `negative_low` for this type to be validly constructed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, Reflect)]
 pub struct SingleAxis {
     /// The axis that is being checked.
     pub axis_type: AxisType,
@@ -203,7 +203,7 @@ impl std::hash::Hash for SingleAxis {
 /// # Warning
 ///
 /// `positive_low` must be greater than or equal to `negative_low` for both `x` and `y` for this type to be validly constructed.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Hash, Reflect)]
 pub struct DualAxis {
     /// The axis representing horizontal movement.
     pub x: SingleAxis,
@@ -342,7 +342,7 @@ impl DualAxis {
 /// even though it can be stored as an [`InputKind`].
 ///
 /// Instead, use it directly as [`InputKind::DualAxis`]!
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub struct VirtualDPad {
     /// The input that represents the up direction in this virtual DPad
     pub up: InputKind,
@@ -449,7 +449,7 @@ impl VirtualDPad {
 /// even though it can be stored as an [`InputKind`].
 ///
 /// Instead, use it directly as [`InputKind::SingleAxis`]!
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub struct VirtualAxis {
     /// The input that represents the negative direction of this virtual axis
     pub negative: InputKind,
@@ -516,7 +516,7 @@ impl VirtualAxis {
 /// The type of axis used by a [`UserInput`](crate::user_input::UserInput).
 ///
 /// This is stored in either a [`SingleAxis`] or [`DualAxis`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum AxisType {
     /// Input associated with a gamepad, such as the triggers or one axis of an analog stick.
     Gamepad(GamepadAxisType),
@@ -529,7 +529,7 @@ pub enum AxisType {
 /// The direction of motion of the mouse wheel.
 ///
 /// Stored in the [`AxisType`] enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum MouseWheelAxisType {
     /// Horizontal movement.
     ///
@@ -544,7 +544,7 @@ pub enum MouseWheelAxisType {
 /// The direction of motion of the mouse.
 ///
 /// Stored in the [`AxisType`] enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum MouseMotionAxisType {
     /// Horizontal movement.
     X,
@@ -736,7 +736,7 @@ impl From<DualAxisData> for Vec2 {
 /// If a volume of a shape is 0, then all input values are read.
 ///
 /// Deadzone values should be in the range `0.0..=1.0`.
-#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Reflect)]
 pub enum DeadZoneShape {
     /// Deadzone with the shape of a cross.
     ///

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -87,7 +87,7 @@ impl ButtonState {
 /// A buttonlike-input triggered by [`MouseWheel`](bevy::input::mouse::MouseWheel) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum MouseWheelDirection {
     /// Corresponds to `+y`
     Up,
@@ -102,7 +102,7 @@ pub enum MouseWheelDirection {
 /// A buttonlike-input triggered by [`MouseMotion`](bevy::input::mouse::MouseMotion) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum MouseMotionDirection {
     /// Corresponds to `+y`
     Up,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -10,7 +10,7 @@ use crate::Actionlike;
 use bevy::ecs::component::Component;
 use bevy::ecs::system::Resource;
 use bevy::input::gamepad::Gamepad;
-use bevy::reflect::TypeUuid;
+use bevy::reflect::{TypePath, TypeUuid};
 
 use core::fmt::Debug;
 use petitset::PetitSet;
@@ -114,7 +114,7 @@ fn change_left_stick_values(mut query: Query<&mut InputMap<Action>>){
 }
 ```
 **/
-#[derive(Resource, Component, Debug, Clone, PartialEq, Eq, TypeUuid)]
+#[derive(Resource, Component, Debug, Clone, PartialEq, Eq, TypeUuid, TypePath)]
 #[uuid = "D7DECC78-8573-42FF-851A-F0344C7D05C9"]
 pub struct InputMap<A: Actionlike> {
     /// The raw vector of [PetitSet]s used to store the input mapping,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub mod input_streams;
 pub mod orientation;
 pub mod plugin;
 pub mod press_scheduler;
+mod reflect;
 pub mod scan_codes;
 pub mod systems;
 pub mod user_input;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,7 +1,11 @@
 //! Contains main plugin exported by this crate.
 
+use crate::action_state::ActionState;
+use crate::axislike::{DualAxis, SingleAxis, VirtualAxis, VirtualDPad};
+use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::clashing_inputs::ClashStrategy;
-use crate::prelude::ActionState;
+use crate::input_map::InputMap;
+use crate::user_input::{InputKind, Modifier, UserInput};
 use crate::Actionlike;
 use core::hash::Hash;
 use core::marker::PhantomData;
@@ -153,6 +157,17 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
         };
 
         app.register_type::<ActionState<A>>()
+            .register_type::<InputMap<A>>()
+            .register_type::<UserInput>()
+            .register_type::<UserInput>()
+            .register_type::<InputKind>()
+            .register_type::<VirtualDPad>()
+            .register_type::<VirtualAxis>()
+            .register_type::<SingleAxis>()
+            .register_type::<DualAxis>()
+            .register_type::<Modifier>()
+            .register_type::<MouseWheelDirection>()
+            .register_type::<MouseMotionDirection>()
             // Resources
             .init_resource::<ToggleActions<A>>()
             .init_resource::<ClashStrategy>();

--- a/src/reflect.rs
+++ b/src/reflect.rs
@@ -1,0 +1,214 @@
+//! Module with manual implementation of [`Reflect`] trait for external types.
+
+use bevy::{
+    prelude::{Deref, DerefMut},
+    reflect::{
+        list_apply, list_partial_eq, utility::GenericTypeInfoCell, FromReflect, FromType,
+        GetTypeRegistration, List, ListInfo, Reflect, ReflectFromPtr, ReflectMut, ReflectOwned,
+        ReflectRef, TypeInfo, TypePath, TypeRegistration, Typed,
+    },
+};
+use derive_more::{AsMut, AsRef, From};
+use serde::{Deserialize, Serialize};
+
+/// Newtype wrapper for [`PetitSet`](petitset::PetitSet) capable of reflection.
+#[derive(
+    Debug,
+    Clone,
+    PartialEq,
+    Eq,
+    Hash,
+    Serialize,
+    Deserialize,
+    Deref,
+    DerefMut,
+    TypePath,
+    AsRef,
+    AsMut,
+    From,
+)]
+#[serde(transparent)]
+#[type_path = "petitset::PetitSet"]
+pub struct ReflectPetitSet<T, const CAP: usize>(petitset::PetitSet<T, CAP>)
+where
+    T: Reflect + Clone + Eq;
+
+impl<T, const CAP: usize> Default for ReflectPetitSet<T, CAP>
+where
+    T: Reflect + Clone + Eq,
+{
+    fn default() -> Self {
+        Self(petitset::PetitSet::<T, CAP>::default())
+    }
+}
+
+impl<T, const CAP: usize> Typed for ReflectPetitSet<T, CAP>
+where
+    T: FromReflect + TypePath + Clone + Eq,
+{
+    fn type_info() -> &'static TypeInfo {
+        static CELL: GenericTypeInfoCell = GenericTypeInfoCell::new();
+        CELL.get_or_insert::<Self, _>(|| TypeInfo::List(ListInfo::new::<Self, T>()))
+    }
+}
+
+impl<T, const CAP: usize> FromReflect for ReflectPetitSet<T, CAP>
+where
+    T: FromReflect + TypePath + Clone + Eq,
+{
+    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+        if let ReflectRef::List(ref_list) = reflect.reflect_ref() {
+            let mut new_set = petitset::PetitSet::<T, CAP>::new();
+            for field in ref_list.iter() {
+                let element = T::from_reflect(field)?;
+                new_set.try_insert(element).ok()?;
+            }
+            Some(Self(new_set))
+        } else {
+            None
+        }
+    }
+}
+
+impl<T, const CAP: usize> GetTypeRegistration for ReflectPetitSet<T, CAP>
+where
+    T: FromReflect + TypePath + Clone + Eq,
+{
+    fn get_type_registration() -> TypeRegistration {
+        let mut registration = TypeRegistration::of::<Self>();
+        registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+        registration
+    }
+}
+
+impl<T, const CAP: usize> List for ReflectPetitSet<T, CAP>
+where
+    T: FromReflect + TypePath + Clone + Eq,
+{
+    fn get(&self, index: usize) -> Option<&dyn Reflect> {
+        self.0.get_at(index).map(|item| item as &dyn Reflect)
+    }
+
+    fn get_mut(&mut self, index: usize) -> Option<&mut dyn Reflect> {
+        self.0
+            .get_at_mut(index)
+            .map(|item| item as &mut dyn Reflect)
+    }
+
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    fn iter(&self) -> bevy::reflect::ListIter {
+        bevy::reflect::ListIter::new(self as &dyn List)
+    }
+
+    fn drain(self: Box<Self>) -> Vec<Box<dyn Reflect>> {
+        self.0
+            .into_iter()
+            .map(|item| Box::new(item) as Box<dyn Reflect>)
+            .collect()
+    }
+
+    fn insert(&mut self, index: usize, element: Box<dyn Reflect>) {
+        let element = element.take::<T>().unwrap_or_else(|value| {
+            T::from_reflect(&*value).unwrap_or_else(|| {
+                panic!(
+                    "Attempted to insert invalid value of type {}.",
+                    value.type_name()
+                )
+            })
+        });
+        self.0.insert_at(element, index);
+    }
+
+    fn remove(&mut self, index: usize) -> Box<dyn Reflect> {
+        Box::new(self.0.remove_at(index))
+    }
+}
+
+impl<T, const CAP: usize> Reflect for ReflectPetitSet<T, CAP>
+where
+    T: FromReflect + TypePath + Clone + Eq,
+{
+    fn type_name(&self) -> &str {
+        std::any::type_name::<Self>()
+    }
+
+    fn get_represented_type_info(&self) -> Option<&'static bevy::reflect::TypeInfo> {
+        Some(<Self as Typed>::type_info())
+    }
+
+    fn into_any(self: Box<Self>) -> Box<dyn std::any::Any> {
+        self
+    }
+
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
+
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+        self
+    }
+
+    fn as_reflect(&self) -> &dyn Reflect {
+        self
+    }
+
+    fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+        self
+    }
+
+    fn apply(&mut self, value: &dyn Reflect) {
+        list_apply(self, value);
+    }
+
+    fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+        *self = value.take()?;
+        Ok(())
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::List(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::List(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::List(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn Reflect> {
+        Box::new(self.clone_dynamic())
+    }
+
+    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+        list_partial_eq(self, value)
+    }
+}
+
+mod tests {
+    #[test]
+    fn reflect_petit_set() {
+        use bevy::reflect::List;
+
+        let mut set: Box<dyn List> = Box::new(crate::reflect::ReflectPetitSet::<i32, 8>::default());
+
+        assert!(set.get_represented_type_info().is_some());
+        assert_eq!(set.len(), 0);
+
+        set.push(Box::new(100));
+        set.push(Box::new(200));
+
+        assert_eq!(set.len(), 2);
+        assert_eq!(set.get(0).unwrap().reflect_partial_eq(&100), Some(true));
+        assert_eq!(set.get(1).unwrap().reflect_partial_eq(&200), Some(true));
+        assert!(set.get(2).is_none());
+    }
+}

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -3,11 +3,13 @@
 use bevy::input::{gamepad::GamepadButtonType, keyboard::KeyCode, mouse::MouseButton};
 
 use bevy::prelude::ScanCode;
+use bevy::reflect::Reflect;
 use bevy::utils::HashSet;
 use petitset::PetitSet;
 use serde::{Deserialize, Serialize};
 
 use crate::axislike::VirtualAxis;
+use crate::reflect::ReflectPetitSet;
 use crate::scan_codes::QwertyScanCode;
 use crate::{
     axislike::{AxisType, DualAxis, SingleAxis, VirtualDPad},
@@ -19,14 +21,14 @@ use crate::{
 /// For example, this may store mouse, keyboard or gamepad input, including cross-device chords!
 ///
 /// Suitable for use in an [`InputMap`](crate::input_map::InputMap)
-#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum UserInput {
     /// A single button
     Single(InputKind),
     /// A combination of buttons, pressed simultaneously
     ///
     /// Up to 8 (!!) buttons can be chorded together at once.
-    Chord(Box<PetitSet<InputKind, 8>>),
+    Chord(ReflectPetitSet<InputKind, 8>),
     /// A virtual DPad that you can get an [`DualAxis`] from
     VirtualDPad(VirtualDPad),
     /// A virtual axis that you can get a [`SingleAxis`] from
@@ -44,7 +46,7 @@ impl UserInput {
         set.insert(modifier);
         set.insert(input);
 
-        UserInput::Chord(Box::new(set))
+        UserInput::Chord(set.into())
     }
 
     /// Creates a [`UserInput::Chord`] from an iterator of inputs of the same type that can be converted into an [`InputKind`]s
@@ -62,7 +64,7 @@ impl UserInput {
 
         match length {
             1 => UserInput::Single(set.into_iter().next().unwrap()),
-            _ => UserInput::Chord(Box::new(set)),
+            _ => UserInput::Chord(set.into()),
         }
     }
 
@@ -359,7 +361,7 @@ impl From<Modifier> for UserInput {
 ///
 /// Please contact the maintainers if you need support for another type!
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum InputKind {
     /// A button on a gamepad
     GamepadButton(GamepadButtonType),
@@ -453,7 +455,7 @@ impl From<Modifier> for InputKind {
 ///
 /// This buttonlike input is stored in [`InputKind`], and will be triggered whenever either of these buttons are pressed.
 /// This will be decomposed into both values when converted into [`RawInputs`].
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum Modifier {
     /// Corresponds to [`KeyCode::AltLeft`] and [`KeyCode::AltRight`].
     Alt,

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -360,6 +360,8 @@ impl From<Modifier> for UserInput {
 /// require traits that are not object-safe.
 ///
 /// Please contact the maintainers if you need support for another type!
+// TODO: https://github.com/bevyengine/bevy/issues/3392
+#[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum InputKind {

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -21,6 +21,8 @@ use crate::{
 /// For example, this may store mouse, keyboard or gamepad input, including cross-device chords!
 ///
 /// Suitable for use in an [`InputMap`](crate::input_map::InputMap)
+// TODO: https://github.com/bevyengine/bevy/issues/3392
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum UserInput {
     /// A single button
@@ -360,8 +362,6 @@ impl From<Modifier> for UserInput {
 /// require traits that are not object-safe.
 ///
 /// Please contact the maintainers if you need support for another type!
-// TODO: https://github.com/bevyengine/bevy/issues/3392
-#[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Reflect)]
 pub enum InputKind {


### PR DESCRIPTION
Currently it's not possible to directly use an `InputMap<A>` as an asset (e.g. `Handle<InputMap<A>>`), as `trait Asset` now requires `TypePath`.