### PR TITLE
Align the behavior of the `ui` feature with `egui`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,20 +18,21 @@ opt-level = 3
 members = ["./", "tools/ci", "macros"]
 
 [features]
-default = ['asset', 'ui', 'block_ui_interactions']
+default = ['asset', 'ui']
 
 # Allow you to use the `InputMap` as `bevy::asset::Asset`.
 asset = ['bevy/bevy_asset']
 
 # Provide functionality refer to `bevy::ui`:
+# - `bevy::ui` will take priority over actions when processing inputs for the `ActionState`.
 # - `MockUIInteraction` for `bevy::ui` input mocking.
 # - `update_action_state_from_interaction` system,
 #   which automatically processes clicks on `bevy::ui` buttons attached to `Actionlike`s,
 #   triggering corresponding actions in their `ActionState`.
 ui = ['bevy/bevy_ui']
 
-# If both this feature and `ui` are enabled, `bevy::ui` will take priority over actions when processing inputs for the `ActionState`.
-block_ui_interactions = []
+# Disable the priority of `bevy::ui` when processing inputs for the `ActionState`.
+no_ui_priority = []
 
 # If this feature is enabled, `egui` will take priority over actions when processing inputs for the `ActionState`.
 egui = ['dep:bevy_egui']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ asset = ['bevy/bevy_asset']
 # - Allow using `MockUIInteraction` for 'bevy::ui' input mocking.
 ui = ['bevy/bevy_ui']
 
-# Disable the priority of `bevy::ui` when processing inputs for the `ActionState`.
+# Disable the priority of `bevy::ui` when processing inputs.
 no_ui_priority = []
 
 # Add support for 'egui' integration:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ asset = ['bevy/bevy_asset']
 # - Allow using `MockUIInteraction` for 'bevy::ui' input mocking.
 ui = ['bevy/bevy_ui']
 
-# Disable the priority of `bevy::ui` when processing inputs.
+# Disable the priority of 'bevy::ui' when processing inputs.
 no_ui_priority = []
 
 # Add support for 'egui' integration:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ default = ['asset', 'ui']
 asset = ['bevy/bevy_asset']
 
 # Add support for 'bevy::ui' integration:
+# - Allow 'bevy::ui' to take priority over actions when processing inputs.
 # - Automatic process clicks on 'bevy::ui' buttons that attached `ActionStateDriver` to drive corresponding actions.
 # - Allow using `MockUIInteraction` for 'bevy::ui' input mocking.
 ui = ['bevy/bevy_ui']

--- a/README.md
+++ b/README.md
@@ -111,5 +111,5 @@ This snippet is the `minimal.rs` example from the [`examples`](./examples) folde
 
 ## Crate Feature Flags
 
-This crate has four feature flags: `asset`, `ui`, `block_ui_interactions`, and `egui`.
+This crate has four feature flags: `asset`, `ui`, `no_ui_priority`, and `egui`.
 Please refer to the `[features]` section in the [`Cargo.toml`](./Cargo.toml) for detailed information about their configurations.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,9 +4,9 @@
 
 ### Breaking Changes
 
-- removed `block_ui_interactions`:
-  - by default, this library will prioritize `bevy::ui`, thus you could simply remove the `block_ui_interactions` feature from your `Cargo.toml`.
-  - if you want to disable this priority, add the `no_ui_priority` feature to your configuration.
+- removed the `block_ui_interactions` feature:
+  - by default, this library will prioritize `bevy::ui`.
+  - if you want to disable this priority, add the newly added `no_ui_priority` feature to your configuration.
 
 ## Version 0.13.0
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Unreleased
+
+### Breaking Changes
+
+- removed `block_ui_interactions`:
+  - by default, this library will prioritize `bevy::ui`, thus you could simply remove the `block_ui_interactions` feature from your `Cargo.toml`.
+  - if you want to disable this priority, add the `no_ui_priority` feature to your configuration.
+
 ## Version 0.13.0
 
 ### Breaking Changes

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -72,9 +72,7 @@ pub fn update_action_state<A: Actionlike>(
     mut mouse_wheel: EventReader<MouseWheel>,
     mut mouse_motion: EventReader<MouseMotion>,
     clash_strategy: Res<ClashStrategy>,
-    #[cfg(all(feature = "ui", feature = "block_ui_interactions"))] interactions: Query<
-        &Interaction,
-    >,
+    #[cfg(all(feature = "ui", not(feature = "no_ui_priority")))] interactions: Query<&Interaction>,
     #[cfg(feature = "egui")] mut maybe_egui: Query<(Entity, &'static mut EguiContext)>,
     action_state: Option<ResMut<ActionState<A>>>,
     input_map: Option<Res<InputMap<A>>>,
@@ -91,7 +89,7 @@ pub fn update_action_state<A: Actionlike>(
     let mouse_motion: Vec<MouseMotion> = mouse_motion.read().cloned().collect();
 
     // If use clicks on a button, do not apply them to the game state
-    #[cfg(all(feature = "ui", feature = "block_ui_interactions"))]
+    #[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
     let (mouse_buttons, mouse_wheel) = if interactions
         .iter()
         .any(|&interaction| interaction != Interaction::None)

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -78,7 +78,7 @@ fn main() {
     }
 
     // The features the lib offers
-    let lib_features = ["asset", "ui", "block_ui_interactions", "egui"];
+    let lib_features = ["asset", "ui", "no_ui_priority", "egui"];
 
     // Generate all possible combinations of lib features
     // and convert them into '--features=<FEATURE_A,FEATURE_B,...>'


### PR DESCRIPTION
## Objective

Currently, the `egui` feature prioritizes `egui` over actions during input processing for the `ActionState`.
However, the `ui` feature behaves differently unless both it and the `block_ui_interactions` feature are enabled (since #391).

### Solution

To ensure consistency, make the `ui` feature behave like `egui` by removing the need for the `block_ui_interactions` feature.

Additionally, introduce a new `no_ui_priority` feature to disable the priority given by the `ui` feature.

### Migration Guide

By default, this library will prioritize `bevy::ui`, thus you could simply remove the `block_ui_interactions` feature from your `Cargo.toml`.
If you want to disable this priority, add the `no_ui_priority` feature to your configuration.

### Changelog

- Removed `block_ui_interactions` feature.
- Added `no_ui_priority` feature.
- Changed the feature gate for parts prioritizing `bevy::ui` from `all(feature = "ui", feature = "block_ui_interactions")` to `all(feature = "ui", not(feature = "no_ui_priority"))`.