### PR TITLE
Fix `redundant explicit link target` docs error

### DIFF
--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -1,4 +1,4 @@
-//! Handles clashing inputs into a [`InputMap`](crate::input_map::InputMap) in a configurable fashion.
+//! Handles clashing inputs into a [`InputMap`] in a configurable fashion.
 
 use crate::action_state::ActionData;
 use crate::axislike::{VirtualAxis, VirtualDPad};

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -34,7 +34,7 @@ By default, if two actions would be triggered by a combination of buttons,
 and one combination is a strict subset of the other, only the larger input is registered.
 For example, pressing both `S` and `Ctrl + S` in your text editor app would save your file,
 but not enter the letters `s`.
-Set the [`ClashStrategy`](crate::clashing_inputs::ClashStrategy) resource
+Set the [`ClashStrategy`] resource
 to configure this behavior.
 
 # Example

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -21,7 +21,7 @@ use crate::user_input::{InputKind, UserInput};
 
 /// A collection of [`Input`] structs, which can be used to update an [`InputMap`](crate::input_map::InputMap).
 ///
-/// These are typically collected via a system from the [`World`](bevy::prelude::World) as resources.
+/// These are typically collected via a system from the [`World`] as resources.
 #[derive(Debug, Clone)]
 pub struct InputStreams<'a> {
     /// A [`GamepadButton`] [`Input`] stream
@@ -413,7 +413,7 @@ impl<'a> InputStreams<'a> {
     ///
     /// If `input` is a chord, returns result of the first dual axis in the chord.
 
-    /// If `input` is not a [`DualAxis`](crate::axislike::DualAxis) or [`VirtualDPad`], returns [`None`].
+    /// If `input` is not a [`DualAxis`] or [`VirtualDPad`], returns [`None`].
     ///
     /// # Warning
     ///
@@ -470,7 +470,7 @@ impl<'a> InputStreams<'a> {
 
 /// A mutable collection of [`Input`] structs, which can be used for mocking user inputs.
 ///
-/// These are typically collected via a system from the [`World`](bevy::prelude::World) as resources.
+/// These are typically collected via a system from the [`World`] as resources.
 // WARNING: If you update the fields of this type, you must also remember to update `InputMocking::reset_inputs`.
 #[derive(Debug)]
 pub struct MutableInputStreams<'a> {

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -14,14 +14,14 @@ use bevy::prelude::{PostUpdate, PreUpdate};
 #[cfg(feature = "ui")]
 use bevy::ui::UiSystem;
 
-/// A [`Plugin`] that collects [`Input`](bevy::input::Input) from disparate sources, producing an [`ActionState`](crate::action_state::ActionState) that can be conveniently checked
+/// A [`Plugin`] that collects [`Input`](bevy::input::Input) from disparate sources, producing an [`ActionState`] that can be conveniently checked
 ///
 /// This plugin needs to be passed in an [`Actionlike`] enum type that you've created for your game.
-/// Each variant represents a "virtual button" whose state is stored in an [`ActionState`](crate::action_state::ActionState) struct.
+/// Each variant represents a "virtual button" whose state is stored in an [`ActionState`] struct.
 ///
 /// Each [`InputManagerBundle`](crate::InputManagerBundle) contains:
 ///  - an [`InputMap`](crate::input_map::InputMap) component, which stores an entity-specific mapping between the assorted input streams and an internal representation of "actions"
-///  - an [`ActionState`](crate::action_state::ActionState) component, which stores the current input state for that entity in an source-agnostic fashion
+///  - an [`ActionState`] component, which stores the current input state for that entity in an source-agnostic fashion
 ///
 /// If you have more than one distinct type of action (e.g. menu actions, camera actions and player actions), consider creating multiple `Actionlike` enums
 /// and adding a copy of this plugin for each `Actionlike` type.
@@ -38,8 +38,8 @@ use bevy::ui::UiSystem;
 ///
 /// Complete list:
 ///
-/// - [`tick_action_state`](crate::systems::tick_action_state), which resets the `pressed` and `just_pressed` fields of the [`ActionState`](crate::action_state::ActionState) each frame
-/// - [`update_action_state`](crate::systems::update_action_state), which collects [`Input`](bevy::input::Input) resources to update the [`ActionState`](crate::action_state::ActionState)
+/// - [`tick_action_state`](crate::systems::tick_action_state), which resets the `pressed` and `just_pressed` fields of the [`ActionState`] each frame
+/// - [`update_action_state`](crate::systems::update_action_state), which collects [`Input`](bevy::input::Input) resources to update the [`ActionState`]
 /// - [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction), for triggering actions from buttons
 ///    - powers the [`ActionStateDriver`](crate::action_state::ActionStateDriver) component based on an [`Interaction`](bevy::ui::Interaction) component
 /// - [`release_on_disable`](crate::systems::release_on_disable), which resets action states when [`ToggleActions`] is flipped, to avoid persistent presses.
@@ -61,7 +61,7 @@ impl<A: Actionlike> Default for InputManagerPlugin<A> {
 impl<A: Actionlike> InputManagerPlugin<A> {
     /// Creates a version of the plugin intended to run on the server
     ///
-    /// Inputs will not be processed; instead, [`ActionState`](crate::action_state::ActionState)
+    /// Inputs will not be processed; instead, [`ActionState`]
     /// should be copied directly from the state provided by the client,
     /// or constructed from [`ActionDiff`](crate::action_state::ActionDiff) event streams.
     #[must_use]
@@ -159,12 +159,12 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
     }
 }
 
-/// Controls whether or not the [`ActionState`](crate::action_state::ActionState) / [`InputMap`](crate::input_map::InputMap) pairs of type `A` are active
+/// Controls whether or not the [`ActionState`] / [`InputMap`](crate::input_map::InputMap) pairs of type `A` are active
 ///
 /// If this resource does not exist, actions work normally, as if `ToggleActions::enabled == true`.
 #[derive(Resource)]
 pub struct ToggleActions<A: Actionlike> {
-    /// When this is false, [`ActionState`](crate::action_state::ActionState)'s corresponding to `A` will ignore user inputs
+    /// When this is false, [`ActionState`]'s corresponding to `A` will ignore user inputs
     ///
     /// When this is set to false, all corresponding [`ActionState`]s are released
     pub enabled: bool,
@@ -204,11 +204,11 @@ pub enum InputManagerSystem {
     ///
     /// Cleans up the state of the input manager, clearing `just_pressed` and just_released`
     Tick,
-    /// Collects input data to update the [`ActionState`](crate::action_state::ActionState)
+    /// Collects input data to update the [`ActionState`]
     Update,
-    /// Release all actions in all [`ActionState`](crate::action_state::ActionState)s if [`ToggleActions`](crate::plugin::ToggleActions) was added
+    /// Release all actions in all [`ActionState`]s if [`ToggleActions`] was added
     ReleaseOnDisable,
-    /// Manually control the [`ActionState`](crate::action_state::ActionState)
+    /// Manually control the [`ActionState`]
     ///
     /// Must run after [`InputManagerSystem::Update`] or the action state will be overridden
     ManualControl,

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -175,7 +175,7 @@ pub fn update_action_state_from_interaction<A: Actionlike>(
     }
 }
 
-/// Generates an [`Events`](bevy::ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
+/// Generates an [`Events`] stream of [`ActionDiff`] from [`ActionState`]
 ///
 /// The `ID` generic type should be a stable entity identifier,
 /// suitable to be sent across a network.
@@ -202,7 +202,7 @@ pub fn generate_action_diffs<A: Actionlike, ID: Eq + Clone + Component>(
     }
 }
 
-/// Generates an [`Events`](bevy::ecs::event::Events) stream of [`ActionDiff`] from [`ActionState`]
+/// Generates an [`Events`] stream of [`ActionDiff`] from [`ActionState`]
 ///
 /// The `ID` generic type should be a stable entity identifier,
 /// suitable to be sent across a network.


### PR DESCRIPTION
Fix doc error due to `redundant explicit link target` that was introduced in Rust 1.73