### PR TITLE
Replace unnecessary `Vec` with a simple flag in `InputMap::which_pressed()`

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -323,20 +323,20 @@ impl<A: Actionlike> InputMap<A> {
 
         // Generate the raw action presses
         for (action, input_vec) in self.iter() {
-            let mut inputs = Vec::new();
+            let mut pressed = false;
             let mut action_datum = ActionData::default();
 
             for input in input_vec {
                 action_datum.axis_pair = input_streams.input_axis_pair(input);
 
                 if input_streams.input_pressed(input) {
-                    inputs.push(input.clone());
+                    pressed = true;
 
                     action_datum.value += input_streams.input_value(input, true);
                 }
             }
 
-            if !inputs.is_empty() {
+            if pressed {
                 action_datum.state = ButtonState::JustPressed;
             }
 


### PR DESCRIPTION
# Objective

The `InputMap::which_pressed()` function is invoked by the `update_action_state()` system every tick when the corresponding `Actionlike` is enabled. Currently, for press state checking, it unnecessarily accumulates a temporary vector, causing avoidable performance losses.

## Solution

Replace the temporary `inputs` vector with a simple `pressed` flag to enhance the efficiency of press state checking.