### PR TITLE
Runtime disabling of specific input type tracking

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -8,6 +8,10 @@
   - by default, this library will prioritize `bevy::ui`.
   - if you want to disable this priority, add the newly added `no_ui_priority` feature to your configuration.
 
+### Usability
+
+- allowed temporarily disabling of specific input type tracking via `TrackingInputType` resource in `InputManagerSystem::PreUpdate` system set
+
 ## Version 0.13.0
 
 ### Breaking Changes

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,7 +10,8 @@
 
 ### Usability
 
-- allowed temporarily disabling of specific input type tracking via `TrackingInputType` resource in `InputManagerSystem::PreUpdate` system set
+- allowed disabling of specific input type tracking via `TrackingInputType` resource
+- added run conditions that is active if `TrackingInputType` resource is enabled for specific input types
 
 ## Version 0.13.0
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,7 +10,7 @@
 
 ### Usability
 
-- allowed disabling of specific input type tracking via `TrackingInputType` resource
+- allowed setting `TrackingState` of specific input type tracking via `TrackingInputType` resource
 - added run conditions that are active when the `TrackingInputType` resource is enabled for specific input types
 
 ## Version 0.13.0

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -11,7 +11,7 @@
 ### Usability
 
 - allowed disabling of specific input type tracking via `TrackingInputType` resource
-- added run conditions that is active if `TrackingInputType` resource is enabled for specific input types
+- added run conditions that are active when the `TrackingInputType` resource is enabled for specific input types
 
 ## Version 0.13.0
 

--- a/src/common_conditions.rs
+++ b/src/common_conditions.rs
@@ -1,7 +1,7 @@
 //! Run conditions for actions.
 
 use crate::{
-    prelude::{ActionState, TrackingInputType},
+    prelude::{ActionState, TrackingInputType, TrackingState},
     Actionlike,
 };
 use bevy::prelude::Res;
@@ -44,15 +44,15 @@ where
 
 /// Run condition that is active if [`TrackingInputType`] is enabled for gamepad.
 pub fn tracking_gamepad_input(tracking_input: Res<TrackingInputType>) -> bool {
-    tracking_input.gamepad
+    tracking_input.gamepad == TrackingState::Enabled
 }
 
 /// Run condition that is active if [`TrackingInputType`] is enabled for keyboard.
 pub fn tracking_keyboard_input(tracking_input: Res<TrackingInputType>) -> bool {
-    tracking_input.keyboard
+    tracking_input.keyboard == TrackingState::Enabled
 }
 
 /// Run condition that is active if [`TrackingInputType`] is enabled for mouse.
 pub fn tracking_mouse_input(tracking_input: Res<TrackingInputType>) -> bool {
-    tracking_input.mouse
+    tracking_input.mouse == TrackingState::Enabled
 }

--- a/src/common_conditions.rs
+++ b/src/common_conditions.rs
@@ -1,6 +1,9 @@
 //! Run conditions for actions.
 
-use crate::{prelude::ActionState, Actionlike};
+use crate::{
+    prelude::{ActionState, TrackingInputType},
+    Actionlike,
+};
 use bevy::prelude::Res;
 
 /// Stateful run condition that can be toggled via an action press using [`ActionState::just_pressed`].
@@ -37,4 +40,19 @@ where
     A: Actionlike + Clone,
 {
     move |action_state: Res<ActionState<A>>| action_state.just_released(&action)
+}
+
+/// Run condition that is active if [`TrackingInputType`] is enabled for gamepad.
+pub fn tracking_gamepad_input(tracking_input: Res<TrackingInputType>) -> bool {
+    tracking_input.gamepad
+}
+
+/// Run condition that is active if [`TrackingInputType`] is enabled for keyboard.
+pub fn tracking_keyboard_input(tracking_input: Res<TrackingInputType>) -> bool {
+    tracking_input.keyboard
+}
+
+/// Run condition that is active if [`TrackingInputType`] is enabled for mouse.
+pub fn tracking_mouse_input(tracking_input: Res<TrackingInputType>) -> bool {
+    tracking_input.mouse
 }

--- a/src/conflicting_inputs.rs
+++ b/src/conflicting_inputs.rs
@@ -12,6 +12,7 @@ use bevy_egui::EguiContext;
 /// # Examples
 ///
 /// ```
+/// use bevy::input::InputSystem;
 /// use bevy::prelude::*;
 /// use leafwing_input_manager::prelude::*;
 ///
@@ -27,7 +28,9 @@ use bevy_egui::EguiContext;
 /// pub fn temporarily_ignore_keyboard(mut tracking_input: ResMut<TrackingInputType>) {
 ///     tracking_input.keyboard = TrackingState::IgnoredOnce;
 /// }
-/// app.add_systems(PreUpdate, temporarily_ignore_keyboard);
+/// // Remember to add your system into the `InputSystem` set
+/// // Otherwise it does not work
+/// app.add_systems(PreUpdate, temporarily_ignore_keyboard.in_set(InputSystem));
 /// ```
 #[derive(Resource, Default)]
 pub struct TrackingInputType {

--- a/src/conflicting_inputs.rs
+++ b/src/conflicting_inputs.rs
@@ -6,9 +6,7 @@ use bevy_egui::EguiContext;
 
 /// Flags to enable specific input type tracking.
 ///
-/// They can be temporarily disabled by setting their fields to `false`
-/// and will be re-enabled after handling all conflicting inputs.
-///
+/// They can be disabled by setting their fields to `false`.
 /// If you are dealing with conflicting input from other crates, this might be useful.
 ///
 /// # Examples
@@ -23,8 +21,7 @@ use bevy_egui::EguiContext;
 ///
 /// let mut app = App::new();
 ///
-/// // Remember to set
-/// app.add_systems(PreUpdate, disable_keyboard.in_set(InputManagerSystem::PreUpdate));
+/// app.add_systems(PreUpdate, disable_keyboard);
 /// ```
 #[derive(Resource)]
 pub struct TrackingInputType {

--- a/src/conflicting_inputs.rs
+++ b/src/conflicting_inputs.rs
@@ -1,0 +1,90 @@
+//! Handles conflicting inputs from outside
+
+use bevy::prelude::*;
+#[cfg(feature = "egui")]
+use bevy_egui::EguiContext;
+
+/// Flags to enable specific input type tracking.
+///
+/// They can be temporarily disabled by setting their fields to `false`
+/// and will be re-enabled after handling all conflicting inputs.
+///
+/// If you are dealing with conflicting input from other crates, this might be useful.
+///
+/// # Examples
+///
+/// ```
+/// use bevy::prelude::*;
+/// use leafwing_input_manager::prelude::*;
+///
+/// pub fn disable_keyboard(mut tracking_input: ResMut<TrackingInputType>) {
+///     tracking_input.keyboard = false;
+/// }
+///
+/// let mut app = App::new();
+///
+/// // Remember to set
+/// app.add_systems(PreUpdate, disable_keyboard.in_set(InputManagerSystem::PreUpdate));
+/// ```
+#[derive(Resource)]
+pub struct TrackingInputType {
+    /// Is tracking gamepad input?
+    pub gamepad: bool,
+
+    /// Is tracking keyboard input?
+    pub keyboard: bool,
+
+    /// Is tracking mouse input?
+    pub mouse: bool,
+}
+
+impl Default for TrackingInputType {
+    fn default() -> Self {
+        Self {
+            gamepad: true,
+            keyboard: true,
+            mouse: true,
+        }
+    }
+}
+
+/// Allow `bevy::ui` to take priority over actions when processing inputs.
+#[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
+pub fn prioritize_ui_inputs(
+    query_interactions: Query<&Interaction>,
+    mut tracking_input: ResMut<TrackingInputType>,
+) {
+    for interaction in query_interactions.iter() {
+        // If use clicks on a button, do not apply them to the game state
+        if *interaction != Interaction::None {
+            tracking_input.mouse = false;
+            return;
+        }
+    }
+}
+
+/// Allow `egui` to take priority over actions when processing inputs.
+#[cfg(feature = "egui")]
+pub fn prioritize_egui_inputs(
+    mut query_egui_context: Query<(Entity, &'static mut EguiContext)>,
+    mut tracking_input: ResMut<TrackingInputType>,
+) {
+    for (_, mut egui_context) in query_egui_context.iter_mut() {
+        let context = egui_context.get_mut();
+
+        // If egui wants to own inputs, don't also apply them to the game state
+        if context.wants_keyboard_input() {
+            tracking_input.keyboard = false;
+        }
+
+        // `wants_pointer_input` sometimes returns `false` after clicking or holding a button over a widget,
+        // so `is_pointer_over_area` is also needed.
+        if context.is_pointer_over_area() || context.wants_pointer_input() {
+            tracking_input.mouse = false;
+        }
+
+        if !tracking_input.keyboard && !tracking_input.mouse {
+            return;
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ pub mod prelude {
     pub use crate::input_mocking::{MockInput, QueryInput};
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
-    pub use crate::conflicting_inputs::TrackingInputType;
+    pub use crate::conflicting_inputs::{TrackingInputType, TrackingState};
     pub use crate::plugin::ToggleActions;
     pub use crate::plugin::{InputManagerPlugin, InputManagerSystem};
     pub use crate::{Actionlike, InputManagerBundle};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,9 @@ pub mod prelude {
     pub use crate::input_mocking::{MockInput, QueryInput};
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
-    pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;
+    pub use crate::plugin::{InputManagerPlugin, InputManagerSystem};
+    pub use crate::systems::TrackingInputType;
     pub use crate::{Actionlike, InputManagerBundle};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,8 +47,8 @@ pub mod prelude {
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
     pub use crate::conflicting_inputs::{TrackingInputType, TrackingState};
+    pub use crate::plugin::InputManagerPlugin;
     pub use crate::plugin::ToggleActions;
-    pub use crate::plugin::{InputManagerPlugin, InputManagerSystem};
     pub use crate::{Actionlike, InputManagerBundle};
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub mod axislike;
 pub mod buttonlike;
 pub mod clashing_inputs;
 pub mod common_conditions;
+pub mod conflicting_inputs;
 mod display_impl;
 pub mod errors;
 pub mod input_map;
@@ -45,9 +46,9 @@ pub mod prelude {
     pub use crate::input_mocking::{MockInput, QueryInput};
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
+    pub use crate::conflicting_inputs::TrackingInputType;
     pub use crate::plugin::ToggleActions;
     pub use crate::plugin::{InputManagerPlugin, InputManagerSystem};
-    pub use crate::systems::TrackingInputType;
     pub use crate::{Actionlike, InputManagerBundle};
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,6 +8,10 @@ use crate::axislike::{
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::clashing_inputs::ClashStrategy;
 #[cfg(feature = "egui")]
+use crate::common_conditions::tracking_keyboard_input;
+#[cfg(any(all(feature = "ui", not(feature = "no_ui_priority")), feature = "egui"))]
+use crate::common_conditions::tracking_mouse_input;
+#[cfg(feature = "egui")]
 use crate::conflicting_inputs::prioritize_egui_inputs;
 #[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
 use crate::conflicting_inputs::prioritize_ui_inputs;
@@ -117,16 +121,25 @@ impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
 
                 app.add_systems(
                     PreUpdate,
-                    (
-                        #[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
-                        prioritize_ui_inputs,
-                        #[cfg(feature = "egui")]
-                        prioritize_egui_inputs,
-                        update_action_state::<A>,
-                    )
-                        .chain()
+                    update_action_state::<A>
                         .run_if(run_if_enabled::<A>)
                         .in_set(InputManagerSystem::Update),
+                );
+
+                #[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
+                app.add_systems(
+                    PreUpdate,
+                    prioritize_ui_inputs
+                        .run_if(tracking_mouse_input)
+                        .in_set(InputManagerSystem::PreUpdate),
+                );
+
+                #[cfg(feature = "egui")]
+                app.add_systems(
+                    PreUpdate,
+                    prioritize_egui_inputs
+                        .run_if(tracking_keyboard_input.or_else(tracking_mouse_input))
+                        .in_set(InputManagerSystem::PreUpdate),
                 );
 
                 app.configure_sets(
@@ -245,6 +258,9 @@ impl<A: Actionlike> Default for ToggleActions<A> {
 #[derive(SystemSet, Clone, Hash, Debug, PartialEq, Eq)]
 pub enum InputManagerSystem {
     /// Performs actions before [`InputManagerSystem::Update`]
+    ///
+    /// This is useful for temporarily disabling [`TrackingInputType`],
+    /// and it will be re-enabled after handling all conflicting inputs
     PreUpdate,
     /// Advances action timers.
     ///

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -7,6 +7,11 @@ use crate::axislike::{
 };
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::clashing_inputs::ClashStrategy;
+#[cfg(feature = "egui")]
+use crate::conflicting_inputs::prioritize_egui_inputs;
+#[cfg(all(feature = "ui", not(feature = "no_ui_priority")))]
+use crate::conflicting_inputs::prioritize_ui_inputs;
+use crate::conflicting_inputs::TrackingInputType;
 use crate::input_map::InputMap;
 use crate::timing::Timing;
 use crate::user_input::{InputKind, Modifier, UserInput};

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -23,6 +23,7 @@ use bevy::{
 };
 
 use crate::action_diff::{ActionDiff, ActionDiffEvent};
+
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -23,11 +23,8 @@ use bevy::{
 };
 
 use crate::action_diff::{ActionDiff, ActionDiffEvent};
-
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;
-#[cfg(feature = "egui")]
-use bevy_egui::EguiContext;
 
 /// Advances actions timer.
 ///

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -23,7 +23,6 @@ use bevy::{
 };
 
 use crate::action_diff::{ActionDiff, ActionDiffEvent};
-
 #[cfg(feature = "ui")]
 use bevy::ui::Interaction;
 
@@ -99,8 +98,8 @@ pub fn update_action_state<A: Actionlike>(
         .then(|| mouse_motion.read().cloned().collect())
         .unwrap_or_default();
 
-    // Ensure the inputs will be tracked by default
-    *tracking_input = Default::default();
+    // Ensure the conflicted inputs will be tracked next time
+    tracking_input.tick();
 
     let resources = input_map
         .zip(action_state)


### PR DESCRIPTION
## Objective

- Parts of completing #483

Allow disabling of specific input type tracking.
This can be especially useful if users encounter conflicts with input handling from other crates not currently integrated yet.

### Solution

Add `TrackingState` enum for always enabling, always disabling, or ignoring once for input type tracking.

Add a new resource called `TrackingInputType`, which includes flags for enabling specific input type tracking.

Furthermore, add run conditions that are active when the `TrackingInputType` is enabled for specific input types.

### Changelog

- Added `TrackingState` enum 
- Added `TrackingInputType` Resource
- Exported new items into the `prelude` module
- Extracted `prioritize_ui_input` and `prioritize_egui_input` systems from `update_action_state`
- Integrated new systems into `InputManagerPlugin`
- `InputStreams` now take `Option` for gamepad values