### PR TITLE
Fix incorrect `ActionData::axis_pair` value when handling multiple `DualAxisData`

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -326,9 +326,13 @@ impl<A: Actionlike> InputMap<A> {
             let mut action_datum = ActionData::default();
 
             for input in input_vec {
-                if let Some(new_axis_pair) = input_streams.input_axis_pair(input) {
-                    let current_axis_pair = action_datum.axis_pair.unwrap_or_default();
-                    action_datum.axis_pair = Some(current_axis_pair.merged_with(new_axis_pair));
+                // Merge axis pair into action datum
+                if let Some(axis_pair) = input_streams.input_axis_pair(input) {
+                    action_datum.axis_pair = action_datum
+                        .axis_pair
+                        .map_or(Some(axis_pair), |current_axis_pair| {
+                            Some(current_axis_pair.merged_with(axis_pair))
+                        })
                 }
 
                 if input_streams.input_pressed(input) {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -323,21 +323,17 @@ impl<A: Actionlike> InputMap<A> {
 
         // Generate the raw action presses
         for (action, input_vec) in self.iter() {
-            let mut pressed = false;
             let mut action_datum = ActionData::default();
 
             for input in input_vec {
-                action_datum.axis_pair = input_streams.input_axis_pair(input);
+                action_datum.axis_pair = input_streams.input_axis_pair(input).map(|new_data| {
+                    new_data.merged_with(action_datum.axis_pair.unwrap_or_default())
+                });
 
                 if input_streams.input_pressed(input) {
-                    pressed = true;
-
+                    action_datum.state = ButtonState::JustPressed;
                     action_datum.value += input_streams.input_value(input, true);
                 }
-            }
-
-            if pressed {
-                action_datum.state = ButtonState::JustPressed;
             }
 
             action_data.insert(action.clone(), action_datum);

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -326,9 +326,9 @@ impl<A: Actionlike> InputMap<A> {
             let mut action_datum = ActionData::default();
 
             for input in input_vec {
-                if let Some(new_data) = input_streams.input_axis_pair(input) {
-                    let current_data = action_datum.axis_pair.unwrap_or_default();
-                    action_datum.axis_pair = Some(new_data.merged_with(current_data));
+                if let Some(new_axis_pair) = input_streams.input_axis_pair(input) {
+                    let current_axis_pair = action_datum.axis_pair.unwrap_or_default();
+                    action_datum.axis_pair = Some(new_axis_pair.merged_with(current_axis_pair));
                 }
 
                 if input_streams.input_pressed(input) {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -328,7 +328,7 @@ impl<A: Actionlike> InputMap<A> {
             for input in input_vec {
                 if let Some(new_axis_pair) = input_streams.input_axis_pair(input) {
                     let current_axis_pair = action_datum.axis_pair.unwrap_or_default();
-                    action_datum.axis_pair = Some(new_axis_pair.merged_with(current_axis_pair));
+                    action_datum.axis_pair = Some(current_axis_pair.merged_with(new_axis_pair));
                 }
 
                 if input_streams.input_pressed(input) {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -332,7 +332,7 @@ impl<A: Actionlike> InputMap<A> {
                         .axis_pair
                         .map_or(Some(axis_pair), |current_axis_pair| {
                             Some(current_axis_pair.merged_with(axis_pair))
-                        })
+                        });
                 }
 
                 if input_streams.input_pressed(input) {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -326,9 +326,10 @@ impl<A: Actionlike> InputMap<A> {
             let mut action_datum = ActionData::default();
 
             for input in input_vec {
-                action_datum.axis_pair = input_streams.input_axis_pair(input).map(|new_data| {
-                    new_data.merged_with(action_datum.axis_pair.unwrap_or_default())
-                });
+                if let Some(new_data) = input_streams.input_axis_pair(input) {
+                    let current_data = action_datum.axis_pair.unwrap_or_default();
+                    action_datum.axis_pair = Some(new_data.merged_with(current_data));
+                }
 
                 if input_streams.input_pressed(input) {
                     action_datum.state = ButtonState::JustPressed;


### PR DESCRIPTION
# Objective

The previous PR (#450) removed the accumulation for `ActionData::axis_pair` in `InputMap::which_pressed()`, resulting in a problem where multiple `DualAxisData` updates would only preserve the last one due to the loss of previously recorded `DualAxisData`.

## A Simple Reproduction Case

```rust
InputMap::new([
        (Action, VirtualDPad::arrow_keys()),
        (Action, VirtualDPad::wasd()),
]);
```

While it functions correctly when pressing WASD, if only the arrow keys were pressed, `ActionState::axis_pair()` will return `None`.

## Solution

Re-implement the accumulation of `ActionData::axis_pair` in `InputMap::which_pressed()`.

## Changelog

- Re-add the accumulation of `ActionData::axis_pair`
- Simplify the `ButtonState::JustPressed` check by moving it into the `input_pressed` checking block and remove the `pressed` flag