### PR TITLE
Add is_consumed getter

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -421,6 +421,13 @@ impl<A: Actionlike> ActionState<A> {
         }
     }
 
+    /// Is this `action` currently consumed?
+    #[inline]
+    #[must_use]
+    pub fn consumed(&self, action: A) -> bool {
+        self.action_data[action.index()].consumed
+    }
+
     /// Is this `action` currently pressed?
     #[inline]
     #[must_use]


### PR DESCRIPTION
I ran into an issue (https://github.com/Leafwing-Studios/leafwing-input-manager/issues/443) when generating `ActionDiffs` for networking; it would be useful for me to be able to access whether a key was consumed or not.
