### PR TITLE
Fix `ToggleActions` from releasing other action's inputs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## Unreleased
+
+### Bugs
+- A disabled `ToggleActions` of one `Action` now does not release other `Action`'s inputs.
+
 ## Version 0.11.1
 - `bevy_egui` integration and the `egui` feature flag have been added back with the release of `bevy_egui` 0.23.
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -107,11 +107,7 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                         .in_set(InputManagerSystem::Update),
                 );
 
-                app.configure_sets(
-                    PreUpdate,
-                    InputManagerSystem::Update
-                        .after(InputSystem),
-                );
+                app.configure_sets(PreUpdate, InputManagerSystem::Update.after(InputSystem));
 
                 #[cfg(feature = "egui")]
                 app.configure_sets(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -102,13 +102,14 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
 
                 app.add_systems(
                     PreUpdate,
-                    update_action_state::<A>.in_set(InputManagerSystem::Update),
+                    update_action_state::<A>
+                        .run_if(run_if_enabled::<A>)
+                        .in_set(InputManagerSystem::Update),
                 );
 
                 app.configure_sets(
                     PreUpdate,
                     InputManagerSystem::Update
-                        .run_if(run_if_enabled::<A>)
                         .after(InputSystem),
                 );
 
@@ -125,7 +126,6 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                 app.configure_sets(
                     PreUpdate,
                     InputManagerSystem::ManualControl
-                        .run_if(run_if_enabled::<A>)
                         .before(InputManagerSystem::ReleaseOnDisable)
                         .after(InputManagerSystem::Tick)
                         // Must run after the system is updated from inputs, or it will be forcibly released due to the inputs
@@ -139,6 +139,7 @@ impl<A: Actionlike> Plugin for InputManagerPlugin<A> {
                 app.add_systems(
                     PreUpdate,
                     update_action_state_from_interaction::<A>
+                        .run_if(run_if_enabled::<A>)
                         .in_set(InputManagerSystem::ManualControl),
                 );
             }


### PR DESCRIPTION
When multiple `ToggleActions` exist, setting even one to disabled will release all input from other actions. Here is an example that fails on current main, but works with this pr:
```rust
fn main() {
    App::new()
        .add_plugins(DefaultPlugins)
        .add_plugins(InputManagerPlugin::<Action>::default())
        .add_plugins(InputManagerPlugin::<Action2>::default())
        .insert_resource(ToggleActions::<Action>::ENABLED)
        .insert_resource(ToggleActions::<Action2>::DISABLED)
        .add_systems(Startup, spawn_player)
        .add_systems(Update, jump)
        .run();
}

#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
enum Action {
    Run,
    Jump,
}

#[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
enum Action2 {
    A,
    B,
}

#[derive(Component)]
struct Player;

fn spawn_player(mut commands: Commands) {
    commands
        .spawn(InputManagerBundle::<Action> {
            action_state: ActionState::default(),
            input_map: InputMap::new([(KeyCode::Space, Action::Jump)]),
        })
        .insert(Player);
}

fn jump(query: Query<&ActionState<Action>, With<Player>>) {
    let action_state = query.single();
    // This will not ever run even if the jump button is pressed as `Action2` is disabled,
    // which affects `Action`
    if action_state.just_pressed(Action::Jump) {
        println!("I'm jumping!");
    }
}
```

This pr moves the run condition from any sets to the systems.