### PR TITLE
Restore the `ButtonState::Pressed` state on re-enabling `ToggleActions`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -22,6 +22,7 @@
 - registered types in the reflection system
 - added `InputMap::clear`
 - fixed [a bug](https://github.com/Leafwing-Studios/leafwing-input-manager/issues/430) related to incorrect axis data in `Chord` when not all buttons are pressed.
+- fixed [a bug](https://github.com/Leafwing-Studios/leafwing-input-manager/issues/446) related to missing restoration for `ButtonState::Pressed` state when re-enabling `ToggleActions`.
 
 ### Code Quality
 

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -18,17 +18,19 @@ pub enum ButtonState {
     /// This button is currently released (and was released before the most recent tick)
     #[default]
     Released,
-    /// This button was pressed before disabling the [`ToggleActions<A>`](crate::plugin::ToggleActions) resource,
+    /// This button was pressed when disabling the [`ToggleActions<A>`](crate::plugin::ToggleActions) resource,
     /// used for restoring the pressed state on re-enabling the resource.
     PressedWhenDisabling,
+    /// This button is disabled because the [`ToggleActions<A>`](crate::plugin::ToggleActions) resource is disabled.
+    Disabled,
 }
 
 impl ButtonState {
     /// Causes [`just_pressed`](ButtonState::just_pressed) and [`just_released`](ButtonState::just_released) to become false
     ///
     /// [`JustPressed`](ButtonState::JustPressed) becomes [`Pressed`](ButtonState::Pressed),
-    /// [`PressedWhenDisabling`](ButtonState::PressedWhenDisabling) becomes [`Pressed`](ButtonState::Pressed), and
-    /// [`JustReleased`](ButtonState::JustReleased) becomes [`Released`](ButtonState::Released)
+    /// [`JustReleased`](ButtonState::JustReleased) becomes [`Released`](ButtonState::Released), and
+    /// [`PressedWhenDisabling`](ButtonState::PressedWhenDisabling) becomes [`Pressed`](ButtonState::Pressed)
     pub fn tick(&mut self) {
         use ButtonState::*;
         *self = match self {
@@ -37,6 +39,7 @@ impl ButtonState {
             JustReleased => Released,
             Released => Released,
             PressedWhenDisabling => Pressed,
+            Disabled => Disabled,
         }
     }
 

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -18,12 +18,16 @@ pub enum ButtonState {
     /// This button is currently released (and was released before the most recent tick)
     #[default]
     Released,
+    /// This button was pressed before disabling the [`ToggleActions<A>`](crate::plugin::ToggleActions) resource,
+    /// used for restoring the pressed state on re-enabling the resource.
+    PressedWhenDisabling,
 }
 
 impl ButtonState {
     /// Causes [`just_pressed`](ButtonState::just_pressed) and [`just_released`](ButtonState::just_released) to become false
     ///
-    /// [`JustPressed`](ButtonState::JustPressed) becomes [`Pressed`](ButtonState::Pressed) and
+    /// [`JustPressed`](ButtonState::JustPressed) becomes [`Pressed`](ButtonState::Pressed),
+    /// [`PressedWhenDisabling`](ButtonState::PressedWhenDisabling) becomes [`Pressed`](ButtonState::Pressed), and
     /// [`JustReleased`](ButtonState::JustReleased) becomes [`Released`](ButtonState::Released)
     pub fn tick(&mut self) {
         use ButtonState::*;
@@ -32,6 +36,7 @@ impl ButtonState {
             Pressed => Pressed,
             JustReleased => Released,
             Released => Released,
+            PressedWhenDisabling => Pressed,
         }
     }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -297,12 +297,12 @@ pub fn release_on_disable<A: Actionlike>(
     resource: Option<ResMut<ActionState<A>>>,
     toggle_actions: Res<ToggleActions<A>>,
 ) {
-    if toggle_actions.is_changed() && !toggle_actions.enabled {
+    if toggle_actions.is_changed() {
         for mut action_state in query.iter_mut() {
-            action_state.release_all_when_disabling();
+            action_state.toggle_actions(&toggle_actions);
         }
         if let Some(mut action_state) = resource {
-            action_state.release_all_when_disabling();
+            action_state.toggle_actions(&toggle_actions);
         }
     }
 }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -299,10 +299,10 @@ pub fn release_on_disable<A: Actionlike>(
 ) {
     if toggle_actions.is_changed() && !toggle_actions.enabled {
         for mut action_state in query.iter_mut() {
-            action_state.release_all();
+            action_state.release_all_when_disabling();
         }
         if let Some(mut action_state) = resource {
-            action_state.release_all();
+            action_state.release_all_when_disabling();
         }
     }
 }


### PR DESCRIPTION
# Objective

- Fixes #446, caused by the lack of restoration for `ButtonState::Pressed` state when re-enabling `ToggleActions`.

## Solution

- Add a new state, `ButtonState::PressedWhenDisabling`, to retain the `Pressed` state for subsequent restoration when `ToggleActions` is re-enabled.
- Add a new state, `ButtonState::Disabled`, to mark the action is disabled by `ToggleActions`.