### PR TITLE
Add CI testing for all feature flag combinations and fix all reported errors

### DIFF
--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 [dependencies]
 xshell = "0.2"
 bitflags = "2"
+itertools = "0.12"

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -66,6 +66,17 @@ fn main() {
             .expect("Please run 'cargo fmt --all' to format your code.");
     }
 
+    if what_to_run.contains(Check::DOC_CHECK) {
+        // Check that building docs work and does not emit warnings
+        std::env::set_var("RUSTDOCFLAGS", "-D warnings");
+        cmd!(
+            sh,
+            "cargo doc --workspace --all-features --no-deps --document-private-items"
+        )
+        .run()
+        .expect("Please fix doc warnings in output above.");
+    }
+
     // The features the lib offers
     let lib_features = ["asset", "ui", "block_ui_interactions", "egui"];
 
@@ -110,17 +121,6 @@ fn main() {
             cmd!(sh, "cargo test --workspace {feature_option} --doc")
                 .run()
                 .expect("Please fix failing doc-tests in output above.");
-        }
-
-        if what_to_run.contains(Check::DOC_CHECK) {
-            // Check that building docs work and does not emit warnings
-            std::env::set_var("RUSTDOCFLAGS", "-D warnings");
-            cmd!(
-                sh,
-                "cargo doc --workspace {feature_option} --no-deps --document-private-items"
-            )
-            .run()
-            .expect("Please fix doc warnings in output above.");
         }
 
         if what_to_run.contains(Check::COMPILE_CHECK) {

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -96,8 +96,8 @@ fn main() {
     for feature_option in all_features_options {
         if what_to_run.contains(Check::CLIPPY) {
             // See if clippy has any complaints.
-            // --all-targets --all-features was removed because Emergence currently has no special
-            // targets or features; please add them back as necessary
+            // --all-targets was removed because Emergence currently has no special targets;
+            // please add them back as necessary
             cmd!(
                 sh,
                 "cargo clippy --workspace {feature_option} -- {CLIPPY_FLAGS...}"

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -66,10 +66,11 @@ fn main() {
             .expect("Please run 'cargo fmt --all' to format your code.");
     }
 
+    // The features the lib offers
     let lib_features = ["asset", "ui", "block_ui_interactions", "egui"];
 
-    // Generate the powerset of lib features
-    // and convert its subset into '--features=<FEATURE_A,FEATURE_B,...>'
+    // Generate all possible combinations of lib features
+    // and convert them into '--features=<FEATURE_A,FEATURE_B,...>'
     let lib_features_options = (1..lib_features.len())
         .flat_map(|combination_length| lib_features.iter().combinations(combination_length))
         .map(|combination| String::from("--features=") + &combination.iter().join(","));

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -1,8 +1,8 @@
 //! Modified from [Bevy's CI runner](https://github.com/bevyengine/bevy/tree/main/tools/ci/src)
 
-use xshell::{cmd, Shell};
-
 use bitflags::bitflags;
+use itertools::Itertools;
+use xshell::{cmd, Shell};
 
 bitflags! {
     #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -66,43 +66,66 @@ fn main() {
             .expect("Please run 'cargo fmt --all' to format your code.");
     }
 
-    if what_to_run.contains(Check::CLIPPY) {
-        // See if clippy has any complaints.
-        // --all-targets --all-features was removed because Emergence currently has no special
-        // targets or features; please add them back as necessary
-        cmd!(sh, "cargo clippy --workspace -- {CLIPPY_FLAGS...}")
+    let lib_features = ["asset", "ui", "block_ui_interactions", "egui"];
+
+    // Generate the powerset of lib features
+    // and convert its subset into '--features=<FEATURE_A,FEATURE_B,...>'
+    let lib_features_options = (1..lib_features.len())
+        .flat_map(|combination_length| lib_features.iter().combinations(combination_length))
+        .map(|combination| String::from("--features=") + &combination.iter().join(","));
+
+    let default_feature_options = ["--no-default-features", "--all-features"];
+    let all_features_options = default_feature_options
+        .iter()
+        .map(|str| str.to_string())
+        .chain(lib_features_options)
+        .collect::<Vec<_>>();
+
+    for feature_option in all_features_options {
+        if what_to_run.contains(Check::CLIPPY) {
+            // See if clippy has any complaints.
+            // --all-targets --all-features was removed because Emergence currently has no special
+            // targets or features; please add them back as necessary
+            cmd!(
+                sh,
+                "cargo clippy --workspace {feature_option} -- {CLIPPY_FLAGS...}"
+            )
             .run()
             .expect("Please fix clippy errors in output above.");
-    }
+        }
 
-    if what_to_run.contains(Check::TEST) {
-        // Run tests (except doc tests and without building examples)
-        cmd!(sh, "cargo test --workspace --lib --bins --tests --benches")
+        if what_to_run.contains(Check::TEST) {
+            // Run tests (except doc tests and without building examples)
+            cmd!(
+                sh,
+                "cargo test --workspace {feature_option} --lib --bins --tests --benches"
+            )
             .run()
             .expect("Please fix failing tests in output above.");
-    }
+        }
 
-    if what_to_run.contains(Check::DOC_TEST) {
-        // Run doc tests
-        cmd!(sh, "cargo test --workspace --doc")
+        if what_to_run.contains(Check::DOC_TEST) {
+            // Run doc tests
+            cmd!(sh, "cargo test --workspace {feature_option} --doc")
+                .run()
+                .expect("Please fix failing doc-tests in output above.");
+        }
+
+        if what_to_run.contains(Check::DOC_CHECK) {
+            // Check that building docs work and does not emit warnings
+            std::env::set_var("RUSTDOCFLAGS", "-D warnings");
+            cmd!(
+                sh,
+                "cargo doc --workspace {feature_option} --no-deps --document-private-items"
+            )
             .run()
-            .expect("Please fix failing doc-tests in output above.");
-    }
+            .expect("Please fix doc warnings in output above.");
+        }
 
-    if what_to_run.contains(Check::DOC_CHECK) {
-        // Check that building docs work and does not emit warnings
-        std::env::set_var("RUSTDOCFLAGS", "-D warnings");
-        cmd!(
-            sh,
-            "cargo doc --workspace --all-features --no-deps --document-private-items"
-        )
-        .run()
-        .expect("Please fix doc warnings in output above.");
-    }
-
-    if what_to_run.contains(Check::COMPILE_CHECK) {
-        cmd!(sh, "cargo check --workspace")
-            .run()
-            .expect("Please fix compiler errors in above output.");
+        if what_to_run.contains(Check::COMPILE_CHECK) {
+            cmd!(sh, "cargo check --workspace {feature_option}")
+                .run()
+                .expect("Please fix compiler errors in above output.");
+        }
     }
 }


### PR DESCRIPTION
# Objective

Make sure we thoroughly test all feature-related code and updates.

## Solution

Cover all combinations of features our crate offers when running CI tests for `clippy`, ~~`doc-check`,~~ `doc-test`, `test`, and `compile-check`.

For instance, given the current existence of four features: `asset`, `ui`, `block_ui_interactions`, and `egui`, the new CI testing will include scenarios like:

- Testing with `--no-default-features`
- Testing with `--all-features`
- Testing with individual features enabled:
  - `--features=asset`
  - `--features=ui`
  - `--features=block_ui_interactions`
  - `--features=egui`
- Testing with various combinations of features enabled:
  - `--features=asset,ui`
  - `--features=asset,block_ui_interactions`
  - `--features=asset,egui`
  - `--features=ui,block_ui_interactions`
  - `--features=ui,egui`
  - `--features=block_ui_interactions,egui`
  - `--features=asset,ui,block_ui_interactions`
  - `--features=asset,ui,egui`
  - `--features=asset,block_ui_interactions,egui`
  - `--features=ui,block_ui_interactions,egui`

This ensures we catch any regressions or issues related to the features.

### TODO

- [x] fix all reported errors (without those reporting from `doc-check`)

### Changelog

- Add new CI testing for all feature flag combinations