### PR TITLE
Fix mouse input events being read multiple times

### DIFF
--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -12,21 +12,23 @@ use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::input_streams::{InputStreams, MutableInputStreams};
 use crate::user_input::UserInput;
 
-use bevy::{app::App, input::mouse::{MouseScrollUnit, MouseMotion}, math::Vec2};
+use bevy::app::App;
 use bevy::ecs::event::Events;
 use bevy::ecs::system::{ResMut, SystemState};
 use bevy::ecs::world::World;
 #[cfg(feature = "ui")]
 use bevy::ecs::{component::Component, query::With, system::Query};
 use bevy::input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent};
+use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::ButtonState;
 use bevy::input::{
     gamepad::{Gamepad, GamepadButton, GamepadEvent},
     keyboard::{KeyCode, KeyboardInput},
-    mouse::{MouseButton, MouseButtonInput, MouseWheel},
+    mouse::{MouseButton, MouseButtonInput, MouseMotion, MouseWheel},
     touch::{TouchInput, Touches},
     Input,
 };
+use bevy::math::Vec2;
 use bevy::prelude::Entity;
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -12,23 +12,21 @@ use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::input_streams::{InputStreams, MutableInputStreams};
 use crate::user_input::UserInput;
 
-use bevy::app::App;
+use bevy::{app::App, input::mouse::{MouseScrollUnit, MouseMotion}, math::Vec2};
 use bevy::ecs::event::Events;
 use bevy::ecs::system::{ResMut, SystemState};
 use bevy::ecs::world::World;
 #[cfg(feature = "ui")]
 use bevy::ecs::{component::Component, query::With, system::Query};
 use bevy::input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent};
-use bevy::input::mouse::MouseScrollUnit;
 use bevy::input::ButtonState;
 use bevy::input::{
     gamepad::{Gamepad, GamepadButton, GamepadEvent},
     keyboard::{KeyCode, KeyboardInput},
-    mouse::{MouseButton, MouseButtonInput, MouseMotion, MouseWheel},
+    mouse::{MouseButton, MouseButtonInput, MouseWheel},
     touch::{TouchInput, Touches},
     Input,
 };
-use bevy::math::Vec2;
 use bevy::prelude::Entity;
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;
@@ -175,25 +173,25 @@ impl MockInput for MutableInputStreams<'_> {
         // Discrete mouse wheel events
         for mouse_wheel_direction in raw_inputs.mouse_wheel {
             match mouse_wheel_direction {
-                MouseWheelDirection::Left => self.mouse_wheel.send(MouseWheel {
+                MouseWheelDirection::Left => self.mouse_wheel.push(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: -1.0,
                     y: 0.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Right => self.mouse_wheel.send(MouseWheel {
+                MouseWheelDirection::Right => self.mouse_wheel.push(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 1.0,
                     y: 0.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Up => self.mouse_wheel.send(MouseWheel {
+                MouseWheelDirection::Up => self.mouse_wheel.push(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: 1.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Down => self.mouse_wheel.send(MouseWheel {
+                MouseWheelDirection::Down => self.mouse_wheel.push(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: -1.0,
@@ -205,16 +203,16 @@ impl MockInput for MutableInputStreams<'_> {
         // Discrete mouse motion event
         for mouse_motion_direction in raw_inputs.mouse_motion {
             match mouse_motion_direction {
-                MouseMotionDirection::Up => self.mouse_motion.send(MouseMotion {
+                MouseMotionDirection::Up => self.mouse_motion.push(MouseMotion {
                     delta: Vec2 { x: 0.0, y: 1.0 },
                 }),
-                MouseMotionDirection::Down => self.mouse_motion.send(MouseMotion {
+                MouseMotionDirection::Down => self.mouse_motion.push(MouseMotion {
                     delta: Vec2 { x: 0.0, y: -1.0 },
                 }),
-                MouseMotionDirection::Right => self.mouse_motion.send(MouseMotion {
+                MouseMotionDirection::Right => self.mouse_motion.push(MouseMotion {
                     delta: Vec2 { x: 1.0, y: 0.0 },
                 }),
-                MouseMotionDirection::Left => self.mouse_motion.send(MouseMotion {
+                MouseMotionDirection::Left => self.mouse_motion.push(MouseMotion {
                     delta: Vec2 { x: -1.0, y: 0.0 },
                 }),
             }
@@ -249,13 +247,13 @@ impl MockInput for MutableInputStreams<'_> {
                     AxisType::MouseWheel(axis_type) => {
                         match axis_type {
                             // FIXME: MouseScrollUnit is not recorded and is always assumed to be Pixel
-                            MouseWheelAxisType::X => self.mouse_wheel.send(MouseWheel {
+                            MouseWheelAxisType::X => self.mouse_wheel.push(MouseWheel {
                                 unit: MouseScrollUnit::Pixel,
                                 x: position_data,
                                 y: 0.0,
                                 window: Entity::PLACEHOLDER,
                             }),
-                            MouseWheelAxisType::Y => self.mouse_wheel.send(MouseWheel {
+                            MouseWheelAxisType::Y => self.mouse_wheel.push(MouseWheel {
                                 unit: MouseScrollUnit::Pixel,
                                 x: 0.0,
                                 y: position_data,
@@ -264,13 +262,13 @@ impl MockInput for MutableInputStreams<'_> {
                         }
                     }
                     AxisType::MouseMotion(axis_type) => match axis_type {
-                        MouseMotionAxisType::X => self.mouse_motion.send(MouseMotion {
+                        MouseMotionAxisType::X => self.mouse_motion.push(MouseMotion {
                             delta: Vec2 {
                                 x: position_data,
                                 y: 0.0,
                             },
                         }),
-                        MouseMotionAxisType::Y => self.mouse_motion.send(MouseMotion {
+                        MouseMotionAxisType::Y => self.mouse_motion.push(MouseMotion {
                             delta: Vec2 {
                                 x: 0.0,
                                 y: position_data,
@@ -341,8 +339,8 @@ impl MockInput for MutableInputStreams<'_> {
         *self.gamepad_axes = Default::default();
         *self.keycodes = Default::default();
         *self.mouse_buttons = Default::default();
-        *self.mouse_wheel = Default::default();
-        *self.mouse_motion = Default::default();
+        self.mouse_wheel = Default::default();
+        self.mouse_motion = Default::default();
     }
 
     #[cfg(feature = "ui")]

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -38,9 +38,9 @@ pub struct InputStreams<'a> {
     /// A [`MouseButton`] [`Input`] stream
     pub mouse_buttons: Option<&'a Input<MouseButton>>,
     /// A [`MouseWheel`] event stream
-    pub mouse_wheel: Option<&'a Events<MouseWheel>>,
+    pub mouse_wheel: Option<Vec<MouseWheel>>,
     /// A [`MouseMotion`] event stream
-    pub mouse_motion: &'a Events<MouseMotion>,
+    pub mouse_motion: Vec<MouseMotion>,
     /// The [`Gamepad`] that this struct will detect inputs from
     pub associated_gamepad: Option<Gamepad>,
 }
@@ -56,8 +56,19 @@ impl<'a> InputStreams<'a> {
         let keycodes = world.get_resource::<Input<KeyCode>>();
         let scan_codes = world.get_resource::<Input<ScanCode>>();
         let mouse_buttons = world.get_resource::<Input<MouseButton>>();
-        let mouse_wheel = world.get_resource::<Events<MouseWheel>>();
+        let mouse_wheel = world.resource::<Events<MouseWheel>>();
         let mouse_motion = world.resource::<Events<MouseMotion>>();
+
+        let mouse_wheel: Vec<MouseWheel> = mouse_wheel
+            .get_reader()
+            .read(mouse_wheel)
+            .cloned()
+            .collect();
+        let mouse_motion: Vec<MouseMotion> = mouse_motion
+            .get_reader()
+            .read(mouse_motion)
+            .cloned()
+            .collect();
 
         InputStreams {
             gamepad_buttons,
@@ -67,7 +78,7 @@ impl<'a> InputStreams<'a> {
             keycodes,
             scan_codes,
             mouse_buttons,
-            mouse_wheel,
+            mouse_wheel: Some(mouse_wheel),
             mouse_motion,
             associated_gamepad: gamepad,
         }
@@ -165,19 +176,16 @@ impl<'a> InputStreams<'a> {
                 matches!(self.mouse_buttons, Some(mouse_buttons) if mouse_buttons.pressed(mouse_button))
             }
             InputKind::MouseWheel(mouse_wheel_direction) => {
-                let Some(mouse_wheel) = self.mouse_wheel else {
+                let Some(mouse_wheel) = &self.mouse_wheel else {
                     return false;
                 };
 
                 let mut total_mouse_wheel_movement = 0.0;
 
-                // FIXME: verify that this works and doesn't double count events
-                let mut event_reader = mouse_wheel.get_reader();
-
                 // PERF: this summing is computed for every individual input
                 // This should probably be computed once, and then cached / read
                 // Fix upstream!
-                for mouse_wheel_event in event_reader.read(mouse_wheel) {
+                for mouse_wheel_event in mouse_wheel {
                     total_mouse_wheel_movement += match mouse_wheel_direction {
                         MouseWheelDirection::Up | MouseWheelDirection::Down => mouse_wheel_event.y,
                         MouseWheelDirection::Left | MouseWheelDirection::Right => {
@@ -199,10 +207,7 @@ impl<'a> InputStreams<'a> {
             InputKind::MouseMotion(mouse_motion_direction) => {
                 let mut total_mouse_movement = 0.0;
 
-                // FIXME: verify that this works and doesn't double count events
-                let mut event_reader = self.mouse_motion.get_reader();
-
-                for mouse_motion_event in event_reader.read(self.mouse_motion) {
+                for mouse_motion_event in &self.mouse_motion {
                     total_mouse_movement += match mouse_motion_direction {
                         MouseMotionDirection::Up | MouseMotionDirection::Down => {
                             mouse_motion_event.delta.y
@@ -300,15 +305,13 @@ impl<'a> InputStreams<'a> {
                         }
                     }
                     AxisType::MouseWheel(axis_type) => {
-                        let Some(mouse_wheel) = self.mouse_wheel else {
+                        let Some(mouse_wheel) = &self.mouse_wheel else {
                             return 0.0;
                         };
 
                         let mut total_mouse_wheel_movement = 0.0;
-                        // FIXME: verify that this works and doesn't double count events
-                        let mut event_reader = mouse_wheel.get_reader();
 
-                        for mouse_wheel_event in event_reader.read(mouse_wheel) {
+                        for mouse_wheel_event in mouse_wheel {
                             total_mouse_wheel_movement += match axis_type {
                                 MouseWheelAxisType::X => mouse_wheel_event.x,
                                 MouseWheelAxisType::Y => mouse_wheel_event.y,
@@ -319,10 +322,8 @@ impl<'a> InputStreams<'a> {
                     // CLEANUP: deduplicate code with MouseWheel
                     AxisType::MouseMotion(axis_type) => {
                         let mut total_mouse_motion_movement = 0.0;
-                        // FIXME: verify that this works and doesn't double count events
-                        let mut event_reader = self.mouse_motion.get_reader();
 
-                        for mouse_wheel_event in event_reader.read(self.mouse_motion) {
+                        for mouse_wheel_event in &self.mouse_motion {
                             total_mouse_motion_movement += match axis_type {
                                 MouseMotionAxisType::X => mouse_wheel_event.delta.x,
                                 MouseMotionAxisType::Y => mouse_wheel_event.delta.y,
@@ -496,9 +497,9 @@ pub struct MutableInputStreams<'a> {
     /// Events used for mocking [`MouseButton`] inputs
     pub mouse_button_events: &'a mut Events<MouseButtonInput>,
     /// A [`MouseWheel`] event stream
-    pub mouse_wheel: &'a mut Events<MouseWheel>,
+    pub mouse_wheel: Vec<MouseWheel>,
     /// A [`MouseMotion`] event stream
-    pub mouse_motion: &'a mut Events<MouseMotion>,
+    pub mouse_motion: Vec<MouseMotion>,
 
     /// The [`Gamepad`] that this struct will detect inputs from
     pub associated_gamepad: Option<Gamepad>,
@@ -537,6 +538,18 @@ impl<'a> MutableInputStreams<'a> {
             mouse_motion,
         ) = input_system_state.get_mut(world);
 
+        let mouse_wheel: Vec<MouseWheel> = mouse_wheel
+            .get_reader()
+            .read(&mouse_wheel)
+            .cloned()
+            .collect();
+
+        let mouse_motion: Vec<MouseMotion> = mouse_motion
+            .get_reader()
+            .read(&mouse_motion)
+            .cloned()
+            .collect();
+
         MutableInputStreams {
             gamepad_buttons: gamepad_buttons.into_inner(),
             gamepad_button_axes: gamepad_button_axes.into_inner(),
@@ -548,8 +561,8 @@ impl<'a> MutableInputStreams<'a> {
             keyboard_events: keyboard_events.into_inner(),
             mouse_buttons: mouse_buttons.into_inner(),
             mouse_button_events: mouse_button_events.into_inner(),
-            mouse_wheel: mouse_wheel.into_inner(),
-            mouse_motion: mouse_motion.into_inner(),
+            mouse_wheel,
+            mouse_motion,
             associated_gamepad: gamepad,
         }
     }
@@ -593,8 +606,8 @@ impl<'a> From<&'a MutableInputStreams<'a>> for InputStreams<'a> {
             keycodes: Some(mutable_streams.keycodes),
             scan_codes: Some(mutable_streams.scan_codes),
             mouse_buttons: Some(mutable_streams.mouse_buttons),
-            mouse_wheel: Some(mutable_streams.mouse_wheel),
-            mouse_motion: mutable_streams.mouse_motion,
+            mouse_wheel: Some(mutable_streams.mouse_wheel.clone()),
+            mouse_motion: mutable_streams.mouse_motion.clone(),
             associated_gamepad: mutable_streams.associated_gamepad,
         }
     }


### PR DESCRIPTION
@alice-i-cecile I saw you were busy moving at the moment (congrats c:), but this should fix the issue with Bevy 0.12.1 that people mentioned in the discord.

Fixes #285

Cleanest fix I could come up with was to replace the `Events<T>` in `InputStreams` with `Vec<T>`, and then collecting the events into that with an `EventReader` in `update_action_state`.

