### PR TITLE
fixed mouse motion tests

### DIFF
--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -175,25 +175,25 @@ impl MockInput for MutableInputStreams<'_> {
         // Discrete mouse wheel events
         for mouse_wheel_direction in raw_inputs.mouse_wheel {
             match mouse_wheel_direction {
-                MouseWheelDirection::Left => self.mouse_wheel.push(MouseWheel {
+                MouseWheelDirection::Left => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: -1.0,
                     y: 0.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Right => self.mouse_wheel.push(MouseWheel {
+                MouseWheelDirection::Right => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 1.0,
                     y: 0.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Up => self.mouse_wheel.push(MouseWheel {
+                MouseWheelDirection::Up => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: 1.0,
                     window: Entity::PLACEHOLDER,
                 }),
-                MouseWheelDirection::Down => self.mouse_wheel.push(MouseWheel {
+                MouseWheelDirection::Down => self.mouse_wheel.send(MouseWheel {
                     unit: MouseScrollUnit::Pixel,
                     x: 0.0,
                     y: -1.0,
@@ -205,16 +205,16 @@ impl MockInput for MutableInputStreams<'_> {
         // Discrete mouse motion event
         for mouse_motion_direction in raw_inputs.mouse_motion {
             match mouse_motion_direction {
-                MouseMotionDirection::Up => self.mouse_motion.push(MouseMotion {
+                MouseMotionDirection::Up => self.mouse_motion.send(MouseMotion {
                     delta: Vec2 { x: 0.0, y: 1.0 },
                 }),
-                MouseMotionDirection::Down => self.mouse_motion.push(MouseMotion {
+                MouseMotionDirection::Down => self.mouse_motion.send(MouseMotion {
                     delta: Vec2 { x: 0.0, y: -1.0 },
                 }),
-                MouseMotionDirection::Right => self.mouse_motion.push(MouseMotion {
+                MouseMotionDirection::Right => self.mouse_motion.send(MouseMotion {
                     delta: Vec2 { x: 1.0, y: 0.0 },
                 }),
-                MouseMotionDirection::Left => self.mouse_motion.push(MouseMotion {
+                MouseMotionDirection::Left => self.mouse_motion.send(MouseMotion {
                     delta: Vec2 { x: -1.0, y: 0.0 },
                 }),
             }
@@ -249,13 +249,13 @@ impl MockInput for MutableInputStreams<'_> {
                     AxisType::MouseWheel(axis_type) => {
                         match axis_type {
                             // FIXME: MouseScrollUnit is not recorded and is always assumed to be Pixel
-                            MouseWheelAxisType::X => self.mouse_wheel.push(MouseWheel {
+                            MouseWheelAxisType::X => self.mouse_wheel.send(MouseWheel {
                                 unit: MouseScrollUnit::Pixel,
                                 x: position_data,
                                 y: 0.0,
                                 window: Entity::PLACEHOLDER,
                             }),
-                            MouseWheelAxisType::Y => self.mouse_wheel.push(MouseWheel {
+                            MouseWheelAxisType::Y => self.mouse_wheel.send(MouseWheel {
                                 unit: MouseScrollUnit::Pixel,
                                 x: 0.0,
                                 y: position_data,
@@ -264,13 +264,13 @@ impl MockInput for MutableInputStreams<'_> {
                         }
                     }
                     AxisType::MouseMotion(axis_type) => match axis_type {
-                        MouseMotionAxisType::X => self.mouse_motion.push(MouseMotion {
+                        MouseMotionAxisType::X => self.mouse_motion.send(MouseMotion {
                             delta: Vec2 {
                                 x: position_data,
                                 y: 0.0,
                             },
                         }),
-                        MouseMotionAxisType::Y => self.mouse_motion.push(MouseMotion {
+                        MouseMotionAxisType::Y => self.mouse_motion.send(MouseMotion {
                             delta: Vec2 {
                                 x: 0.0,
                                 y: position_data,
@@ -341,8 +341,8 @@ impl MockInput for MutableInputStreams<'_> {
         *self.gamepad_axes = Default::default();
         *self.keycodes = Default::default();
         *self.mouse_buttons = Default::default();
-        self.mouse_wheel = Default::default();
-        self.mouse_motion = Default::default();
+        *self.mouse_wheel = Default::default();
+        *self.mouse_motion = Default::default();
     }
 
     #[cfg(feature = "ui")]

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -497,9 +497,9 @@ pub struct MutableInputStreams<'a> {
     /// Events used for mocking [`MouseButton`] inputs
     pub mouse_button_events: &'a mut Events<MouseButtonInput>,
     /// A [`MouseWheel`] event stream
-    pub mouse_wheel: Vec<MouseWheel>,
+    pub mouse_wheel: &'a mut Events<MouseWheel>,
     /// A [`MouseMotion`] event stream
-    pub mouse_motion: Vec<MouseMotion>,
+    pub mouse_motion: &'a mut Events<MouseMotion>,
 
     /// The [`Gamepad`] that this struct will detect inputs from
     pub associated_gamepad: Option<Gamepad>,
@@ -538,18 +538,6 @@ impl<'a> MutableInputStreams<'a> {
             mouse_motion,
         ) = input_system_state.get_mut(world);
 
-        let mouse_wheel: Vec<MouseWheel> = mouse_wheel
-            .get_reader()
-            .read(&mouse_wheel)
-            .cloned()
-            .collect();
-
-        let mouse_motion: Vec<MouseMotion> = mouse_motion
-            .get_reader()
-            .read(&mouse_motion)
-            .cloned()
-            .collect();
-
         MutableInputStreams {
             gamepad_buttons: gamepad_buttons.into_inner(),
             gamepad_button_axes: gamepad_button_axes.into_inner(),
@@ -561,8 +549,8 @@ impl<'a> MutableInputStreams<'a> {
             keyboard_events: keyboard_events.into_inner(),
             mouse_buttons: mouse_buttons.into_inner(),
             mouse_button_events: mouse_button_events.into_inner(),
-            mouse_wheel,
-            mouse_motion,
+            mouse_wheel: mouse_wheel.into_inner(),
+            mouse_motion: mouse_motion.into_inner(),
             associated_gamepad: gamepad,
         }
     }
@@ -589,8 +577,20 @@ impl<'a> From<MutableInputStreams<'a>> for InputStreams<'a> {
             keycodes: Some(mutable_streams.keycodes),
             scan_codes: Some(mutable_streams.scan_codes),
             mouse_buttons: Some(mutable_streams.mouse_buttons),
-            mouse_wheel: Some(mutable_streams.mouse_wheel),
-            mouse_motion: mutable_streams.mouse_motion,
+            mouse_wheel: Some(
+                mutable_streams
+                    .mouse_wheel
+                    .get_reader()
+                    .read(mutable_streams.mouse_wheel)
+                    .cloned()
+                    .collect(),
+            ),
+            mouse_motion: mutable_streams
+                .mouse_motion
+                .get_reader()
+                .read(mutable_streams.mouse_motion)
+                .cloned()
+                .collect(),
             associated_gamepad: mutable_streams.associated_gamepad,
         }
     }
@@ -606,8 +606,20 @@ impl<'a> From<&'a MutableInputStreams<'a>> for InputStreams<'a> {
             keycodes: Some(mutable_streams.keycodes),
             scan_codes: Some(mutable_streams.scan_codes),
             mouse_buttons: Some(mutable_streams.mouse_buttons),
-            mouse_wheel: Some(mutable_streams.mouse_wheel.clone()),
-            mouse_motion: mutable_streams.mouse_motion.clone(),
+            mouse_wheel: Some(
+                mutable_streams
+                    .mouse_wheel
+                    .get_reader()
+                    .read(mutable_streams.mouse_wheel)
+                    .cloned()
+                    .collect(),
+            ),
+            mouse_motion: mutable_streams
+                .mouse_motion
+                .get_reader()
+                .read(mutable_streams.mouse_motion)
+                .cloned()
+                .collect(),
             associated_gamepad: mutable_streams.associated_gamepad,
         }
     }


### PR DESCRIPTION
The change in #418 to use a Vec instead of Events in MutableInputStreams broke input mocking for MouseMotion. I reverted the changes to MutableInputStreams so that it can send MouseMotion events. InputStreams remains unchanged. This brings the tests back to passing without undoing the effect of the original change. 

Fixes #419