### PR TITLE
Fix divide by zero in ellipse deadzone

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -842,6 +842,10 @@ impl DeadZoneShape {
 
     /// Returns whether the (x, y) input is outside an ellipse.
     fn outside_ellipse(&self, x: f32, y: f32, radius_x: f32, radius_y: f32) -> bool {
+        if radius_x == 0.0 || radius_y == 0.0 {
+            return true;
+        }
+
         ((x / radius_x).powi(2) + (y / radius_y).powi(2)) > 1.0
     }
 }


### PR DESCRIPTION
As vero brought up in Discord, when either ellipse radius is 0, `NaN` is returned. So to fit with the other shapes when they are 0, if either radius is 0 then return true to allow any input value to be read.