### PR TITLE
Add `VirtualAxis::from_keys` Helper

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,7 +18,8 @@
 
 - Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
 - Added sensitivity for `SingleAxis` and `DualAxis`, allowing you to scale mouse, keypad and gamepad inputs differently for each action.
-- Added a hlper `from_keys` to `VirtualAxis` to simplify creating one from two keys
+- Added a helper `from_keys` to `VirtualAxis` to simplify creating one from two keys
+
 
 ### Usability
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -18,6 +18,7 @@
 
 - Added `DeadZoneShape` for `DualAxis` which allows for different deadzones shapes: cross, rectangle, and ellipse.
 - Added sensitivity for `SingleAxis` and `DualAxis`, allowing you to scale mouse, keypad and gamepad inputs differently for each action.
+- Added a hlper `from_keys` to `VirtualAxis` to simplify creating one from two keys
 
 ### Usability
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -458,36 +458,33 @@ pub struct VirtualAxis {
 }
 
 impl VirtualAxis {
+    /// Helper function for generating a [`VirtualAxis`] from arbitrary keycodes, shorthand for
+    /// wrapping each key in [`InputKind::Keyboard`]
+    pub fn from_keys(negative: KeyCode, positive: KeyCode) -> VirtualAxis {
+        VirtualAxis {
+            negative: InputKind::Keyboard(negative),
+            positive: InputKind::Keyboard(positive),
+        }
+    }
+
     /// Generates a [`VirtualAxis`] corresponding to the horizontal arrow keyboard keycodes
     pub fn horizontal_arrow_keys() -> VirtualAxis {
-        VirtualAxis {
-            negative: InputKind::Keyboard(KeyCode::Left),
-            positive: InputKind::Keyboard(KeyCode::Right),
-        }
+        VirtualAxis::from_keys(KeyCode::Left, KeyCode::Right)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the horizontal arrow keyboard keycodes
     pub fn vertical_arrow_keys() -> VirtualAxis {
-        VirtualAxis {
-            negative: InputKind::Keyboard(KeyCode::Down),
-            positive: InputKind::Keyboard(KeyCode::Up),
-        }
+        VirtualAxis::from_keys(KeyCode::Down, KeyCode::Up)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the `AD` keyboard keycodes.
     pub fn ad() -> VirtualAxis {
-        VirtualAxis {
-            negative: InputKind::Keyboard(KeyCode::A),
-            positive: InputKind::Keyboard(KeyCode::D),
-        }
+        VirtualAxis::from_keys(KeyCode::A, KeyCode::D)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the `WS` keyboard keycodes.
     pub fn ws() -> VirtualAxis {
-        VirtualAxis {
-            negative: InputKind::Keyboard(KeyCode::S),
-            positive: InputKind::Keyboard(KeyCode::W),
-        }
+        VirtualAxis::from_keys(KeyCode::S, KeyCode::W)
     }
 
     #[allow(clippy::doc_markdown)]


### PR DESCRIPTION
Adds a simple helper for two keys making up an axis beyond the `ad`, `ws` etc. provided. Usage is just:

```rs
input_map.insert(VirtualAxis::from_keys(KeyCode::F, KeyCode::R), Movement::Vertical);
```

Also migrated `ad`, `ws` etc. to use the new helper.