### PR TITLE
Replace `ToggleActions<A>` with per-action disable flags

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -7,7 +7,7 @@
 - the `timing` field of the `ActionData` is now disabled by default. Timing information will only be collected
 if the `timing` feature is enabled. It is disabled by default because most games don't require timing information.
 (how long a button was pressed for)
-
+- removed `ToggleActions` resource in favor of new methods on `ActionState`: `disable_all`, `disable(action)`, `enable_all`, `enable(action)`, and `disabled(action)`.
 - removed `InputMap::build` method in favor of new fluent builder pattern (see 'Usability: InputMap' for details).
 - renamed `InputMap::which_pressed` method to `process_actions` to better reflect its current functionality for clarity.
 - replaced axis-like input handling with new input processors (see 'Enhancements: Input Processors' for details).
@@ -96,6 +96,7 @@ Input processors allow you to create custom logic for axis-like input manipulati
 
 ### Bugs
 
+- fixed a bug where enabling a pressed action would read as `just_pressed`, and disabling a pressed action would read as `just_released`.
 - fixed a bug in `InputStreams::button_pressed()` where unrelated gamepads were not filtered out when an `associated_gamepad` is defined.
 
 ## Version 0.13.3

--- a/benches/action_state.rs
+++ b/benches/action_state.rs
@@ -69,6 +69,7 @@ fn criterion_benchmark(c: &mut Criterion) {
                     #[cfg(feature = "timing")]
                     timing: Timing::default(),
                     consumed: false,
+                    disabled: false,
                 },
             )
         })

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -38,6 +38,40 @@ pub struct ActionData {
     /// Actions that are consumed cannot be pressed again until they are explicitly released.
     /// This ensures that consumed actions are not immediately re-pressed by continued inputs.
     pub consumed: bool,
+    /// Is the action disabled?
+    ///
+    /// While disabled, an action will always report as released, regardless of its actual state.
+    pub disabled: bool,
+}
+
+impl ActionData {
+    /// Is the action currently pressed?
+    #[inline]
+    #[must_use]
+    fn pressed(&self) -> bool {
+        !self.disabled && self.state.pressed()
+    }
+
+    /// Was the action pressed since the last time it was ticked?
+    #[inline]
+    #[must_use]
+    pub fn just_pressed(&self) -> bool {
+        !self.disabled && self.state.just_pressed()
+    }
+
+    /// Is the action currently released?
+    #[inline]
+    #[must_use]
+    pub fn released(&self) -> bool {
+        self.disabled || self.state.released()
+    }
+
+    /// Was the action released since the last time it was ticked?
+    #[inline]
+    #[must_use]
+    pub fn just_released(&self) -> bool {
+        !self.disabled && self.state.just_released()
+    }
 }
 
 /// Stores the canonical input-method-agnostic representation of the inputs received
@@ -400,6 +434,13 @@ impl<A: Actionlike> ActionState<A> {
         action_data.state.release();
     }
 
+    /// Releases all actions
+    pub fn release_all(&mut self) {
+        for action in self.keys() {
+            self.release(&action);
+        }
+    }
+
     /// Consumes the `action`
     ///
     /// The action will be released, and will not be able to be pressed again
@@ -458,13 +499,6 @@ impl<A: Actionlike> ActionState<A> {
         }
     }
 
-    /// Releases all actions
-    pub fn release_all(&mut self) {
-        for action in self.keys() {
-            self.release(&action);
-        }
-    }
-
     /// Is this `action` currently consumed?
     #[inline]
     #[must_use]
@@ -472,18 +506,72 @@ impl<A: Actionlike> ActionState<A> {
         matches!(self.action_data(action), Some(action_data) if action_data.consumed)
     }
 
+    /// Disables the `action`
+    #[inline]
+    pub fn disable(&mut self, action: &A) {
+        let action_data = match self.action_data_mut(action) {
+            Some(action_data) => action_data,
+            None => {
+                self.set_action_data(action.clone(), ActionData::default());
+                self.action_data_mut(action).unwrap()
+            }
+        };
+
+        action_data.disabled = true;
+    }
+
+    /// Disables all actions
+    #[inline]
+    pub fn disable_all(&mut self) {
+        for action in self.keys() {
+            self.disable(&action);
+        }
+    }
+
+    /// Is this `action` currently disabled?
+    #[inline]
+    #[must_use]
+    pub fn disabled(&mut self, action: &A) -> bool {
+        match self.action_data(action) {
+            Some(action_data) => action_data.disabled,
+            None => false,
+        }
+    }
+
+    /// Enables the `action`
+    #[inline]
+    pub fn enable(&mut self, action: &A) {
+        let action_data = match self.action_data_mut(action) {
+            Some(action_data) => action_data,
+            None => {
+                self.set_action_data(action.clone(), ActionData::default());
+                self.action_data_mut(action).unwrap()
+            }
+        };
+
+        action_data.disabled = false;
+    }
+
+    /// Enables all actions
+    #[inline]
+    pub fn enable_all(&mut self) {
+        for action in self.keys() {
+            self.enable(&action);
+        }
+    }
+
     /// Is this `action` currently pressed?
     #[inline]
     #[must_use]
     pub fn pressed(&self, action: &A) -> bool {
-        matches!(self.action_data(action), Some(action_data) if action_data.state.pressed())
+        matches!(self.action_data(action), Some(action_data) if action_data.pressed())
     }
 
     /// Was this `action` pressed since the last time [tick](ActionState::tick) was called?
     #[inline]
     #[must_use]
     pub fn just_pressed(&self, action: &A) -> bool {
-        matches!(self.action_data(action), Some(action_data) if action_data.state.just_pressed())
+        matches!(self.action_data(action), Some(action_data) if action_data.just_pressed())
     }
 
     /// Is this `action` currently released?
@@ -493,7 +581,7 @@ impl<A: Actionlike> ActionState<A> {
     #[must_use]
     pub fn released(&self, action: &A) -> bool {
         match self.action_data(action) {
-            Some(action_data) => action_data.state.released(),
+            Some(action_data) => action_data.released(),
             None => true,
         }
     }
@@ -502,7 +590,7 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn just_released(&self, action: &A) -> bool {
-        matches!(self.action_data(action), Some(action_data) if action_data.state.just_released())
+        matches!(self.action_data(action), Some(action_data) if action_data.just_released())
     }
 
     #[must_use]
@@ -510,7 +598,7 @@ impl<A: Actionlike> ActionState<A> {
     pub fn get_pressed(&self) -> Vec<A> {
         self.action_data
             .iter()
-            .filter(|(_action, data)| data.state.pressed())
+            .filter(|(_action, data)| data.pressed())
             .map(|(action, _data)| action.clone())
             .collect()
     }
@@ -520,7 +608,7 @@ impl<A: Actionlike> ActionState<A> {
     pub fn get_just_pressed(&self) -> Vec<A> {
         self.action_data
             .iter()
-            .filter(|(_action, data)| data.state.just_pressed())
+            .filter(|(_action, data)| data.just_pressed())
             .map(|(action, _data)| action.clone())
             .collect()
     }
@@ -530,7 +618,7 @@ impl<A: Actionlike> ActionState<A> {
     pub fn get_released(&self) -> Vec<A> {
         self.action_data
             .iter()
-            .filter(|(_action, data)| data.state.released())
+            .filter(|(_action, data)| data.released())
             .map(|(action, _data)| action.clone())
             .collect()
     }
@@ -540,7 +628,7 @@ impl<A: Actionlike> ActionState<A> {
     pub fn get_just_released(&self) -> Vec<A> {
         self.action_data
             .iter()
-            .filter(|(_action, data)| data.state.just_released())
+            .filter(|(_action, data)| data.just_released())
             .map(|(action, _data)| action.clone())
             .collect()
     }

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -48,7 +48,7 @@ impl ActionData {
     /// Is the action currently pressed?
     #[inline]
     #[must_use]
-    fn pressed(&self) -> bool {
+    pub fn pressed(&self) -> bool {
         !self.disabled && self.state.pressed()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,6 @@ pub mod prelude {
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;
-    pub use crate::plugin::ToggleActions;
     pub use crate::{Actionlike, InputManagerBundle};
 
     pub use leafwing_input_manager_macros::serde_typetag;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -39,10 +39,11 @@ use bevy::ui::UiSystem;
 /// consider creating multiple `Actionlike` enums
 /// and adding a copy of this plugin for each `Actionlike` type.
 ///
-/// ## Systems
+/// All actions can be dynamically enabled or disabled by calling the relevant methods on
+/// `ActionState<A>`. This can be useful when working with states to pause the game, navigate
+/// menus, and so on.
 ///
-/// All systems added by this plugin can be dynamically enabled and disabled by setting the value of the [`ToggleActions<A>`] resource is set.
-/// This can be useful when working with states to pause the game, navigate menus, or so on.
+/// ## Systems
 ///
 /// **WARNING:** These systems run during [`PreUpdate`].
 /// If you have systems that care about inputs and actions that also run during this stage,
@@ -55,7 +56,6 @@ use bevy::ui::UiSystem;
 /// - [`update_action_state`](crate::systems::update_action_state), which collects [`ButtonInput`](bevy::input::ButtonInput) resources to update the [`ActionState`]
 /// - [`update_action_state_from_interaction`](crate::systems::update_action_state_from_interaction), for triggering actions from buttons
 ///    - powers the [`ActionStateDriver`](crate::action_driver::ActionStateDriver) component based on an [`Interaction`](bevy::ui::Interaction) component
-/// - [`release_on_disable`](crate::systems::release_on_disable), which resets action states when [`ToggleActions`] is flipped, to avoid persistent presses.
 pub struct InputManagerPlugin<A: Actionlike> {
     _phantom: PhantomData<A>,
     machine: Machine,
@@ -101,23 +101,14 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
                 app.add_systems(
                     PreUpdate,
                     tick_action_state::<A>
-                        .run_if(run_if_enabled::<A>)
                         .in_set(InputManagerSystem::Tick)
                         .before(InputManagerSystem::Update),
-                )
-                .add_systems(
-                    PreUpdate,
-                    release_on_disable::<A>
-                        .in_set(InputManagerSystem::ReleaseOnDisable)
-                        .after(InputManagerSystem::Update),
                 )
                 .add_systems(PostUpdate, release_on_input_map_removed::<A>);
 
                 app.add_systems(
                     PreUpdate,
-                    update_action_state::<A>
-                        .run_if(run_if_enabled::<A>)
-                        .in_set(InputManagerSystem::Update),
+                    update_action_state::<A>.in_set(InputManagerSystem::Update),
                 );
 
                 app.configure_sets(PreUpdate, InputManagerSystem::Update.after(InputSystem));
@@ -135,7 +126,6 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
                 app.configure_sets(
                     PreUpdate,
                     InputManagerSystem::ManualControl
-                        .before(InputManagerSystem::ReleaseOnDisable)
                         .after(InputManagerSystem::Tick)
                         // Must run after the system is updated from inputs, or it will be forcibly released due to the inputs
                         // not being pressed
@@ -148,16 +138,13 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
                 app.add_systems(
                     PreUpdate,
                     update_action_state_from_interaction::<A>
-                        .run_if(run_if_enabled::<A>)
                         .in_set(InputManagerSystem::ManualControl),
                 );
             }
             Machine::Server => {
                 app.add_systems(
                     PreUpdate,
-                    tick_action_state::<A>
-                        .run_if(run_if_enabled::<A>)
-                        .in_set(InputManagerSystem::Tick),
+                    tick_action_state::<A>.in_set(InputManagerSystem::Tick),
                 );
             }
         };
@@ -195,47 +182,10 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
             .register_type::<CircleExclusion>()
             .register_type::<CircleDeadZone>()
             // Resources
-            .init_resource::<ToggleActions<A>>()
             .init_resource::<ClashStrategy>();
 
         #[cfg(feature = "timing")]
         app.register_type::<Timing>();
-    }
-}
-
-/// Controls whether the [`ActionState`] / [`InputMap`] pairs of type `A` are active
-///
-/// If this resource does not exist, actions work normally, as if `ToggleActions::enabled == true`.
-#[derive(Resource)]
-pub struct ToggleActions<A: Actionlike> {
-    /// When this is false, [`ActionState`]'s corresponding to `A` will ignore user inputs
-    ///
-    /// When this is set to false, all corresponding [`ActionState`]s are released
-    pub enabled: bool,
-    /// Marker that stores the type of action to toggle
-    pub phantom: PhantomData<A>,
-}
-
-impl<A: Actionlike> ToggleActions<A> {
-    /// A [`ToggleActions`] in enabled state.
-    pub const ENABLED: ToggleActions<A> = ToggleActions::<A> {
-        enabled: true,
-        phantom: PhantomData::<A>,
-    };
-    /// A [`ToggleActions`] in disabled state.
-    pub const DISABLED: ToggleActions<A> = ToggleActions::<A> {
-        enabled: false,
-        phantom: PhantomData::<A>,
-    };
-}
-
-// Implement manually to not require [`Default`] for `A`
-impl<A: Actionlike> Default for ToggleActions<A> {
-    fn default() -> Self {
-        Self {
-            enabled: true,
-            phantom: PhantomData::<A>,
-        }
     }
 }
 
@@ -250,8 +200,6 @@ pub enum InputManagerSystem {
     Tick,
     /// Collects input data to update the [`ActionState`]
     Update,
-    /// Release all actions in all [`ActionState`]s if [`ToggleActions`] was added
-    ReleaseOnDisable,
     /// Manually control the [`ActionState`]
     ///
     /// Must run after [`InputManagerSystem::Update`] or the action state will be overridden

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -4,7 +4,7 @@
 use crate::action_driver::ActionStateDriver;
 use crate::{
     action_state::ActionState, clashing_inputs::ClashStrategy, input_map::InputMap,
-    input_streams::InputStreams, plugin::ToggleActions, Actionlike,
+    input_streams::InputStreams, Actionlike,
 };
 
 use bevy::ecs::prelude::*;
@@ -270,22 +270,6 @@ pub fn generate_action_diffs<A: Actionlike>(
     }
 }
 
-/// Release all inputs if the [`ToggleActions<A>`] resource exists and its `enabled` field is false.
-pub fn release_on_disable<A: Actionlike>(
-    mut query: Query<&mut ActionState<A>>,
-    resource: Option<ResMut<ActionState<A>>>,
-    toggle_actions: Res<ToggleActions<A>>,
-) {
-    if toggle_actions.is_changed() && !toggle_actions.enabled {
-        for mut action_state in query.iter_mut() {
-            action_state.release_all();
-        }
-        if let Some(mut action_state) = resource {
-            action_state.release_all();
-        }
-    }
-}
-
 /// Release all inputs when an [`InputMap<A>`] is removed to prevent them from being held forever.
 ///
 /// By default, [`InputManagerPlugin<A>`](crate::plugin::InputManagerPlugin) will run this on [`PostUpdate`](bevy::prelude::PostUpdate).
@@ -318,9 +302,4 @@ pub fn release_on_input_map_removed<A: Actionlike>(
         // Reset our local so our removal detection is only triggered once.
         *input_map_resource_existed = false;
     }
-}
-
-/// Uses the value of [`ToggleActions<A>`] to determine if input manager systems of the type `A` should run.
-pub fn run_if_enabled<A: Actionlike>(toggle_actions: Res<ToggleActions<A>>) -> bool {
-    toggle_actions.enabled
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -76,9 +76,21 @@ fn disable_input() {
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 
-    // Disable the input
-    let mut toggle_actions = app.world.resource_mut::<ToggleActions<Action>>();
-    toggle_actions.enabled = false;
+    // Disable the global input
+    let mut action_state = app.world.resource_mut::<ActionState<Action>>();
+    action_state.disable_all();
+
+    // But the player is still paying respects
+    app.update();
+    let respect = app.world.resource::<Respect>();
+    assert_eq!(*respect, Respect(true));
+
+    // Disable the player's input too
+    let mut action_state = app
+        .world
+        .query_filtered::<&mut ActionState<Action>, With<Player>>()
+        .single_mut(&mut app.world);
+    action_state.disable_all();
 
     // Now, all respect has faded
     app.update();
@@ -90,6 +102,15 @@ fn disable_input() {
     app.update();
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(false));
+
+    // Re-enable the global input
+    let mut action_state = app.world.resource_mut::<ActionState<Action>>();
+    action_state.enable_all();
+
+    // And it will start paying respects again
+    app.update();
+    let respect = app.world.resource::<Respect>();
+    assert_eq!(*respect, Respect(true));
 }
 
 #[test]


### PR DESCRIPTION
# Objective

Fixes https://github.com/Leafwing-Studios/leafwing-input-manager/issues/446, https://github.com/Leafwing-Studios/leafwing-input-manager/issues/416.

# Solution

Don't disable the systems that update action state. Instead, include a `disabled` flag per action within `ActionState<A>`. While `disabled` is `true`, an action will always read as released, regardless of its actual state.

Pros:
- Replaces `ToggleActions<A>`, making the API surface area smaller.
- Supports granular enabling / disabling between:
  - The individual actions of an `ActionState<A>`
  - Different entities with the same `ActionState<A>` component type
  - Resource vs component instances of `ActionState<A>`
- Keeps the action update logic simple and consistent by only affecting how the state is read, not how it's written.
- Similar to the existing `consumed` flag.

Cons:
- Harder to enable / disable _all actions_ for a given `A: Actionlike` (you'd have to check for a resource as well as query for any components -- and that still doesn't account for e.g. new entities spawning with their own `ActionState<A>` in later frames).
- Disabling an action only affects its button state (pressed, released, etc.), not e.g. `value` and `axis_pair` (this is also the current behavior without this PR, see https://github.com/Leafwing-Studios/leafwing-input-manager/issues/506). Those could be updated as well to read as zero while disabled.
- Breaking change.

Alternative approach: https://github.com/Leafwing-Studios/leafwing-input-manager/pull/454.

