### PR TITLE
Add `block_ui_interactions` feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ opt-level = 3
 members = ["./", "tools/ci", "macros"]
 
 [features]
-default = ['ui']
+default = ['ui', 'block_ui_interactions']
 ui = ['bevy/bevy_ui']
+block_ui_interactions = []
 # If this feature is enabled, egui will have priority over actions when processing inputs
 egui = ['dep:bevy_egui']
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -17,6 +17,10 @@
 - Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
 - Added sensitivity for `SingleAxis` and `DualAxis`, allowing you to scale mouse, keypad and gamepad inputs differently for each action.
 
+### Usability
+
+- Added `block_ui_interactions` feature flag; when on, mouse input won't be read if any `bevy_ui` element has an active `Interaction`.
+
 ## Version 0.10
 
 ### Usability

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -72,7 +72,9 @@ pub fn update_action_state<A: Actionlike>(
     mouse_wheel: Option<Res<Events<MouseWheel>>>,
     mouse_motion: Res<Events<MouseMotion>>,
     clash_strategy: Res<ClashStrategy>,
-    #[cfg(feature = "ui")] interactions: Query<&Interaction>,
+    #[cfg(all(feature = "ui", feature = "block_ui_interactions"))] interactions: Query<
+        &Interaction,
+    >,
     #[cfg(feature = "egui")] mut maybe_egui: EguiContexts,
     action_state: Option<ResMut<ActionState<A>>>,
     input_map: Option<Res<InputMap<A>>>,
@@ -94,7 +96,7 @@ pub fn update_action_state<A: Actionlike>(
     let mouse_motion = mouse_motion.into_inner();
 
     // If use clicks on a button, do not apply them to the game state
-    #[cfg(feature = "ui")]
+    #[cfg(all(feature = "ui", feature = "block_ui_interactions"))]
     let (mouse_buttons, mouse_wheel) = if interactions
         .iter()
         .any(|&interaction| interaction != Interaction::None)


### PR DESCRIPTION
Adds the `block_ui_interactions` feature, which allows users to optionally disable #355. 

I chose to place the feature in the default feature to keep the current behavior. As for the feature itself, I chose not to turn on `ui` or `bevy_ui`. This makes users explicitly state that `ui` is on, and they want to block ui interaction as well. That does mean that turning on `block_ui_interactions` will do nothing, as it relies on `ui`.