### PR TITLE
Add `InputMap::clear`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## Unreleased
+
+- Added `InputMap::Clear`.
+
 ## Version 0.11.2
 
 - fixed [a bug](https://github.com/Leafwing-Studios/leafwing-input-manager/issues/285) with mouse motion and mouse wheel events being improperly counted

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -431,6 +431,13 @@ impl<A: Actionlike> InputMap<A> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    /// Clears the map, removing all action-inputs pairs.
+    ///
+    /// Keeps the allocated memory for reuse.
+    pub fn clear(&mut self) {
+        self.map.clear();
+    }
 }
 
 // Removing


### PR DESCRIPTION
Sometimes it's useful to reset all mappings and re-populate it from scratch. Instead of creating a new `InputMap`, it's better to  reuse the allocated memory.