### PR TITLE
[Breaking Changes] Rename `Modifier::Win` to `Modifier::Super`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Unreleased
+
+### Breaking Changes
+
+- `Modifier::Win` has been renamed to `Modifier::Super`, consistent with `KeyCode::SuperLeft` and `KeyCode::SuperRight`.
+
 ## Version 0.12.1
 
 ### Usability

--- a/src/user_input.rs
+++ b/src/user_input.rs
@@ -461,7 +461,7 @@ pub enum Modifier {
     /// The key that makes letters capitalized, corresponding to [`KeyCode::ShiftLeft`] and [`KeyCode::ShiftRight`]
     Shift,
     /// The OS or "Windows" key, corresponding to [`KeyCode::SuperLeft`] and [`KeyCode::SuperRight`].
-    Win,
+    Super,
 }
 
 impl Modifier {
@@ -474,7 +474,7 @@ impl Modifier {
             Modifier::Alt => [KeyCode::AltLeft, KeyCode::AltRight],
             Modifier::Control => [KeyCode::ControlLeft, KeyCode::ControlRight],
             Modifier::Shift => [KeyCode::ShiftLeft, KeyCode::ShiftRight],
-            Modifier::Win => [KeyCode::SuperLeft, KeyCode::SuperRight],
+            Modifier::Super => [KeyCode::SuperLeft, KeyCode::SuperRight],
         }
     }
 }


### PR DESCRIPTION
Rename `Modifier::Win` to `Modifier::Super`, consistent with `KeyCode::SuperLeft` and `KeyCode::SuperRight` (since Bevy 0.11).