### PR TITLE
Release 0.12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ block_ui_interactions = []
 egui = ['dep:bevy_egui']
 
 [dependencies]
-leafwing_input_manager_macros = { path = "macros", version = "0.11" }
+leafwing_input_manager_macros = { path = "macros", version = "0.12" }
 bevy = { version = "0.12", default-features = false, features = [
   "serialize",
   "bevy_gilrs",

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Unreleased
+## Version 0.12
 
 ### Enhancements
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing_input_manager_macros"
 description = "Macros for the `leafwing-input-manager` crate"
-version = "0.11.0"
+version = "0.12.0"
 
 license = "MIT OR Apache-2.0"
 edition = "2021"


### PR DESCRIPTION
This is a breaking change release, but does *not* add support for Bevy 0.13. See #463 for that.

The idea here is to split this into two parts, to both better support users stuck on 0.12, and ease the migration process.