### PR TITLE
A better solution to fix incorrect axis data in `Chord`

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -373,19 +373,15 @@ impl<A: Actionlike> InputMap<A> {
             for input in input_vec {
                 let action = &mut action_data[action.index()];
 
-                // Exclude chord combining both button-like and axis-like inputs unless all buttons are pressed.
-                if let UserInput::Chord(buttons) = input {
-                    if input_streams.all_buttons_pressed(buttons) {
-                        inputs.push(input.clone());
-
-                        action.value += input_streams.input_value(input, true);
-
-                        merge_axis_pair_into_action(action, input_streams, input);
+                // Merge axis pair into action data
+                let axis_pair = input_streams.input_axis_pair(input);
+                if let Some(axis_pair) = axis_pair {
+                    if let Some(current_axis_pair) = &mut action.axis_pair {
+                        *current_axis_pair = current_axis_pair.merged_with(axis_pair);
+                    } else {
+                        action.axis_pair = Some(axis_pair);
                     }
-                    continue;
                 }
-
-                merge_axis_pair_into_action(action, input_streams, input);
 
                 if input_streams.input_pressed(input) {
                     inputs.push(input.clone());
@@ -403,22 +399,6 @@ impl<A: Actionlike> InputMap<A> {
         self.handle_clashes(&mut action_data, input_streams, clash_strategy);
 
         action_data
-    }
-}
-
-/// Merges axis pair into action data.
-#[inline]
-fn merge_axis_pair_into_action(
-    action: &mut ActionData,
-    input_streams: &InputStreams,
-    input: &UserInput,
-) {
-    if let Some(axis_pair) = input_streams.input_axis_pair(input) {
-        if let Some(current_axis_pair) = &mut action.axis_pair {
-            *current_axis_pair = current_axis_pair.merged_with(axis_pair);
-        } else {
-            action.axis_pair = Some(axis_pair);
-        }
     }
 }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -421,16 +421,20 @@ impl<'a> InputStreams<'a> {
     /// be sure to clamp the returned data.
     pub fn input_axis_pair(&self, input: &UserInput) -> Option<DualAxisData> {
         match input {
-            UserInput::Chord(inputs) => inputs
-                .iter()
-                .flat_map(|input_kind| {
-                    if let InputKind::DualAxis(dual_axis) = input_kind {
-                        Some(self.extract_dual_axis_data(dual_axis))
-                    } else {
-                        None
+            UserInput::Chord(inputs) => {
+                for input_kind in inputs.iter() {
+                    // Exclude chord combining both button-like and axis-like inputs unless all buttons are pressed.
+                    if !self.button_pressed(*input_kind) {
+                        return None;
                     }
-                })
-                .next(),
+
+                    // Return result of the first dual axis in the chord.
+                    if let InputKind::DualAxis(dual_axis) = input_kind {
+                        return Some(self.extract_dual_axis_data(dual_axis));
+                    }
+                }
+                None
+            }
             UserInput::Single(InputKind::DualAxis(dual_axis)) => {
                 Some(self.extract_dual_axis_data(dual_axis))
             }


### PR DESCRIPTION
Previously, I missed checking where the `InputStream::input_axis_pair()` function was used, got a bit worried that it might be widely used. However, upon investigation, it seems it’s just handling this way for `Chord`s—my bad! This made the solution more complex. So, I undid #432 (what I did earlier) and fixed up #430 again.

Fixing this problem should mainly involve checking if all buttons declared in the `Chord` are pressed. This simpler solution ([compared to the unchanged](https://github.com/Dzjudieng/leafwing-input-manager/compare/9d60abb..d3d0c00)) uses a for-loop that breaks out early. Perhaps it could potentially improve performance by avoiding redundant calculations to get the first dual axis data?