### PR TITLE
Change deadzone to have boundary mean outside shape

### DIFF
--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -735,7 +735,7 @@ impl From<DualAxisData> for Vec2 {
 
 /// The shape of the deadzone for a [`DualAxis`] input.
 ///
-/// Input values that are on the line of the shape are counted as outside.
+/// Input values that are on the boundary of the shape are counted as outside.
 /// If a volume of a shape is 0, then all input values are read.
 ///
 /// Deadzone values should be in the range `0.0..=1.0`.

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -735,7 +735,8 @@ impl From<DualAxisData> for Vec2 {
 
 /// The shape of the deadzone for a [`DualAxis`] input.
 ///
-/// Input values that are on the line of the shape are counted as inside.
+/// Input values that are on the line of the shape are counted as outside.
+/// If a volume of a shape is 0, then all input values are read.
 ///
 /// Deadzone values should be in the range `0.0..=1.0`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
@@ -837,7 +838,7 @@ impl DeadZoneShape {
 
     /// Returns whether the (x, y) input is outside a rectangle.
     fn outside_rectangle(&self, x: f32, y: f32, width: f32, height: f32) -> bool {
-        x > width || x < -width || y > height || y < -height
+        x >= width || x <= -width || y >= height || y <= -height
     }
 
     /// Returns whether the (x, y) input is outside an ellipse.
@@ -846,6 +847,6 @@ impl DeadZoneShape {
             return true;
         }
 
-        ((x / radius_x).powi(2) + (y / radius_y).powi(2)) > 1.0
+        ((x / radius_x).powi(2) + (y / radius_y).powi(2)) >= 1.0
     }
 }

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -312,8 +312,8 @@ fn game_pad_dual_axis_cross() {
     app.send_input(DualAxis::from_value(
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
-        0.1,
-        0.05,
+        0.04,
+        0.04,
     ));
 
     app.update();
@@ -330,18 +330,18 @@ fn game_pad_dual_axis_cross() {
     app.send_input(DualAxis::from_value(
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
-        0.06,
-        0.06,
+        0.1,
+        0.05,
     ));
 
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(AxislikeTestAction::XY));
-    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.084852815);
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.111803405);
     assert_eq!(
         action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
-        DualAxisData::new(0.06, 0.06)
+        DualAxisData::new(0.1, 0.05)
     );
 }
 
@@ -360,8 +360,8 @@ fn game_pad_dual_axis_rect() {
     app.send_input(DualAxis::from_value(
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
-        0.1,
-        0.1,
+        0.05,
+        0.05,
     ));
 
     app.update();
@@ -379,17 +379,17 @@ fn game_pad_dual_axis_rect() {
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
         0.1,
-        0.2,
+        0.1,
     ));
 
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(AxislikeTestAction::XY));
-    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.22360681);
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.14142136);
     assert_eq!(
         action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
-        DualAxisData::new(0.1, 0.2)
+        DualAxisData::new(0.1, 0.1)
     );
 }
 
@@ -427,17 +427,17 @@ fn game_pad_dual_axis_ellipse() {
         GamepadAxisType::LeftStickX,
         GamepadAxisType::LeftStickY,
         0.1,
-        0.1,
+        0.0,
     ));
 
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(AxislikeTestAction::XY));
-    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.14142136);
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.1);
     assert_eq!(
         action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
-        DualAxisData::new(0.1, 0.1)
+        DualAxisData::new(0.1, 0.0)
     );
 }
 

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -442,6 +442,99 @@ fn game_pad_dual_axis_ellipse() {
 }
 
 #[test]
+fn test_zero_volume_cross() {
+    let mut app = test_app();
+    app.insert_resource(InputMap::new([(
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Cross {
+            rect_1_width: 0.0,
+            rect_1_height: 0.0,
+            rect_2_width: 0.0,
+            rect_2_height: 0.0,
+        }),
+        AxislikeTestAction::XY,
+    )]));
+
+    // Test any input, even (0, 0), will count as input
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.0,
+        0.0,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.pressed(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.0);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.0, 0.0)
+    );
+}
+
+#[test]
+fn test_zero_volume_rect() {
+    let mut app = test_app();
+    app.insert_resource(InputMap::new([(
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Rect {
+            width: 0.0,
+            height: 0.0,
+        }),
+        AxislikeTestAction::XY,
+    )]));
+
+    // Test any input, even (0, 0), will count as input
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.0,
+        0.0,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.pressed(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.0);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.0, 0.0)
+    );
+}
+
+
+#[test]
+fn test_zero_volume_ellipse() {
+    let mut app = test_app();
+    app.insert_resource(InputMap::new([(
+        DualAxis::left_stick().with_deadzone(DeadZoneShape::Ellipse {
+            radius_x: 0.0,
+            radius_y: 0.0,
+        }),
+        AxislikeTestAction::XY,
+    )]));
+
+    // Test any input, even (0, 0), will count as input
+    app.send_input(DualAxis::from_value(
+        GamepadAxisType::LeftStickX,
+        GamepadAxisType::LeftStickY,
+        0.0,
+        0.0,
+    ));
+
+    app.update();
+
+    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    assert!(action_state.pressed(AxislikeTestAction::XY));
+    assert_eq!(action_state.value(AxislikeTestAction::XY), 0.0);
+    assert_eq!(
+        action_state.axis_pair(AxislikeTestAction::XY).unwrap(),
+        DualAxisData::new(0.0, 0.0)
+    );
+}
+
+#[test]
 fn game_pad_virtualdpad() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -503,7 +503,6 @@ fn test_zero_volume_rect() {
     );
 }
 
-
 #[test]
 fn test_zero_volume_ellipse() {
     let mut app = test_app();


### PR DESCRIPTION
Having the boundary of the `DeadZoneShape` mean that it is outside is in line with #395. This also means that any `DeadZoneShape` that has a volume of 0 will let all input values be read.