### PR TITLE
Release the pressed `ActionData` when it isn't being updated

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
 ### Bugs
 
 - fixed compilation issues with no-default-features
+- fixed [a bug](https://github.com/Leafwing-Studios/leafwing-input-manager/issues/471) related to incorrect updating of `ActionState`.
 
 ## Version 0.12
 

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -103,6 +103,11 @@ impl<A: Actionlike> ActionState<A> {
     /// The `action_data` is typically constructed from [`InputMap::which_pressed`](crate::input_map::InputMap),
     /// which reads from the assorted [`Input`](bevy::input::Input) resources.
     pub fn update(&mut self, action_data: HashMap<A, ActionData>) {
+        for (action, action_datum) in self.action_data.iter_mut() {
+            if !action_data.contains_key(action) {
+                action_datum.state.release();
+            }
+        }
         for (action, action_datum) in action_data {
             match self.action_data.entry(action) {
                 Entry::Occupied(occupied_entry) => {

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -590,29 +590,27 @@ impl<A: Actionlike> ActionState<A> {
 #[cfg(test)]
 mod tests {
     use crate as leafwing_input_manager;
+    use crate::action_state::ActionState;
+    use crate::clashing_inputs::ClashStrategy;
+    use crate::input_map::InputMap;
     use crate::input_mocking::MockInput;
-    use bevy::prelude::Reflect;
+    use crate::input_streams::InputStreams;
+    use bevy::input::InputPlugin;
+    use bevy::prelude::*;
+    use bevy::utils::{Duration, Instant};
     use leafwing_input_manager_macros::Actionlike;
-
-    #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
-    enum Action {
-        Run,
-        Jump,
-        Hide,
-    }
 
     #[test]
     fn press_lifecycle() {
-        use crate::action_state::ActionState;
-        use crate::clashing_inputs::ClashStrategy;
-        use crate::input_map::InputMap;
-        use crate::input_streams::InputStreams;
-        use bevy::input::InputPlugin;
-        use bevy::prelude::*;
-        use bevy::utils::{Duration, Instant};
-
         let mut app = App::new();
         app.add_plugins(InputPlugin);
+
+        #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, bevy::prelude::Reflect)]
+        enum Action {
+            Run,
+            Jump,
+            Hide,
+        }
 
         // Action state
         let mut action_state = ActionState::<Action>::default();
@@ -672,5 +670,80 @@ mod tests {
         assert!(!action_state.just_pressed(&Action::Run));
         assert!(action_state.released(&Action::Run));
         assert!(!action_state.just_released(&Action::Run));
+    }
+
+    #[test]
+    fn update_with_clashes_prioritizing_longest() {
+        #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
+        enum Action {
+            One,
+            Two,
+            OneAndTwo,
+        }
+
+        // Input map
+        use bevy::prelude::KeyCode::*;
+        let mut input_map = InputMap::default();
+        input_map.insert(Action::One, Key1);
+        input_map.insert(Action::Two, Key2);
+        input_map.insert_chord(Action::OneAndTwo, [Key1, Key2]);
+
+        let mut app = App::new();
+        app.add_plugins(InputPlugin);
+
+        // Action state
+        let mut action_state = ActionState::<Action>::default();
+
+        // Starting state
+        let input_streams = InputStreams::from_world(&app.world, None);
+        action_state
+            .update(input_map.which_pressed(&input_streams, ClashStrategy::PrioritizeLongest));
+        assert!(action_state.released(&Action::One));
+        assert!(action_state.released(&Action::Two));
+        assert!(action_state.released(&Action::OneAndTwo));
+
+        // Pressing One
+        app.send_input(Key1);
+        app.update();
+        let input_streams = InputStreams::from_world(&app.world, None);
+
+        action_state
+            .update(input_map.which_pressed(&input_streams, ClashStrategy::PrioritizeLongest));
+
+        assert!(action_state.pressed(&Action::One));
+        assert!(action_state.released(&Action::Two));
+        assert!(action_state.released(&Action::OneAndTwo));
+
+        // Waiting
+        action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
+        action_state
+            .update(input_map.which_pressed(&input_streams, ClashStrategy::PrioritizeLongest));
+
+        assert!(action_state.pressed(&Action::One));
+        assert!(action_state.released(&Action::Two));
+        assert!(action_state.released(&Action::OneAndTwo));
+
+        // Pressing Two
+        app.send_input(Key2);
+        app.update();
+        let input_streams = InputStreams::from_world(&app.world, None);
+
+        action_state
+            .update(input_map.which_pressed(&input_streams, ClashStrategy::PrioritizeLongest));
+
+        // Now only the longest OneAndTwo has been pressed,
+        // while both One and Two have been released
+        assert!(action_state.released(&Action::One));
+        assert!(action_state.released(&Action::Two));
+        assert!(action_state.pressed(&Action::OneAndTwo));
+
+        // Waiting
+        action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
+        action_state
+            .update(input_map.which_pressed(&input_streams, ClashStrategy::PrioritizeLongest));
+
+        assert!(action_state.released(&Action::One));
+        assert!(action_state.released(&Action::Two));
+        assert!(action_state.pressed(&Action::OneAndTwo));
     }
 }


### PR DESCRIPTION
# Objective

Fixes #471.

## Solution

The actual issue lies in the incorrect updating of `ActionState` because it is now updated through a `HashMap` instead of a `Vec`, but the clashed `ActionData` has been removed (since #450).

## Relevant Code
```rust
// Handle clashes before #450
pub fn handle_clashes(
    &self,
    action_data: &mut [ActionData],
    input_streams: &InputStreams,
    clash_strategy: ClashStrategy,
) {
    for clash in self.get_clashes(action_data, input_streams) {
        // Remove the action in the pair that was overruled, if any
        if let Some(culled_action) = resolve_clash(&clash, clash_strategy, input_streams) {
            action_data[culled_action.index()] = ActionData::default();
        }
    }
}
// Update ActionData before #450
pub fn update(&mut self, action_data: Vec<ActionData>) {
    assert_eq!(action_data.len(), A::n_variants());

    for (i, action) in A::variants().enumerate() {
        match action_data[i].state {
            ButtonState::JustPressed => self.press(&action),
            ButtonState::Pressed => self.press(&action),
            ButtonState::JustReleased => self.release(&action),
            ButtonState::Released => self.release(&action),
        }

        self.action_data[i].axis_pair = action_data[i].axis_pair;
        self.action_data[i].value = action_data[i].value;
    }
}

// Handle clashes after #450
pub fn handle_clashes(
    &self,
    action_data: &mut HashMap<A, ActionData>,
    input_streams: &InputStreams,
    clash_strategy: ClashStrategy,
) {
    for clash in self.get_clashes(action_data, input_streams) {
        // Remove the action in the pair that was overruled, if any
        if let Some(culled_action) = resolve_clash(&clash, clash_strategy, input_streams) {
            action_data.remove(&culled_action);
        }
    }
}
// Update ActionData after #450
pub fn update(&mut self, action_data: HashMap<A, ActionData>) {
    for (action, action_datum) in action_data {
        match self.action_data.entry(action) {
            Entry::Occupied(occupied_entry) => {
                let entry = occupied_entry.into_mut();

                match action_datum.state {
                    ButtonState::JustPressed => entry.state.press(),
                    ButtonState::Pressed => entry.state.press(),
                    ButtonState::JustReleased => entry.state.release(),
                    ButtonState::Released => entry.state.release(),
                }

                entry.axis_pair = action_datum.axis_pair;
                entry.value = action_datum.value;
            }
            Entry::Vacant(empty_entry) => {
                empty_entry.insert(action_datum.clone());
            }
        }
    }
}
```