### PR TITLE
Refactor for clearer and more performant code

### DIFF
--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -314,13 +314,20 @@ impl<A: Actionlike> ActionState<A> {
         self.action_data.insert(action, data);
     }
 
+    fn action_data_mut_or_default(&mut self, action: &A) -> &mut ActionData {
+        if !self.action_data.contains_key(action) {
+            self.set_action_data(action.clone(), ActionData::default());
+        }
+        self.action_data_mut(action).unwrap()
+    }
+
     /// Press the `action`
     ///
     /// No initial instant or reasons why the button was pressed will be recorded
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn press(&mut self, action: &A) {
-        let action_data = self.action_data.entry(action.clone()).or_default();
+        let action_data = self.action_data_mut_or_default(action);
 
         // Consumed actions cannot be pressed until they are released
         if action_data.consumed {
@@ -340,7 +347,7 @@ impl<A: Actionlike> ActionState<A> {
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn release(&mut self, action: &A) {
-        let action_data = self.action_data.entry(action.clone()).or_default();
+        let action_data = self.action_data_mut_or_default(action);
 
         // Once released, consumed actions can be pressed again
         action_data.consumed = false;
@@ -393,7 +400,7 @@ impl<A: Actionlike> ActionState<A> {
     /// ```
     #[inline]
     pub fn consume(&mut self, action: &A) {
-        let action_data = self.action_data.entry(action.clone()).or_default();
+        let action_data = self.action_data_mut_or_default(action);
 
         // This is the only difference from action_state.release(&action)
         action_data.consumed = true;

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -320,13 +320,7 @@ impl<A: Actionlike> ActionState<A> {
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn press(&mut self, action: &A) {
-        let action_data = match self.action_data_mut(action) {
-            Some(action_data) => action_data,
-            None => {
-                self.set_action_data(action.clone(), ActionData::default());
-                self.action_data_mut(action).unwrap()
-            }
-        };
+        let action_data = self.action_data.entry(action.clone()).or_default();
 
         // Consumed actions cannot be pressed until they are released
         if action_data.consumed {
@@ -346,13 +340,7 @@ impl<A: Actionlike> ActionState<A> {
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn release(&mut self, action: &A) {
-        let action_data = match self.action_data_mut(action) {
-            Some(action_data) => action_data,
-            None => {
-                self.set_action_data(action.clone(), ActionData::default());
-                self.action_data_mut(action).unwrap()
-            }
-        };
+        let action_data = self.action_data.entry(action.clone()).or_default();
 
         // Once released, consumed actions can be pressed again
         action_data.consumed = false;
@@ -405,13 +393,7 @@ impl<A: Actionlike> ActionState<A> {
     /// ```
     #[inline]
     pub fn consume(&mut self, action: &A) {
-        let action_data = match self.action_data_mut(action) {
-            Some(action_data) => action_data,
-            None => {
-                self.set_action_data(action.clone(), ActionData::default());
-                self.action_data_mut(action).unwrap()
-            }
-        };
+        let action_data = self.action_data.entry(action.clone()).or_default();
 
         // This is the only difference from action_state.release(&action)
         action_data.consumed = true;
@@ -438,30 +420,21 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn consumed(&self, action: &A) -> bool {
-        match self.action_data(action) {
-            Some(action_data) => action_data.consumed,
-            None => false,
-        }
+        matches!(self.action_data(action), Some(action_data) if action_data.consumed)
     }
 
     /// Is this `action` currently pressed?
     #[inline]
     #[must_use]
     pub fn pressed(&self, action: &A) -> bool {
-        match self.action_data(action) {
-            Some(action_data) => action_data.state.pressed(),
-            None => false,
-        }
+        matches!(self.action_data(action), Some(action_data) if action_data.state.pressed())
     }
 
     /// Was this `action` pressed since the last time [tick](ActionState::tick) was called?
     #[inline]
     #[must_use]
     pub fn just_pressed(&self, action: &A) -> bool {
-        match self.action_data(action) {
-            Some(action_data) => action_data.state.just_pressed(),
-            None => false,
-        }
+        matches!(self.action_data(action), Some(action_data) if action_data.state.just_pressed())
     }
 
     /// Is this `action` currently released?
@@ -480,10 +453,7 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn just_released(&self, action: &A) -> bool {
-        match self.action_data(action) {
-            Some(action_data) => action_data.state.just_released(),
-            None => false,
-        }
+        matches!(self.action_data(action), Some(action_data) if action_data.state.just_released())
     }
 
     #[must_use]

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -315,10 +315,11 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     fn action_data_mut_or_default(&mut self, action: &A) -> &mut ActionData {
-        if !self.action_data.contains_key(action) {
-            self.set_action_data(action.clone(), ActionData::default());
-        }
-        self.action_data_mut(action).unwrap()
+        self.action_data
+            .raw_entry_mut()
+            .from_key(action)
+            .or_insert_with(|| (action.clone(), ActionData::default()))
+            .1
     }
 
     /// Press the `action`

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -686,10 +686,7 @@ impl DualAxisData {
     #[inline]
     pub fn direction(&self) -> Option<Direction> {
         // TODO: replace this quick-n-dirty hack once Direction::new no longer panics
-        if self.xy.length() > 0.00001 {
-            return Some(Direction::new(self.xy));
-        }
-        None
+        (self.xy.length() > 0.00001).then(|| Direction::new(self.xy))
     }
 
     /// The [`Rotation`] (measured clockwise from midnight) that this axis is pointing towards, if any
@@ -698,10 +695,7 @@ impl DualAxisData {
     #[must_use]
     #[inline]
     pub fn rotation(&self) -> Option<Rotation> {
-        match Rotation::from_xy(self.xy) {
-            Ok(rotation) => Some(rotation),
-            Err(_) => None,
-        }
+        Rotation::from_xy(self.xy).ok()
     }
 
     /// How far from the origin is this axis's position?
@@ -741,20 +735,20 @@ impl From<DualAxisData> for Vec2 {
 /// The shape of the deadzone for a [`DualAxis`] input.
 ///
 /// Input values that are on the boundary of the shape are counted as inside.
-/// If a size of a shape is 0.0, then all input values are read, except for 0.0.
+/// If the size of a shape is 0.0, then all input values are read, except for 0.0.
 ///
 /// All inputs are scaled to be continuous.
-/// So with a ellipse deadzone of a radius of 0.1, the input range `0.1..=1.0` will be scaled to `0.0..=1.0`.
+/// So with an ellipse deadzone of a radius of 0.1, the input range `0.1..=1.0` will be scaled to `0.0..=1.0`.
 ///
 /// Deadzone values should be in the range `0.0..=1.0`.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Reflect)]
 pub enum DeadZoneShape {
     /// Deadzone with the shape of a cross.
     ///
-    /// The cross is represented by horizonal and vertical rectangles.
-    /// Each axis is handled seperately which creates a per-axis "snapping" effect.
+    /// The cross is represented by horizontal and vertical rectangles.
+    /// Each axis is handled separately which creates a per-axis "snapping" effect.
     Cross {
-        /// The width of the horizonal axis.
+        /// The width of the horizontal axis.
         ///
         /// Affects the snapping of the y-axis.
         horizontal_width: f32,
@@ -794,15 +788,13 @@ impl std::hash::Hash for DeadZoneShape {
 impl DeadZoneShape {
     /// Computes the input value based on the deadzone.
     pub fn deadzone_input_value(&self, x: f32, y: f32) -> Option<DualAxisData> {
-        let value = Vec2::new(x, y);
-
         match self {
             DeadZoneShape::Cross {
                 horizontal_width,
                 vertical_width,
-            } => self.cross_deadzone_value(value, *horizontal_width, *vertical_width),
+            } => self.cross_deadzone_value(x, y, *horizontal_width, *vertical_width),
             DeadZoneShape::Ellipse { radius_x, radius_y } => {
-                self.ellipse_deadzone_value(value, *radius_x, *radius_y)
+                self.ellipse_deadzone_value(x, y, *radius_x, *radius_y)
             }
         }
     }
@@ -810,41 +802,46 @@ impl DeadZoneShape {
     /// Computes the input value based on the cross deadzone.
     fn cross_deadzone_value(
         &self,
-        value: Vec2,
+        x: f32,
+        y: f32,
         horizontal_width: f32,
         vertical_width: f32,
     ) -> Option<DualAxisData> {
-        let new_x = f32::from(value.x.abs() > vertical_width) * value.x;
-        let new_y = f32::from(value.y.abs() > horizontal_width) * value.y;
-        let new_value = Vec2::new(new_x, new_y);
-
-        if new_value == Vec2::ZERO {
-            None
-        } else {
-            let scaled_value =
-                Self::scale_value(new_value, Vec2::new(vertical_width, horizontal_width));
-            Some(DualAxisData::from_xy(scaled_value))
-        }
+        let new_x = deadzone_axis_value(x, vertical_width);
+        let new_y = deadzone_axis_value(y, horizontal_width);
+        let is_outside_deadzone = new_x != 0.0 || new_y != 0.0;
+        is_outside_deadzone.then(|| DualAxisData::new(new_x, new_y))
     }
 
     /// Computes the input value based on the ellipse deadzone.
     fn ellipse_deadzone_value(
         &self,
-        value: Vec2,
+        x: f32,
+        y: f32,
         radius_x: f32,
         radius_y: f32,
     ) -> Option<DualAxisData> {
-        let clamped_radius_x = radius_x.max(f32::EPSILON);
-        let clamped_radius_y = radius_y.max(f32::EPSILON);
-        if (value.x / clamped_radius_x).powi(2) + (value.y / clamped_radius_y).powi(2) < 1.0 {
-            return None;
-        }
-
-        let scaled_value = Self::scale_value(value, Vec2::new(radius_x, radius_y));
-        Some(DualAxisData::from_xy(scaled_value))
+        let x_ratio = x / radius_x.max(f32::EPSILON);
+        let y_ratio = y / radius_y.max(f32::EPSILON);
+        let is_outside_deadzone = x_ratio.powi(2) + y_ratio.powi(2) >= 1.0;
+        is_outside_deadzone.then(|| {
+            let new_x = deadzone_axis_value(x, radius_x);
+            let new_y = deadzone_axis_value(y, radius_y);
+            DualAxisData::new(new_x, new_y)
+        })
     }
+}
 
-    fn scale_value(value: Vec2, deadzone_size: Vec2) -> Vec2 {
-        value.signum() * (value.abs() - deadzone_size).max(Vec2::ZERO) / (1.0 - deadzone_size)
+/// Applies the given deadzone to the axis value.
+///
+/// Returns 0.0 if the axis value is within the deadzone.
+/// Otherwise, returns the normalized axis value between -1.0 and 1.0.
+#[inline(always)]
+pub(crate) fn deadzone_axis_value(axis_value: f32, deadzone: f32) -> f32 {
+    let abs_axis_value = axis_value.abs();
+    if abs_axis_value <= deadzone {
+        0.0
+    } else {
+        axis_value.signum() * (abs_axis_value - deadzone) / (1.0 - deadzone)
     }
 }

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -836,7 +836,6 @@ impl DeadZoneShape {
 ///
 /// Returns 0.0 if the axis value is within the deadzone.
 /// Otherwise, returns the normalized axis value between -1.0 and 1.0.
-#[inline(always)]
 pub(crate) fn deadzone_axis_value(axis_value: f32, deadzone: f32) -> f32 {
     let abs_axis_value = axis_value.abs();
     if abs_axis_value <= deadzone {

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -199,19 +199,20 @@ fn button_chord_clash(button: &InputKind, chord: &[InputKind]) -> bool {
 // Does the `dpad` clash with the `chord`?
 #[must_use]
 fn dpad_chord_clash(dpad: &VirtualDPad, chord: &[InputKind]) -> bool {
-    chord.len() > 1 && chord.iter().any(|button| dpad_button_clash(dpad, button))
+    chord.len() > 1
+        && chord
+            .iter()
+            .any(|button| [dpad.up, dpad.down, dpad.left, dpad.right].contains(button))
 }
 
 fn dpad_button_clash(dpad: &VirtualDPad, button: &InputKind) -> bool {
-    [dpad.up, dpad.down, dpad.left, dpad.right]
-        .iter()
-        .any(|dpad_button| button == dpad_button)
+    [dpad.up, dpad.down, dpad.left, dpad.right].contains(button)
 }
 
 fn dpad_dpad_clash(dpad1: &VirtualDPad, dpad2: &VirtualDPad) -> bool {
-    let iter1 = [&dpad1.up, &dpad1.down, &dpad1.left, &dpad1.right].into_iter();
-    let iter2 = [&dpad2.up, &dpad2.down, &dpad2.left, &dpad2.right].into_iter();
-    iter1.zip(iter2).any(|(left, right)| left == right)
+    [dpad1.up, dpad1.down, dpad1.left, dpad1.right]
+        .into_iter()
+        .any(|button| [dpad2.up, dpad2.down, dpad2.left, dpad2.right].contains(&button))
 }
 
 #[must_use]

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -103,8 +103,8 @@ impl<A: Actionlike> InputMap<A> {
     pub(crate) fn possible_clashes(&self) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
 
-        for (action_a, _) in self.iter() {
-            for (action_b, _) in self.iter() {
+        for action_a in self.actions() {
+            for action_b in self.actions() {
                 if let Some(clash) = self.possible_clash(action_a, action_b) {
                     clashes.push(clash);
                 }
@@ -162,11 +162,8 @@ impl<A: Actionlike> InputMap<A> {
             }
         }
 
-        if !clash.inputs_a.is_empty() {
-            Some(clash)
-        } else {
-            None
-        }
+        let not_empty = !clash.inputs_a.is_empty();
+        not_empty.then_some(clash)
     }
 }
 
@@ -196,49 +193,25 @@ impl<A: Actionlike> Clash<A> {
 // Does the `button` clash with the `chord`?
 #[must_use]
 fn button_chord_clash(button: &InputKind, chord: &[InputKind]) -> bool {
-    if chord.len() <= 1 {
-        return false;
-    }
-
-    chord.contains(button)
+    chord.len() > 1 && chord.contains(button)
 }
 
 // Does the `dpad` clash with the `chord`?
 #[must_use]
 fn dpad_chord_clash(dpad: &VirtualDPad, chord: &[InputKind]) -> bool {
-    if chord.len() <= 1 {
-        return false;
-    }
-
-    for button in &[dpad.up, dpad.down, dpad.left, dpad.right] {
-        if chord.contains(button) {
-            return true;
-        }
-    }
-
-    false
+    chord.len() > 1 && chord.iter().any(|button| dpad_button_clash(dpad, button))
 }
 
 fn dpad_button_clash(dpad: &VirtualDPad, button: &InputKind) -> bool {
-    for dpad_button in &[dpad.up, dpad.down, dpad.left, dpad.right] {
-        if button == dpad_button {
-            return true;
-        }
-    }
-
-    false
+    [dpad.up, dpad.down, dpad.left, dpad.right]
+        .iter()
+        .any(|dpad_button| button == dpad_button)
 }
 
 fn dpad_dpad_clash(dpad1: &VirtualDPad, dpad2: &VirtualDPad) -> bool {
-    for button1 in &[dpad1.up, dpad1.down, dpad1.left, dpad1.right] {
-        for button2 in &[dpad2.up, dpad2.down, dpad2.left, dpad2.right] {
-            if button1 == button2 {
-                return true;
-            }
-        }
-    }
-
-    false
+    let iter1 = [&dpad1.up, &dpad1.down, &dpad1.left, &dpad1.right].into_iter();
+    let iter2 = [&dpad2.up, &dpad2.down, &dpad2.left, &dpad2.right].into_iter();
+    iter1.zip(iter2).any(|(left, right)| left == right)
 }
 
 #[must_use]
@@ -248,30 +221,23 @@ fn virtual_axis_button_clash(axis: &VirtualAxis, button: &InputKind) -> bool {
 
 #[must_use]
 fn virtual_axis_dpad_clash(axis: &VirtualAxis, dpad: &VirtualDPad) -> bool {
-    for dpad_button in &[dpad.up, dpad.down, dpad.left, dpad.right] {
-        if dpad_button == &axis.negative || dpad_button == &axis.positive {
-            return true;
-        }
-    }
-
-    false
+    [&dpad.up, &dpad.down, &dpad.left, &dpad.right]
+        .iter()
+        .any(|button| virtual_axis_button_clash(axis, button))
 }
 
 #[must_use]
 fn virtual_axis_chord_clash(axis: &VirtualAxis, chord: &[InputKind]) -> bool {
-    if chord.len() <= 1 {
-        return false;
-    }
-
-    chord.contains(&axis.negative) || chord.contains(&axis.positive)
+    chord.len() > 1
+        && chord
+            .iter()
+            .any(|button| virtual_axis_button_clash(axis, button))
 }
 
 #[must_use]
 fn virtual_axis_virtual_axis_clash(axis1: &VirtualAxis, axis2: &VirtualAxis) -> bool {
-    axis1.negative == axis2.negative
-        || axis1.negative == axis2.positive
-        || axis1.positive == axis2.negative
-        || axis1.positive == axis2.positive
+    virtual_axis_button_clash(axis1, &axis2.negative)
+        || virtual_axis_button_clash(axis1, &axis2.positive)
 }
 
 /// Does the `chord_a` clash with `chord_b`?
@@ -285,17 +251,11 @@ fn chord_chord_clash(chord_a: &Vec<InputKind>, chord_b: &Vec<InputKind>) -> bool
         return false;
     }
 
-    is_subset(chord_a, chord_b) || is_subset(chord_b, chord_a)
-}
-
-fn is_subset(slice_a: &[InputKind], slice_b: &[InputKind]) -> bool {
-    for a in slice_a {
-        if !slice_b.contains(a) {
-            return false;
-        }
+    fn is_subset(slice_a: &[InputKind], slice_b: &[InputKind]) -> bool {
+        slice_a.iter().all(|a| slice_b.contains(a))
     }
 
-    true
+    is_subset(chord_a, chord_b) || is_subset(chord_b, chord_a)
 }
 
 /// Given the `input_streams`, does the provided clash actually occur?
@@ -325,11 +285,8 @@ fn check_clash<A: Actionlike>(clash: &Clash<A>, input_streams: &InputStreams) ->
         }
     }
 
-    if !clash.inputs_a.is_empty() {
-        Some(actual_clash)
-    } else {
-        None
-    }
+    let not_empty = !clash.inputs_a.is_empty();
+    not_empty.then_some(actual_clash)
 }
 
 /// Which (if any) of the actions in the [`Clash`] should be discarded?

--- a/src/display_impl.rs
+++ b/src/display_impl.rs
@@ -2,6 +2,7 @@
 
 use crate::axislike::{VirtualAxis, VirtualDPad};
 use crate::user_input::{InputKind, UserInput};
+use itertools::Itertools;
 use std::fmt::Display;
 
 impl Display for UserInput {
@@ -10,14 +11,7 @@ impl Display for UserInput {
             // The representation of the button
             UserInput::Single(button) => write!(f, "{button}"),
             // The representation of each button, separated by "+"
-            UserInput::Chord(button_set) => {
-                let mut string = String::default();
-                for button in button_set.iter() {
-                    string.push('+');
-                    string.push_str(&button.to_string());
-                }
-                write!(f, "{string}")
-            }
+            UserInput::Chord(button_set) => f.write_str(&button_set.iter().join("+")),
             UserInput::VirtualDPad(VirtualDPad {
                 up,
                 down,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -357,6 +357,10 @@ impl<A: Actionlike> InputMap<A> {
     pub fn iter(&self) -> impl Iterator<Item = (&A, &Vec<UserInput>)> {
         self.map.iter()
     }
+    /// Returns an iterator over actions
+    pub(crate) fn actions(&self) -> impl Iterator<Item = &A> {
+        self.map.keys()
+    }
     /// Returns a reference to the inputs mapped to `action`
     #[must_use]
     pub fn get(&self, action: &A) -> Option<&Vec<UserInput>> {
@@ -372,11 +376,7 @@ impl<A: Actionlike> InputMap<A> {
     /// How many input bindings are registered total?
     #[must_use]
     pub fn len(&self) -> usize {
-        let mut i = 0;
-        for inputs in self.map.values() {
-            i += inputs.len();
-        }
-        i
+        self.map.values().map(|inputs| inputs.len()).sum()
     }
 
     /// Are any input bindings registered at all?
@@ -406,11 +406,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Returns `Some(input)` if found.
     pub fn remove_at(&mut self, action: &A, index: usize) -> Option<UserInput> {
         let input_vec = self.map.get_mut(action)?;
-        if input_vec.len() <= index {
-            None
-        } else {
-            Some(input_vec.remove(index))
-        }
+        (input_vec.len() > index).then(|| input_vec.remove(index))
     }
 
     /// Removes the input for the `action`, if it exists

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -282,8 +282,8 @@ impl MutableInputStreams<'_> {
     }
 
     fn send_gamepad_button_changed(&mut self, gamepad: Option<Gamepad>, raw_inputs: &RawInputs) {
-        for button_type in raw_inputs.gamepad_buttons.iter() {
-            if let Some(gamepad) = gamepad {
+        if let Some(gamepad) = gamepad {
+            for button_type in raw_inputs.gamepad_buttons.iter() {
                 self.gamepad_events
                     .send(GamepadEvent::Button(GamepadButtonChangedEvent {
                         gamepad,

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -651,8 +651,9 @@ mod conversions {
             // for 1.0 and -1.0 can't be represented exactly, so our unit vectors start with an
             // approximate value and both `atan2` above and `from_radians` below magnify the
             // imprecision. So, we cheat.
-            const APPROX_SOUTH: f32 = -1.5707964;
-            const APPROX_NORTHWEST: f32 = 2.3561945;
+            use std::f32::consts::FRAC_PI_2;
+            const APPROX_SOUTH: f32 = -FRAC_PI_2;
+            const APPROX_NORTHWEST: f32 = 1.5 * FRAC_PI_2;
             if radians == APPROX_NORTHWEST {
                 Rotation::from_degrees_int(135)
             } else if radians == APPROX_SOUTH {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -201,10 +201,8 @@ pub fn generate_action_diffs<A: Actionlike>(
                         axis_pair: axis_pair.into(),
                     });
                     previous_axis_pairs
-                        .raw_entry_mut()
-                        .from_key(&action)
-                        .or_insert_with(|| (action.clone(), HashMap::default()))
-                        .1
+                        .entry(action)
+                        .or_insert_with(HashMap::default)
                         .insert(maybe_entity, axis_pair.xy());
                 }
                 None => {
@@ -221,10 +219,8 @@ pub fn generate_action_diffs<A: Actionlike>(
                         }
                     });
                     previous_values
-                        .raw_entry_mut()
-                        .from_key(&action)
-                        .or_insert_with(|| (action.clone(), HashMap::default()))
-                        .1
+                        .entry(action)
+                        .or_insert_with(HashMap::default)
                         .insert(maybe_entity, value);
                 }
             }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -202,7 +202,7 @@ pub fn generate_action_diffs<A: Actionlike>(
                     });
                     previous_axis_pairs
                         .entry(action)
-                        .or_insert_with(HashMap::default)
+                        .or_default()
                         .insert(maybe_entity, axis_pair.xy());
                 }
                 None => {
@@ -220,7 +220,7 @@ pub fn generate_action_diffs<A: Actionlike>(
                     });
                     previous_values
                         .entry(action)
-                        .or_insert_with(HashMap::default)
+                        .or_default()
                         .insert(maybe_entity, value);
                 }
             }

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -101,20 +101,14 @@ impl UserInput {
                 .iter()
                 .filter(|button| chord_buttons.contains(button))
                 .count(),
-            UserInput::VirtualDPad(dpad) => {
-                let dpad_buttons = [dpad.up, dpad.down, dpad.left, dpad.right];
-                buttons
-                    .iter()
-                    .filter(|button| dpad_buttons.contains(button))
-                    .count()
-            }
-            UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
-                let axis_buttons = [negative, positive];
-                buttons
-                    .iter()
-                    .filter(|button| axis_buttons.contains(button))
-                    .count()
-            }
+            UserInput::VirtualDPad(dpad) => buttons
+                .iter()
+                .filter(|button| [dpad.up, dpad.down, dpad.left, dpad.right].contains(button))
+                .count(),
+            UserInput::VirtualAxis(VirtualAxis { negative, positive }) => buttons
+                .iter()
+                .filter(|button| [negative, positive].contains(button))
+                .count(),
         }
     }
 

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -51,16 +51,10 @@ impl UserInput {
     /// If `inputs` has a length of 1, a [`UserInput::Single`] variant will be returned instead.
     pub fn chord(inputs: impl IntoIterator<Item = impl Into<InputKind>>) -> Self {
         // We can't just check the length unless we add an ExactSizeIterator bound :(
-        let mut length: u8 = 0;
+        let vec: Vec<InputKind> = inputs.into_iter().map(|input| input.into()).collect();
 
-        let mut vec: Vec<InputKind> = Vec::default();
-        for button in inputs {
-            length += 1;
-            vec.push(button.into());
-        }
-
-        match length {
-            1 => UserInput::Single(*vec.first().unwrap()),
+        match vec.len() {
+            1 => UserInput::Single(vec[0]),
             _ => UserInput::Chord(vec),
         }
     }
@@ -70,12 +64,11 @@ impl UserInput {
     /// - A [`Single`][UserInput::Single] input returns 1
     /// - A [`Chord`][UserInput::Chord] returns the number of buttons in the chord
     /// - A [`VirtualDPad`][UserInput::VirtualDPad] returns 1
+    /// - A [`VirtualAxis`][UserInput::VirtualAxis] returns 1
     pub fn len(&self) -> usize {
         match self {
-            UserInput::Single(_) => 1,
             UserInput::Chord(button_set) => button_set.len(),
-            UserInput::VirtualDPad { .. } => 1,
-            UserInput::VirtualAxis { .. } => 1,
+            _ => 1,
         }
     }
 
@@ -104,44 +97,23 @@ impl UserInput {
     pub fn n_matching(&self, buttons: &HashSet<InputKind>) -> usize {
         match self {
             UserInput::Single(button) => usize::from(buttons.contains(button)),
-            UserInput::Chord(chord_buttons) => {
-                let mut n_matching = 0;
-                for button in buttons.iter() {
-                    if chord_buttons.contains(button) {
-                        n_matching += 1;
-                    }
-                }
-
-                n_matching
-            }
-            UserInput::VirtualDPad(VirtualDPad {
-                up,
-                down,
-                left,
-                right,
-            }) => {
-                let mut n_matching = 0;
-                for button in buttons.iter() {
-                    for dpad_button in [up, down, left, right] {
-                        if button == dpad_button {
-                            n_matching += 1;
-                        }
-                    }
-                }
-
-                n_matching
+            UserInput::Chord(chord_buttons) => buttons
+                .iter()
+                .filter(|button| chord_buttons.contains(button))
+                .count(),
+            UserInput::VirtualDPad(dpad) => {
+                let dpad_buttons = [dpad.up, dpad.down, dpad.left, dpad.right];
+                buttons
+                    .iter()
+                    .filter(|button| dpad_buttons.contains(button))
+                    .count()
             }
             UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
-                let mut n_matching = 0;
-                for button in buttons.iter() {
-                    for dpad_button in [negative, positive] {
-                        if button == dpad_button {
-                            n_matching += 1;
-                        }
-                    }
-                }
-
-                n_matching
+                let axis_buttons = [negative, positive];
+                buttons
+                    .iter()
+                    .filter(|button| axis_buttons.contains(button))
+                    .count()
             }
         }
     }
@@ -151,119 +123,22 @@ impl UserInput {
         let mut raw_inputs = RawInputs::default();
 
         match self {
-            UserInput::Single(button) => match *button {
-                InputKind::DualAxis(dual_axis) => {
-                    raw_inputs
-                        .axis_data
-                        .push((dual_axis.x.axis_type, dual_axis.x.value));
-                    raw_inputs
-                        .axis_data
-                        .push((dual_axis.y.axis_type, dual_axis.y.value));
-                }
-                InputKind::SingleAxis(single_axis) => raw_inputs
-                    .axis_data
-                    .push((single_axis.axis_type, single_axis.value)),
-                InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
-                InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
-                InputKind::KeyLocation(scan_code) => raw_inputs.scan_codes.push(scan_code),
-                InputKind::Modifier(modifier) => {
-                    let key_codes = modifier.key_codes();
-                    raw_inputs.keycodes.push(key_codes[0]);
-                    raw_inputs.keycodes.push(key_codes[1]);
-                }
-                InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
-                InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
-                InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
-            },
+            UserInput::Single(button) => {
+                raw_inputs.merge_input_data(button);
+            }
             UserInput::Chord(button_set) => {
                 for button in button_set.iter() {
-                    match *button {
-                        InputKind::DualAxis(dual_axis) => {
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.x.axis_type, dual_axis.x.value));
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.y.axis_type, dual_axis.y.value));
-                        }
-                        InputKind::SingleAxis(single_axis) => raw_inputs
-                            .axis_data
-                            .push((single_axis.axis_type, single_axis.value)),
-                        InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
-                        InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
-                        InputKind::KeyLocation(scan_code) => raw_inputs.scan_codes.push(scan_code),
-                        InputKind::Modifier(modifier) => {
-                            let key_codes = modifier.key_codes();
-                            raw_inputs.keycodes.push(key_codes[0]);
-                            raw_inputs.keycodes.push(key_codes[1]);
-                        }
-                        InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
-                        InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
-                        InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
-                    }
+                    raw_inputs.merge_input_data(button);
                 }
             }
-            UserInput::VirtualDPad(VirtualDPad {
-                up,
-                down,
-                left,
-                right,
-            }) => {
-                for button in [up, down, left, right] {
-                    match *button {
-                        InputKind::DualAxis(dual_axis) => {
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.x.axis_type, dual_axis.x.value));
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.y.axis_type, dual_axis.y.value));
-                        }
-                        InputKind::SingleAxis(single_axis) => raw_inputs
-                            .axis_data
-                            .push((single_axis.axis_type, single_axis.value)),
-                        InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
-                        InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
-                        InputKind::KeyLocation(scan_code) => raw_inputs.scan_codes.push(scan_code),
-                        InputKind::Modifier(modifier) => {
-                            let key_codes = modifier.key_codes();
-                            raw_inputs.keycodes.push(key_codes[0]);
-                            raw_inputs.keycodes.push(key_codes[1]);
-                        }
-                        InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
-                        InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
-                        InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
-                    }
+            UserInput::VirtualDPad(dpad) => {
+                for button in [dpad.up, dpad.down, dpad.left, dpad.right] {
+                    raw_inputs.merge_input_data(&button);
                 }
             }
             UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
-                for button in [negative, positive] {
-                    // todo: dedup with VirtualDPad?
-                    match *button {
-                        InputKind::DualAxis(dual_axis) => {
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.x.axis_type, dual_axis.x.value));
-                            raw_inputs
-                                .axis_data
-                                .push((dual_axis.y.axis_type, dual_axis.y.value));
-                        }
-                        InputKind::SingleAxis(single_axis) => raw_inputs
-                            .axis_data
-                            .push((single_axis.axis_type, single_axis.value)),
-                        InputKind::GamepadButton(button) => raw_inputs.gamepad_buttons.push(button),
-                        InputKind::Keyboard(button) => raw_inputs.keycodes.push(button),
-                        InputKind::KeyLocation(scan_code) => raw_inputs.scan_codes.push(scan_code),
-                        InputKind::Modifier(modifier) => {
-                            let key_codes = modifier.key_codes();
-                            raw_inputs.keycodes.push(key_codes[0]);
-                            raw_inputs.keycodes.push(key_codes[1]);
-                        }
-                        InputKind::Mouse(button) => raw_inputs.mouse_buttons.push(button),
-                        InputKind::MouseWheel(button) => raw_inputs.mouse_wheel.push(button),
-                        InputKind::MouseMotion(button) => raw_inputs.mouse_motion.push(button),
-                    }
-                }
+                raw_inputs.merge_input_data(negative);
+                raw_inputs.merge_input_data(positive);
             }
         };
 
@@ -500,6 +375,30 @@ pub struct RawInputs {
     ///
     /// The `f32` stores the magnitude of the axis motion, and is only used for input mocking.
     pub axis_data: Vec<(AxisType, Option<f32>)>,
+}
+
+impl RawInputs {
+    /// Merges the data from the given `input_kind` into `self`.
+    fn merge_input_data(&mut self, input_kind: &InputKind) {
+        match *input_kind {
+            InputKind::DualAxis(DualAxis { x, y, .. }) => {
+                self.axis_data.push((x.axis_type, x.value));
+                self.axis_data.push((y.axis_type, y.value));
+            }
+            InputKind::SingleAxis(single_axis) => self
+                .axis_data
+                .push((single_axis.axis_type, single_axis.value)),
+            InputKind::GamepadButton(button) => self.gamepad_buttons.push(button),
+            InputKind::Keyboard(button) => self.keycodes.push(button),
+            InputKind::KeyLocation(scan_code) => self.scan_codes.push(scan_code),
+            InputKind::Modifier(modifier) => {
+                self.keycodes.extend_from_slice(&modifier.key_codes());
+            }
+            InputKind::Mouse(button) => self.mouse_buttons.push(button),
+            InputKind::MouseWheel(button) => self.mouse_wheel.push(button),
+            InputKind::MouseMotion(button) => self.mouse_motion.push(button),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -73,12 +73,11 @@ fn send_action_diff(app: &mut App, action_diff: ActionDiffEvent<Action>) {
 fn assert_has_no_action_diffs(app: &mut App) {
     let action_diff_events = get_events::<ActionDiffEvent<Action>>(app);
     let action_diff_event_reader = &mut action_diff_events.get_reader();
-    match action_diff_event_reader.read(action_diff_events).next() {
-        Some(action_diff) => panic!(
+    if let Some(action_diff) = action_diff_event_reader.read(action_diff_events).next() {
+        panic!(
             "Expected no `ActionDiff` variants. Received: {:?}",
             action_diff
-        ),
-        None => {}
+        )
     }
 }
 
@@ -103,23 +102,23 @@ fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent
     match action_diff_event.action_diffs.first().unwrap().clone() {
         ActionDiff::Pressed { action } => {
             assert!(action_state.pressed(&action));
-            assert!(action_state.value(&action) == 1.);
+            assert_eq!(action_state.value(&action), 1.);
         }
         ActionDiff::Released { action } => {
             assert!(action_state.released(&action));
-            assert!(action_state.value(&action) == 0.);
+            assert_eq!(action_state.value(&action), 0.);
             assert!(action_state.axis_pair(&action).is_none());
         }
         ActionDiff::ValueChanged { action, value } => {
             assert!(action_state.pressed(&action));
-            assert!(action_state.value(&action) == value);
+            assert_eq!(action_state.value(&action), value);
         }
         ActionDiff::AxisPairChanged { action, axis_pair } => {
             assert!(action_state.pressed(&action));
             match action_state.axis_pair(&action) {
                 Some(axis_pair_data) => {
-                    assert!(axis_pair_data.xy() == axis_pair);
-                    assert!(action_state.value(&action) == axis_pair_data.xy().length());
+                    assert_eq!(axis_pair_data.xy(), axis_pair);
+                    assert_eq!(action_state.value(&action), axis_pair_data.xy().length());
                 }
                 None => panic!("Expected an `AxisPair` variant. Received none."),
             }

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -233,7 +233,7 @@ fn game_pad_single_axis() {
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
-    assert!(action_state.value(&AxislikeTestAction::X) == 0.11111112);
+    assert_eq!(action_state.value(&AxislikeTestAction::X), 0.11111112);
 }
 
 #[test]
@@ -264,7 +264,7 @@ fn game_pad_single_axis_inverted() {
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
-    assert!(action_state.value(&AxislikeTestAction::X) == -1.0);
+    assert_eq!(action_state.value(&AxislikeTestAction::X), -1.0);
 
     // -X
     let input = SingleAxis {
@@ -279,7 +279,7 @@ fn game_pad_single_axis_inverted() {
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
-    assert!(action_state.value(&AxislikeTestAction::X) == 1.0);
+    assert_eq!(action_state.value(&AxislikeTestAction::X), 1.0);
 
     // +Y
     let input = SingleAxis {
@@ -294,7 +294,7 @@ fn game_pad_single_axis_inverted() {
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
-    assert!(action_state.value(&AxislikeTestAction::Y) == -1.0);
+    assert_eq!(action_state.value(&AxislikeTestAction::Y), -1.0);
 
     // -Y
     let input = SingleAxis {
@@ -309,7 +309,7 @@ fn game_pad_single_axis_inverted() {
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
-    assert!(action_state.value(&AxislikeTestAction::Y) == 1.0);
+    assert_eq!(action_state.value(&AxislikeTestAction::Y), 1.0);
 }
 
 #[test]


### PR DESCRIPTION
Simplified PR #463 to refactor for clearer and more performant code.

## Changelog

### Logic Refactor

- Refactored `DeadZoneShape::cross_deadzone_value()` and `DeadZoneShape::ellipse_deadzone_value()` to improve clarity of logic.
- Refactored `InputStreams::button_pressed()` and `InputStreams::input_value()` functions for both `MouseWheel` and `MouseMotion` events by using more efficient `f64` accumulation, reducing unnecessary `match`.

### Deduplication

- Extracted `ActionState::action_data_mut_or_default()` function to remove duplication in the parts checking `press()`, `release()`, and `consume()`.
- Extracted `deadzone_axis_value()` to remove duplication in the parts applying deadzone to input values.
- Reused the existing `virtual_axis_button_clash()` for checking clashes of `VirtualAxis`.
- Extracted `send_keyboard_input()`, `send_mouse_wheel()`, `send_mouse_motion()`, `send_gamepad_button_changed()` for `MutableInputStreams` when mocking input.
- Extracted `collect_events_cloned()` to remove duplication in the parts collecting the cloned events of `MouseWheel` and `MouseMotion`.
- Reused the existing `InputStreams::extract_dual_axis_data()` to check `InputKind::DualAxis` has been `button_pressed()`.
- Extracted `get_gamepad_value()` closure to reuse the logic getting values from `InputStreams::gamepad_axes` and `InputStreams::gamepad_buttons_axes`.
- Extracted `InputStreams::extract_single_axis_data()` for computing the `input_value()` of `VirtualAxis` and the `input_axis_pair()` of `VirtualDpad`.
- Extracted `RawInputs::merge_input_data()` to remove duplication in the parts merging `UserInput`s into a `RawInputs`.

### Code Quality

- Used the existing std::consts like `FRAC_PI_2` rather than magic numbers.
- Used `f32::from()` rather than manual `if` when just getting a `f32` from `bool` value.
- Used `matches!` rather than manual `match` when just getting a `bool` field value.
- Used `if let Some()` rather than manual `match` when the `None` arm does nothing.
- Used `Result::ok()` rather than manual `match` when casting `Result` into `Option`.
- Used `Option::then()` rather than manual `match` when just mapping its value.
- Used `bool::then_some()` rather than `if` when just mapping it into `Option`.
- Used iterators rather than manual `for` loops when the logic can be replaced with simple and meaningful operators.
- Used `Itertools::join()` rather than manual `for` loop when just converting values into a string.
- Used `Option::into_iter().chain(Iter)` instead of manual `if` for identical behavior, as they result in the same assembly code.
- Used `HashMap::entry().or_default()` rather than manual `HashMap::raw_entry_mut().or_insert_with()` to ensure its value existence.
- Used `assert_eq!` rather than `assert!` when asserting two values are equal.

### Typo

- Fixed typo in the documentation of `DeadZoneShape`.

### Documentation

- Added missing documentation of `UserInput::len()` for `VirtualAxis`.