### PR TITLE
Update action-diff to not include the stable component ID

### DIFF
--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -9,9 +9,9 @@
 use bevy::ecs::event::{Events, ManualEventReader};
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::action_state::{ActionDiffEvent};
+use leafwing_input_manager::action_state::ActionDiffEvent;
 use leafwing_input_manager::prelude::*;
-use leafwing_input_manager::systems::{generate_action_diffs};
+use leafwing_input_manager::systems::generate_action_diffs;
 
 use std::fmt::Debug;
 
@@ -104,11 +104,8 @@ fn main() {
 
     // Sending over the new `ActionDiff` event stream,
     // we can see that the actions are now released on the server too
-    let _event_reader = send_events::<ActionDiffEvent<FpsAction>>(
-        &client_app,
-        &mut server_app,
-        Some(event_reader),
-    );
+    let _event_reader =
+        send_events::<ActionDiffEvent<FpsAction>>(&client_app, &mut server_app, Some(event_reader));
 
     server_app.update();
 

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -9,9 +9,9 @@
 use bevy::ecs::event::{Events, ManualEventReader};
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::action_state::ActionDiff;
+use leafwing_input_manager::action_state::{ActionDiffEvent};
 use leafwing_input_manager::prelude::*;
-use leafwing_input_manager::systems::{generate_action_diffs, process_action_diffs};
+use leafwing_input_manager::systems::{generate_action_diffs};
 
 use std::fmt::Debug;
 
@@ -27,6 +27,22 @@ enum FpsAction {
 #[derive(Component, Clone, PartialEq, Eq, Hash, Debug)]
 struct StableId(u64);
 
+/// Processes an [`Events`] stream of [`ActionDiff`] to update an [`ActionState`]
+///
+/// In a real scenario, you would have to map the entities between the server and client world.
+/// In this case, we will just use the fact that there is only a single entity.
+fn process_action_diffs<A: Actionlike>(
+    mut action_state_query: Query<&mut ActionState<A>>,
+    mut action_diff_events: EventReader<ActionDiffEvent<A>>,
+) {
+    for action_diff_event in action_diff_events.read() {
+        if action_diff_event.owner.is_some() {
+            let mut action_state = action_state_query.get_single_mut().unwrap();
+            action_state.apply_diff(&action_diff_event.action_diff);
+        }
+    }
+}
+
 fn main() {
     // In a real use case, these apps would be running on separate devices.
     let mut client_app = App::new();
@@ -36,17 +52,17 @@ fn main() {
         .add_plugins(InputPlugin)
         .add_plugins(InputManagerPlugin::<FpsAction>::default())
         // Creates an event stream of `ActionDiffs` to send to the server
-        .add_systems(PostUpdate, generate_action_diffs::<FpsAction, StableId>)
-        .add_event::<ActionDiff<FpsAction, StableId>>()
+        .add_systems(PostUpdate, generate_action_diffs::<FpsAction>)
+        .add_event::<ActionDiffEvent<FpsAction>>()
         .add_systems(Startup, spawn_player);
 
     let mut server_app = App::new();
     server_app
         .add_plugins(MinimalPlugins)
         .add_plugins(InputManagerPlugin::<FpsAction>::server())
-        .add_event::<ActionDiff<FpsAction, StableId>>()
+        .add_event::<ActionDiffEvent<FpsAction>>()
         // Reads in the event stream of `ActionDiffs` to update the `ActionState`
-        .add_systems(PreUpdate, process_action_diffs::<FpsAction, StableId>)
+        .add_systems(PreUpdate, process_action_diffs::<FpsAction>)
         // Typically, the rest of this information would synchronized as well
         .add_systems(Startup, spawn_player);
 
@@ -67,7 +83,7 @@ fn main() {
 
     // These events are transferred to the server
     let event_reader =
-        send_events::<ActionDiff<FpsAction, StableId>>(&client_app, &mut server_app, None);
+        send_events::<ActionDiffEvent<FpsAction>>(&client_app, &mut server_app, None);
 
     // The server processes the event stream
     server_app.update();
@@ -88,7 +104,7 @@ fn main() {
 
     // Sending over the new `ActionDiff` event stream,
     // we can see that the actions are now released on the server too
-    let _event_reader = send_events::<ActionDiff<FpsAction, StableId>>(
+    let _event_reader = send_events::<ActionDiffEvent<FpsAction>>(
         &client_app,
         &mut server_app,
         Some(event_reader),
@@ -116,9 +132,6 @@ fn spawn_player(mut commands: Commands) {
                 .build(),
             ..default()
         })
-        // This identifier must match on both the client and server
-        // and be unique between players
-        .insert(StableId(76))
         .insert(Player);
 }
 

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -38,7 +38,7 @@ fn process_action_diffs<A: Actionlike>(
     for action_diff_event in action_diff_events.read() {
         if action_diff_event.owner.is_some() {
             let mut action_state = action_state_query.get_single_mut().unwrap();
-            action_state.apply_diff(&action_diff_event.action_diff);
+            action_diff_event.action_diffs.iter().for_each(|diff| action_state.apply_diff(diff));
         }
     }
 }

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -38,7 +38,10 @@ fn process_action_diffs<A: Actionlike>(
     for action_diff_event in action_diff_events.read() {
         if action_diff_event.owner.is_some() {
             let mut action_state = action_state_query.get_single_mut().unwrap();
-            action_diff_event.action_diffs.iter().for_each(|diff| action_state.apply_diff(diff));
+            action_diff_event
+                .action_diffs
+                .iter()
+                .for_each(|diff| action_state.apply_diff(diff));
         }
     }
 }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -501,6 +501,44 @@ impl<A: Actionlike> ActionState<A> {
     pub fn previous_duration(&self, action: A) -> Duration {
         self.action_data[action.index()].timing.previous_duration
     }
+
+    /// Applies an [`ActionDiff`] (usually received over the network) to the [`ActionState`].
+    ///
+    /// This lets you reconstruct an [`ActionState`] from a stream of [`ActionDiff`]s
+    pub fn apply_diff(&mut self, action_diff: &ActionDiff<A>) {
+        match action_diff {
+            ActionDiff::Pressed {
+                action,
+            } => {
+                self.press(action.clone());
+                self.action_data_mut(action.clone()).value = 1.;
+            }
+            ActionDiff::Released {
+                action,
+            } => {
+                self.release(action.clone());
+                let action_data = self.action_data_mut(action.clone());
+                action_data.value = 0.;
+                action_data.axis_pair = None;
+            }
+            ActionDiff::ValueChanged {
+                action,
+                value,
+            } => {
+                self.press(action.clone());
+                self.action_data_mut(action.clone()).value = *value;
+            }
+            ActionDiff::AxisPairChanged {
+                action,
+                axis_pair,
+            } => {
+                self.press(action.clone());
+                let action_data = self.action_data_mut(action.clone());
+                action_data.axis_pair = Some(DualAxisData::from_xy(*axis_pair));
+                action_data.value = axis_pair.length();
+            }
+        };
+    }
 }
 
 impl<A: Actionlike> Default for ActionState<A> {
@@ -752,35 +790,42 @@ impl Timing {
     }
 }
 
+/// Will store an `ActionDiff` as well as what generated it (either an Entity, or nothing if the
+/// input actions are represented by a `Resource`)
+///
+/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Event)]
+pub struct ActionDiffEvent<A: Actionlike> {
+    /// If some: the entity that has the `ActionState<A>` component
+    /// If none: `ActionState<A>` is a Resource, not a component
+    pub owner: Option<Entity>,
+    /// The `ActionDiff` that was generated
+    pub action_diff: ActionDiff<A>,
+}
+
+
 /// Stores presses and releases of buttons without timing information
 ///
-/// These are typically accessed using the `Events<ActionDiff>` resource.
+/// These are typically accessed using the `Events<ActionDiffEvent>` resource.
 /// Uses a minimal storage format, in order to facilitate transport over the network.
 ///
-/// `ID` should be a component type that stores a unique stable identifier for the entity
-/// that stores the corresponding [`ActionState`].
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Event)]
-pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
+/// An `ActionState` can be fully reconstructed from a stream of `ActionDiff`
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum ActionDiff<A: Actionlike> {
     /// The action was pressed
     Pressed {
         /// The value of the action
         action: A,
-        /// The stable identifier of the entity
-        id: ID,
     },
     /// The action was released
     Released {
         /// The value of the action
         action: A,
-        /// The stable identifier of the entity
-        id: ID,
     },
     /// The value of the action changed
     ValueChanged {
         /// The value of the action
         action: A,
-        /// The stable identifier of the entity
-        id: ID,
         /// The new value of the action
         value: f32,
     },
@@ -788,8 +833,6 @@ pub enum ActionDiff<A: Actionlike, ID: Eq + Clone + Component> {
     AxisPairChanged {
         /// The value of the action
         action: A,
-        /// The stable identifier of the entity
-        id: ID,
         /// The new value of the axis
         axis_pair: Vec2,
     },

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -507,31 +507,21 @@ impl<A: Actionlike> ActionState<A> {
     /// This lets you reconstruct an [`ActionState`] from a stream of [`ActionDiff`]s
     pub fn apply_diff(&mut self, action_diff: &ActionDiff<A>) {
         match action_diff {
-            ActionDiff::Pressed {
-                action,
-            } => {
+            ActionDiff::Pressed { action } => {
                 self.press(action.clone());
                 self.action_data_mut(action.clone()).value = 1.;
             }
-            ActionDiff::Released {
-                action,
-            } => {
+            ActionDiff::Released { action } => {
                 self.release(action.clone());
                 let action_data = self.action_data_mut(action.clone());
                 action_data.value = 0.;
                 action_data.axis_pair = None;
             }
-            ActionDiff::ValueChanged {
-                action,
-                value,
-            } => {
+            ActionDiff::ValueChanged { action, value } => {
                 self.press(action.clone());
                 self.action_data_mut(action.clone()).value = *value;
             }
-            ActionDiff::AxisPairChanged {
-                action,
-                axis_pair,
-            } => {
+            ActionDiff::AxisPairChanged { action, axis_pair } => {
                 self.press(action.clone());
                 let action_data = self.action_data_mut(action.clone());
                 action_data.axis_pair = Some(DualAxisData::from_xy(*axis_pair));
@@ -802,7 +792,6 @@ pub struct ActionDiffEvent<A: Actionlike> {
     /// The `ActionDiff` that was generated
     pub action_diff: ActionDiff<A>,
 }
-
 
 /// Stores presses and releases of buttons without timing information
 ///

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -790,7 +790,7 @@ pub struct ActionDiffEvent<A: Actionlike> {
     /// If none: `ActionState<A>` is a Resource, not a component
     pub owner: Option<Entity>,
     /// The `ActionDiff` that was generated
-    pub action_diff: ActionDiff<A>,
+    pub action_diffs: Vec<ActionDiff<A>>,
 }
 
 /// Stores presses and releases of buttons without timing information

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -3,22 +3,21 @@ use leafwing_input_manager::{
     action_state::ActionDiff,
     axislike::DualAxisData,
     prelude::*,
-    systems::{generate_action_diffs, process_action_diffs},
+    systems::{generate_action_diffs},
 };
+use leafwing_input_manager::action_state::ActionDiffEvent;
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
 enum Action {
     PayTheBills,
 }
 
-#[derive(Clone, Copy, Component, Debug, Reflect, PartialEq, Eq, Hash)]
-struct BankAccountId(u32);
 
 #[derive(Default)]
 struct Counter(pub u8);
 
-fn spawn_da_bills(mut commands: Commands) {
-    commands.spawn((BankAccountId(1337), ActionState::<Action>::default()));
+fn spawn_da_bills(mut commands: Commands, ) {
+    commands.spawn(ActionState::<Action>::default());
 }
 
 fn pay_da_bills(
@@ -37,6 +36,18 @@ fn pay_da_bills(
     }
 }
 
+fn process_action_diffs<A: Actionlike>(
+    mut action_state_query: Query<&mut ActionState<A>>,
+    mut action_diff_events: EventReader<ActionDiffEvent<A>>,
+) {
+    for action_diff_event in action_diff_events.read() {
+        if action_diff_event.owner.is_some() {
+            let mut action_state = action_state_query.get_single_mut().unwrap();
+            action_state.apply_diff(&action_diff_event.action_diff);
+        }
+    }
+}
+
 fn create_app() -> App {
     let mut app = App::new();
     app.add_plugins((
@@ -45,7 +56,8 @@ fn create_app() -> App {
         InputManagerPlugin::<Action>::default(),
     ))
     .add_systems(Startup, spawn_da_bills)
-    .add_event::<ActionDiff<Action, BankAccountId>>();
+    .add_event::<ActionDiffEvent<Action>>();
+    app.update();
     app
 }
 
@@ -56,13 +68,13 @@ fn get_events_mut<E: Event>(app: &mut App) -> Mut<Events<E>> {
     app.world.resource_mut()
 }
 
-fn send_action_diff(app: &mut App, action_diff: ActionDiff<Action, BankAccountId>) {
-    let mut action_diff_events = get_events_mut::<ActionDiff<Action, BankAccountId>>(app);
+fn send_action_diff(app: &mut App, action_diff: ActionDiffEvent<Action>) {
+    let mut action_diff_events = get_events_mut::<ActionDiffEvent<Action>>(app);
     action_diff_events.send(action_diff);
 }
 
 fn assert_has_no_action_diffs(app: &mut App) {
-    let action_diff_events = get_events::<ActionDiff<Action, BankAccountId>>(app);
+    let action_diff_events = get_events::<ActionDiffEvent<Action>>(app);
     let action_diff_event_reader = &mut action_diff_events.get_reader();
     match action_diff_event_reader.read(action_diff_events).next() {
         Some(action_diff) => panic!(
@@ -75,9 +87,9 @@ fn assert_has_no_action_diffs(app: &mut App) {
 
 fn assert_action_diff_created(
     app: &mut App,
-    predicate: impl Fn(&ActionDiff<Action, BankAccountId>),
+    predicate: impl Fn(&ActionDiffEvent<Action>),
 ) {
-    let mut action_diff_events = get_events_mut::<ActionDiff<Action, BankAccountId>>(app);
+    let mut action_diff_events = get_events_mut::<ActionDiffEvent<Action>>(app);
     let action_diff_event_reader = &mut action_diff_events.get_reader();
     assert!(action_diff_event_reader.len(action_diff_events.as_ref()) < 2);
     match action_diff_event_reader
@@ -90,21 +102,20 @@ fn assert_action_diff_created(
     action_diff_events.clear();
 }
 
-fn assert_action_diff_received(app: &mut App, action_diff: ActionDiff<Action, BankAccountId>) {
+fn assert_action_diff_received(app: &mut App, action_diff: ActionDiffEvent<Action>) {
     let mut action_state_query = app.world.query::<&ActionState<Action>>();
     let action_state = action_state_query.get_single(&app.world).unwrap();
-    match action_diff {
-        ActionDiff::Pressed { id: _, action } => {
+    match action_diff.action_diff {
+        ActionDiff::Pressed { action } => {
             assert!(action_state.pressed(action));
             assert!(action_state.value(action) == 1.);
         }
-        ActionDiff::Released { id: _, action } => {
+        ActionDiff::Released { action } => {
             assert!(action_state.released(action));
             assert!(action_state.value(action) == 0.);
             assert!(action_state.axis_pair(action).is_none());
         }
         ActionDiff::ValueChanged {
-            id: _,
             action,
             value,
         } => {
@@ -112,7 +123,6 @@ fn assert_action_diff_received(app: &mut App, action_diff: ActionDiff<Action, Ba
             assert!(action_state.value(action) == value);
         }
         ActionDiff::AxisPairChanged {
-            id: _,
             action,
             axis_pair,
         } => {
@@ -131,33 +141,28 @@ fn assert_action_diff_received(app: &mut App, action_diff: ActionDiff<Action, Ba
 #[test]
 fn generate_binary_action_diffs() {
     let mut app = create_app();
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(|mut action_state| {
             action_state.action_data_mut(Action::PayTheBills).value = 1.;
         }),
     )
-    .add_systems(PostUpdate, generate_action_diffs::<Action, BankAccountId>);
+    .add_systems(PostUpdate, generate_action_diffs::<Action>);
 
     app.update();
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::Pressed { id, action } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::Pressed { action } => {
+                assert_eq!(action, Action::PayTheBills);
+            }
+            ActionDiff::Released { .. } => {
+                panic!("Expected a `Pressed` variant got a `Released` variant")
+            }
+            ActionDiff::ValueChanged { .. } => panic!("Expected a `Pressed` variant got a `ValueChanged` variant"),
+            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Pressed` variant got a `AxisPairChanged` variant"),
         }
-        ActionDiff::Released { action: _, id: _ } => {
-            panic!("Expected a `Pressed` variant got a `Released` variant")
-        }
-        ActionDiff::ValueChanged {
-            action: _,
-            id: _,
-            value: _,
-        } => panic!("Expected a `Pressed` variant got a `ValueChanged` variant"),
-        ActionDiff::AxisPairChanged {
-            action: _,
-            id: _,
-            axis_pair: _,
-        } => panic!("Expected a `Pressed` variant got a `AxisPairChanged` variant"),
     });
 
     app.update();
@@ -166,24 +171,18 @@ fn generate_binary_action_diffs() {
 
     app.update();
 
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::Released { id, action } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::Released { action } => {
+                assert_eq!(action, Action::PayTheBills);
+            }
+            ActionDiff::Pressed { .. } => {
+                panic!("Expected a `Released` variant got a `Pressed` variant")
+            }
+            ActionDiff::ValueChanged { .. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
+            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
         }
-        ActionDiff::Pressed { action: _, id: _ } => {
-            panic!("Expected a `Released` variant got a `Pressed` variant")
-        }
-        ActionDiff::ValueChanged {
-            action: _,
-            id: _,
-            value: _,
-        } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-        ActionDiff::AxisPairChanged {
-            action: _,
-            id: _,
-            axis_pair: _,
-        } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
     });
 }
 
@@ -191,34 +190,33 @@ fn generate_binary_action_diffs() {
 fn generate_value_action_diffs() {
     let input_value = 0.5;
     let mut app = create_app();
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
             action_state.action_data_mut(Action::PayTheBills).value = input_value;
         }),
     )
-    .add_systems(PostUpdate, generate_action_diffs::<Action, BankAccountId>)
-    .add_event::<ActionDiff<Action, BankAccountId>>();
+    .add_systems(PostUpdate, generate_action_diffs::<Action>)
+    .add_event::<ActionDiffEvent<Action>>();
 
     app.update();
 
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::ValueChanged { id, action, value } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
-            assert!(*value == input_value);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::ValueChanged { action, value } => {
+                assert_eq!(action, Action::PayTheBills);
+                assert_eq!(value, input_value);
+            }
+            ActionDiff::Released { .. } => {
+                panic!("Expected a `ValueChanged` variant got a `Released` variant")
+            }
+            ActionDiff::Pressed { .. } => {
+                panic!("Expected a `ValueChanged` variant got a `Pressed` variant")
+            }
+            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `ValueChanged` variant got a `AxisPairChanged` variant"),
         }
-        ActionDiff::Released { action: _, id: _ } => {
-            panic!("Expected a `ValueChanged` variant got a `Released` variant")
-        }
-        ActionDiff::Pressed { action: _, id: _ } => {
-            panic!("Expected a `ValueChanged` variant got a `Pressed` variant")
-        }
-        ActionDiff::AxisPairChanged {
-            action: _,
-            id: _,
-            axis_pair: _,
-        } => panic!("Expected a `ValueChanged` variant got a `AxisPairChanged` variant"),
     });
 
     app.update();
@@ -227,24 +225,19 @@ fn generate_value_action_diffs() {
 
     app.update();
 
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::Released { id, action } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::Released { action } => {
+                assert_eq!(action, Action::PayTheBills);
+            }
+            ActionDiff::Pressed { .. } => {
+                panic!("Expected a `Released` variant got a `Pressed` variant")
+            }
+            ActionDiff::ValueChanged {.. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
+            ActionDiff::AxisPairChanged {..
+            } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
         }
-        ActionDiff::Pressed { action: _, id: _ } => {
-            panic!("Expected a `Released` variant got a `Pressed` variant")
-        }
-        ActionDiff::ValueChanged {
-            action: _,
-            id: _,
-            value: _,
-        } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-        ActionDiff::AxisPairChanged {
-            action: _,
-            id: _,
-            axis_pair: _,
-        } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
     });
 }
 
@@ -252,6 +245,7 @@ fn generate_value_action_diffs() {
 fn generate_axis_action_diffs() {
     let input_axis_pair = Vec2 { x: 5., y: 8. };
     let mut app = create_app();
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
@@ -259,32 +253,29 @@ fn generate_axis_action_diffs() {
                 Some(DualAxisData::from_xy(input_axis_pair));
         }),
     )
-    .add_systems(PostUpdate, generate_action_diffs::<Action, BankAccountId>)
-    .add_event::<ActionDiff<Action, BankAccountId>>();
+    .add_systems(PostUpdate, generate_action_diffs::<Action>)
+    .add_event::<ActionDiffEvent<Action>>();
 
     app.update();
 
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::AxisPairChanged {
-            id,
-            action,
-            axis_pair,
-        } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
-            assert!(*axis_pair == input_axis_pair);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::AxisPairChanged {
+                action,
+                axis_pair,
+            } => {
+                assert_eq!(action, Action::PayTheBills);
+                assert_eq!(axis_pair, input_axis_pair);
+            }
+            ActionDiff::Released { .. } => {
+                panic!("Expected a `AxisPairChanged` variant got a `Released` variant")
+            }
+            ActionDiff::Pressed { .. } => {
+                panic!("Expected a `AxisPairChanged` variant got a `Pressed` variant")
+            }
+            ActionDiff::ValueChanged { .. } => panic!("Expected a `AxisPairChanged` variant got a `ValueChanged` variant"),
         }
-        ActionDiff::Released { action: _, id: _ } => {
-            panic!("Expected a `AxisPairChanged` variant got a `Released` variant")
-        }
-        ActionDiff::Pressed { action: _, id: _ } => {
-            panic!("Expected a `AxisPairChanged` variant got a `Pressed` variant")
-        }
-        ActionDiff::ValueChanged {
-            action: _,
-            id: _,
-            value: _,
-        } => panic!("Expected a `AxisPairChanged` variant got a `ValueChanged` variant"),
     });
 
     app.update();
@@ -293,103 +284,118 @@ fn generate_axis_action_diffs() {
 
     app.update();
 
-    assert_action_diff_created(&mut app, |action_diff| match action_diff {
-        ActionDiff::Released { id, action } => {
-            assert!(*id == BankAccountId(1337));
-            assert!(*action == Action::PayTheBills);
+    assert_action_diff_created(&mut app, |action_diff| {
+        assert_eq!(action_diff.owner, Some(entity));
+        match action_diff.action_diff {
+            ActionDiff::Released { action } => {
+                assert_eq!(action, Action::PayTheBills);
+            }
+            ActionDiff::Pressed { .. } => {
+                panic!("Expected a `Released` variant got a `Pressed` variant")
+            }
+            ActionDiff::ValueChanged { .. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
+            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
         }
-        ActionDiff::Pressed { action: _, id: _ } => {
-            panic!("Expected a `Released` variant got a `Pressed` variant")
-        }
-        ActionDiff::ValueChanged {
-            action: _,
-            id: _,
-            value: _,
-        } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-        ActionDiff::AxisPairChanged {
-            action: _,
-            id: _,
-            axis_pair: _,
-        } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
     });
 }
 
 #[test]
 fn process_binary_action_diffs() {
     let mut app = create_app();
-    app.add_systems(PreUpdate, process_action_diffs::<Action, BankAccountId>);
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff = ActionDiff::Pressed {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 
     let action_diff = ActionDiff::Released {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 }
 
 #[test]
 fn process_value_action_diff() {
     let mut app = create_app();
-    app.add_systems(PreUpdate, process_action_diffs::<Action, BankAccountId>);
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff = ActionDiff::ValueChanged {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
         value: 0.5,
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 
     let action_diff = ActionDiff::Released {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 }
 
 #[test]
 fn process_axis_action_diff() {
     let mut app = create_app();
-    app.add_systems(PreUpdate, process_action_diffs::<Action, BankAccountId>);
+    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff = ActionDiff::AxisPairChanged {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
         axis_pair: Vec2 { x: 1., y: 0. },
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 
     let action_diff = ActionDiff::Released {
-        id: BankAccountId(1337),
         action: Action::PayTheBills,
     };
-    send_action_diff(&mut app, action_diff.clone());
+    let action_diff_event = ActionDiffEvent {
+        owner: Some(entity),
+        action_diff,
+    };
+    send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
 
-    assert_action_diff_received(&mut app, action_diff);
+    assert_action_diff_received(&mut app, action_diff_event);
 }

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -1,22 +1,18 @@
 use bevy::{input::InputPlugin, prelude::*};
-use leafwing_input_manager::{
-    action_state::ActionDiff,
-    axislike::DualAxisData,
-    prelude::*,
-    systems::{generate_action_diffs},
-};
 use leafwing_input_manager::action_state::ActionDiffEvent;
+use leafwing_input_manager::{
+    action_state::ActionDiff, axislike::DualAxisData, prelude::*, systems::generate_action_diffs,
+};
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
 enum Action {
     PayTheBills,
 }
 
-
 #[derive(Default)]
 struct Counter(pub u8);
 
-fn spawn_da_bills(mut commands: Commands, ) {
+fn spawn_da_bills(mut commands: Commands) {
     commands.spawn(ActionState::<Action>::default());
 }
 
@@ -43,7 +39,10 @@ fn process_action_diffs<A: Actionlike>(
     for action_diff_event in action_diff_events.read() {
         if action_diff_event.owner.is_some() {
             let mut action_state = action_state_query.get_single_mut().unwrap();
-            action_diff_event.action_diffs.iter().for_each(|diff| action_state.apply_diff(diff));
+            action_diff_event
+                .action_diffs
+                .iter()
+                .for_each(|diff| action_state.apply_diff(diff));
         }
     }
 }
@@ -85,10 +84,7 @@ fn assert_has_no_action_diffs(app: &mut App) {
     }
 }
 
-fn assert_action_diff_created(
-    app: &mut App,
-    predicate: impl Fn(&ActionDiffEvent<Action>),
-) {
+fn assert_action_diff_created(app: &mut App, predicate: impl Fn(&ActionDiffEvent<Action>)) {
     let mut action_diff_events = get_events_mut::<ActionDiffEvent<Action>>(app);
     let action_diff_event_reader = &mut action_diff_events.get_reader();
     assert!(action_diff_event_reader.len(action_diff_events.as_ref()) < 2);
@@ -116,17 +112,11 @@ fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent
             assert!(action_state.value(action) == 0.);
             assert!(action_state.axis_pair(action).is_none());
         }
-        ActionDiff::ValueChanged {
-            action,
-            value,
-        } => {
+        ActionDiff::ValueChanged { action, value } => {
             assert!(action_state.pressed(action));
             assert!(action_state.value(action) == value);
         }
-        ActionDiff::AxisPairChanged {
-            action,
-            axis_pair,
-        } => {
+        ActionDiff::AxisPairChanged { action, axis_pair } => {
             assert!(action_state.pressed(action));
             match action_state.axis_pair(action) {
                 Some(axis_pair_data) => {
@@ -142,7 +132,10 @@ fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent
 #[test]
 fn generate_binary_action_diffs() {
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(|mut action_state| {
@@ -162,8 +155,12 @@ fn generate_binary_action_diffs() {
             ActionDiff::Released { .. } => {
                 panic!("Expected a `Pressed` variant got a `Released` variant")
             }
-            ActionDiff::ValueChanged { .. } => panic!("Expected a `Pressed` variant got a `ValueChanged` variant"),
-            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Pressed` variant got a `AxisPairChanged` variant"),
+            ActionDiff::ValueChanged { .. } => {
+                panic!("Expected a `Pressed` variant got a `ValueChanged` variant")
+            }
+            ActionDiff::AxisPairChanged { .. } => {
+                panic!("Expected a `Pressed` variant got a `AxisPairChanged` variant")
+            }
         }
     });
 
@@ -183,8 +180,12 @@ fn generate_binary_action_diffs() {
             ActionDiff::Pressed { .. } => {
                 panic!("Expected a `Released` variant got a `Pressed` variant")
             }
-            ActionDiff::ValueChanged { .. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
+            ActionDiff::ValueChanged { .. } => {
+                panic!("Expected a `Released` variant got a `ValueChanged` variant")
+            }
+            ActionDiff::AxisPairChanged { .. } => {
+                panic!("Expected a `Released` variant got a `AxisPairChanged` variant")
+            }
         }
     });
 }
@@ -193,7 +194,10 @@ fn generate_binary_action_diffs() {
 fn generate_value_action_diffs() {
     let input_value = 0.5;
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
@@ -219,7 +223,9 @@ fn generate_value_action_diffs() {
             ActionDiff::Pressed { .. } => {
                 panic!("Expected a `ValueChanged` variant got a `Pressed` variant")
             }
-            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `ValueChanged` variant got a `AxisPairChanged` variant"),
+            ActionDiff::AxisPairChanged { .. } => {
+                panic!("Expected a `ValueChanged` variant got a `AxisPairChanged` variant")
+            }
         }
     });
 
@@ -239,9 +245,12 @@ fn generate_value_action_diffs() {
             ActionDiff::Pressed { .. } => {
                 panic!("Expected a `Released` variant got a `Pressed` variant")
             }
-            ActionDiff::ValueChanged {.. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-            ActionDiff::AxisPairChanged {..
-            } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
+            ActionDiff::ValueChanged { .. } => {
+                panic!("Expected a `Released` variant got a `ValueChanged` variant")
+            }
+            ActionDiff::AxisPairChanged { .. } => {
+                panic!("Expected a `Released` variant got a `AxisPairChanged` variant")
+            }
         }
     });
 }
@@ -250,7 +259,10 @@ fn generate_value_action_diffs() {
 fn generate_axis_action_diffs() {
     let input_axis_pair = Vec2 { x: 5., y: 8. };
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
@@ -267,10 +279,7 @@ fn generate_axis_action_diffs() {
         assert_eq!(action_diff_event.owner, Some(entity));
         assert_eq!(action_diff_event.action_diffs.len(), 1);
         match action_diff_event.action_diffs.first().unwrap().clone() {
-            ActionDiff::AxisPairChanged {
-                action,
-                axis_pair,
-            } => {
+            ActionDiff::AxisPairChanged { action, axis_pair } => {
                 assert_eq!(action, Action::PayTheBills);
                 assert_eq!(axis_pair, input_axis_pair);
             }
@@ -280,7 +289,9 @@ fn generate_axis_action_diffs() {
             ActionDiff::Pressed { .. } => {
                 panic!("Expected a `AxisPairChanged` variant got a `Pressed` variant")
             }
-            ActionDiff::ValueChanged { .. } => panic!("Expected a `AxisPairChanged` variant got a `ValueChanged` variant"),
+            ActionDiff::ValueChanged { .. } => {
+                panic!("Expected a `AxisPairChanged` variant got a `ValueChanged` variant")
+            }
         }
     });
 
@@ -300,8 +311,12 @@ fn generate_axis_action_diffs() {
             ActionDiff::Pressed { .. } => {
                 panic!("Expected a `Released` variant got a `Pressed` variant")
             }
-            ActionDiff::ValueChanged { .. } => panic!("Expected a `Released` variant got a `ValueChanged` variant"),
-            ActionDiff::AxisPairChanged { .. } => panic!("Expected a `Released` variant got a `AxisPairChanged` variant"),
+            ActionDiff::ValueChanged { .. } => {
+                panic!("Expected a `Released` variant got a `ValueChanged` variant")
+            }
+            ActionDiff::AxisPairChanged { .. } => {
+                panic!("Expected a `Released` variant got a `AxisPairChanged` variant")
+            }
         }
     });
 }
@@ -309,15 +324,18 @@ fn generate_axis_action_diffs() {
 #[test]
 fn process_binary_action_diffs() {
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff_event = ActionDiffEvent {
         owner: Some(entity),
         action_diffs: vec![ActionDiff::Pressed {
             action: Action::PayTheBills,
-        }
-    ]};
+        }],
+    };
     send_action_diff(&mut app, action_diff_event.clone());
 
     app.update();
@@ -328,7 +346,7 @@ fn process_binary_action_diffs() {
         owner: Some(entity),
         action_diffs: vec![ActionDiff::Released {
             action: Action::PayTheBills,
-        }]
+        }],
     };
     send_action_diff(&mut app, action_diff_event.clone());
 
@@ -340,9 +358,11 @@ fn process_binary_action_diffs() {
 #[test]
 fn process_value_action_diff() {
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
-
 
     let action_diff_event = ActionDiffEvent {
         owner: Some(entity),
@@ -360,8 +380,8 @@ fn process_value_action_diff() {
     let action_diff_event = ActionDiffEvent {
         owner: Some(entity),
         action_diffs: vec![ActionDiff::Released {
-        action: Action::PayTheBills,
-    }],
+            action: Action::PayTheBills,
+        }],
     };
     send_action_diff(&mut app, action_diff_event.clone());
 
@@ -373,16 +393,18 @@ fn process_value_action_diff() {
 #[test]
 fn process_axis_action_diff() {
     let mut app = create_app();
-    let entity = app.world.query_filtered::<Entity, With<ActionState<Action>>>().single(&app.world);
+    let entity = app
+        .world
+        .query_filtered::<Entity, With<ActionState<Action>>>()
+        .single(&app.world);
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
-
 
     let action_diff_event = ActionDiffEvent {
         owner: Some(entity),
         action_diffs: vec![ActionDiff::AxisPairChanged {
-        action: Action::PayTheBills,
-        axis_pair: Vec2 { x: 1., y: 0. },
-    }],
+            action: Action::PayTheBills,
+            axis_pair: Vec2 { x: 1., y: 0. },
+        }],
     };
     send_action_diff(&mut app, action_diff_event.clone());
 
@@ -393,8 +415,8 @@ fn process_axis_action_diff() {
     let action_diff_event = ActionDiffEvent {
         owner: Some(entity),
         action_diffs: vec![ActionDiff::Released {
-        action: Action::PayTheBills,
-    }],
+            action: Action::PayTheBills,
+        }],
     };
     send_action_diff(&mut app, action_diff_event.clone());
 


### PR DESCRIPTION
This PR reworks how networking via `ActionDiff` works:
- instead of using a "Stable `ID` Component" that uniquely identifies entities across client and server, we introduce the `ActionDiffEvent` type, which has:
  - an owner: the Entity that generates the action, or None if we are using a global `ActionState`
  - the action_diff itself
- we remove the `process_action_diffs` system in favor of a method `ActionState.apply_diff(action_diff)`, to leave more flexibility to users over how to process the action-diffs (perform entity-mapping, etc.)

I'm slightly confused about this: https://github.com/Leafwing-Studios/leafwing-input-manager/blob/main/src/systems.rs#L216: we detect if the button is Pressed/ValueChanged just based on the value?
What if we have a 'Value' type button that has a value of 1.0? We would then get a `Pressed` `ActionDiff`, which seems incompatible?

NOTE: it might actually be more efficient to have the ActionDiffEvent contains a `Vec<ActionDiff>` since we can compute all of them in one go for a given entity