### PR TITLE
Const functions and cleanup

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,13 +2,22 @@
 
 ## Unreleased
 
+### Usability
+
+- Added `with_threshold()` for const `SingleAxis` creation.
+- Added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to  `VirtualDpad::gamepad_face_buttons()`.
+- Changed various creations of `DualAxis`, `VirtualAxis`, `VirtualDpad` into const functions as they should be:
+  - `left_stick()`, `right_stick()` for `DualAxis`.
+  - `from_keys()`, `horizontal_arrow_keys()`, `vertical_arrow_keys()`, `ad()`, `ws()`, `horizontal_dpad()`, `vertical_dpad()` for `VirtualAxis`.
+  - `arrow_keys()`, `wasd()`, `dpad()`, `gamepad_face_buttons()`, `mouse_wheel()`, `mouse_motion()` for `VirtualDpad`.
+
+## Version 0.13.1
+
 ### Breaking Changes
 
 - removed the `block_ui_interactions` feature:
   - by default, this library will prioritize `bevy::ui`.
   - if you want to disable this priority, add the newly added `no_ui_priority` feature to your configuration.
-
-## Version 0.13.1
 
 ### Bugs
 

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -15,15 +15,3 @@ pub fn actionlike(input: TokenStream) -> TokenStream {
 
     crate::actionlike::actionlike_inner(&ast).into()
 }
-
-#[proc_macro_derive(DynActionMarker)]
-pub fn dyn_action_marker(input: TokenStream) -> TokenStream {
-    let ast = syn::parse_macro_input!(input as DeriveInput);
-    let ident = ast.ident;
-    let (impl_generics, ty_generics, where_clause) = ast.generics.split_for_impl();
-
-    let output = quote::quote! {
-        impl #impl_generics ::leafwing_input_manager::dynamic_action::DynActionMarker for #ident #ty_generics #where_clause {}
-    };
-    output.into()
-}

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -529,10 +529,9 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// This will be [`Duration::ZERO`] if the action was never pressed or released.
     pub fn current_duration(&self, action: &A) -> Duration {
-        let Some(action_data) = self.action_data(action) else {
-            return Duration::ZERO;
-        };
-        action_data.timing.current_duration
+        self.action_data(action)
+            .map(|data| data.timing.current_duration)
+            .unwrap_or_default()
     }
 
     /// The [`Duration`] for which the action was last held or released
@@ -542,10 +541,9 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// This will be [`Duration::ZERO`] if the action was never pressed or released.
     pub fn previous_duration(&self, action: &A) -> Duration {
-        let Some(action_data) = self.action_data(action) else {
-            return Duration::ZERO;
-        };
-        action_data.timing.previous_duration
+        self.action_data(action)
+            .map(|data| data.timing.previous_duration)
+            .unwrap_or_default()
     }
 
     /// Applies an [`ActionDiff`] (usually received over the network) to the [`ActionState`].

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -42,17 +42,27 @@ pub struct SingleAxis {
 }
 
 impl SingleAxis {
-    /// Creates a [`SingleAxis`] with both `positive_low` and `negative_low` set to `threshold`.
+    /// Creates a [`SingleAxis`] with the given `positive_low` and `negative_low` thresholds.
     #[must_use]
-    pub fn symmetric(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
+    pub const fn with_threshold(
+        axis_type: AxisType,
+        negative_low: f32,
+        positive_low: f32,
+    ) -> SingleAxis {
         SingleAxis {
-            axis_type: axis_type.into(),
-            positive_low: threshold,
-            negative_low: -threshold,
+            axis_type,
+            positive_low,
+            negative_low,
             inverted: false,
             sensitivity: 1.0,
             value: None,
         }
+    }
+
+    /// Creates a [`SingleAxis`] with both `positive_low` and `negative_low` set to `threshold`.
+    #[must_use]
+    pub fn symmetric(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
+        Self::with_threshold(axis_type.into(), -threshold, threshold)
     }
 
     /// Creates a [`SingleAxis`] with the specified `axis_type` and `value`.
@@ -74,81 +84,43 @@ impl SingleAxis {
     /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
     #[must_use]
     pub const fn mouse_wheel_x() -> SingleAxis {
-        SingleAxis {
-            axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
-            positive_low: 0.,
-            negative_low: 0.,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        let axis_type = AxisType::MouseWheel(MouseWheelAxisType::X);
+        SingleAxis::with_threshold(axis_type, 0.0, 0.0)
     }
 
     /// Creates a [`SingleAxis`] corresponding to vertical [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
     #[must_use]
     pub const fn mouse_wheel_y() -> SingleAxis {
-        SingleAxis {
-            axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-            positive_low: 0.,
-            negative_low: 0.,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        let axis_type = AxisType::MouseWheel(MouseWheelAxisType::Y);
+        SingleAxis::with_threshold(axis_type, 0.0, 0.0)
     }
 
     /// Creates a [`SingleAxis`] corresponding to horizontal [`MouseMotion`](bevy::input::mouse::MouseMotion) movement
     #[must_use]
     pub const fn mouse_motion_x() -> SingleAxis {
-        SingleAxis {
-            axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
-            positive_low: 0.,
-            negative_low: 0.,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        let axis_type = AxisType::MouseMotion(MouseMotionAxisType::X);
+        SingleAxis::with_threshold(axis_type, 0.0, 0.0)
     }
 
     /// Creates a [`SingleAxis`] corresponding to vertical [`MouseMotion`](bevy::input::mouse::MouseMotion) movement
     #[must_use]
     pub const fn mouse_motion_y() -> SingleAxis {
-        SingleAxis {
-            axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-            positive_low: 0.,
-            negative_low: 0.,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        let axis_type = AxisType::MouseMotion(MouseMotionAxisType::Y);
+        SingleAxis::with_threshold(axis_type, 0.0, 0.0)
     }
 
     /// Creates a [`SingleAxis`] with the `axis_type` and `negative_low` set to `threshold`.
     ///
     /// Positive values will not trigger the input.
     pub fn negative_only(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
-        SingleAxis {
-            axis_type: axis_type.into(),
-            negative_low: threshold,
-            positive_low: f32::MAX,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        SingleAxis::with_threshold(axis_type.into(), threshold, f32::MAX)
     }
 
     /// Creates a [`SingleAxis`] with the `axis_type` and `positive_low` set to `threshold`.
     ///
     /// Negative values will not trigger the input.
     pub fn positive_only(axis_type: impl Into<AxisType>, threshold: f32) -> SingleAxis {
-        SingleAxis {
-            axis_type: axis_type.into(),
-            negative_low: f32::MIN,
-            positive_low: threshold,
-            inverted: false,
-            sensitivity: 1.0,
-            value: None,
-        }
+        SingleAxis::with_threshold(axis_type.into(), f32::MIN, threshold)
     }
 
     /// Returns this [`SingleAxis`] with the deadzone set to the specified value
@@ -268,22 +240,26 @@ impl DualAxis {
 
     /// Creates a [`DualAxis`] for the left analogue stick of the gamepad.
     #[must_use]
-    pub fn left_stick() -> DualAxis {
-        DualAxis::symmetric(
-            GamepadAxisType::LeftStickX,
-            GamepadAxisType::LeftStickY,
-            Self::DEFAULT_DEADZONE_SHAPE,
-        )
+    pub const fn left_stick() -> DualAxis {
+        let axis_x = AxisType::Gamepad(GamepadAxisType::LeftStickX);
+        let axis_y = AxisType::Gamepad(GamepadAxisType::LeftStickY);
+        DualAxis {
+            x: SingleAxis::with_threshold(axis_x, 0.0, 0.0),
+            y: SingleAxis::with_threshold(axis_y, 0.0, 0.0),
+            deadzone: Self::DEFAULT_DEADZONE_SHAPE,
+        }
     }
 
     /// Creates a [`DualAxis`] for the right analogue stick of the gamepad.
     #[must_use]
-    pub fn right_stick() -> DualAxis {
-        DualAxis::symmetric(
-            GamepadAxisType::RightStickX,
-            GamepadAxisType::RightStickY,
-            Self::DEFAULT_DEADZONE_SHAPE,
-        )
+    pub const fn right_stick() -> DualAxis {
+        let axis_x = AxisType::Gamepad(GamepadAxisType::RightStickX);
+        let axis_y = AxisType::Gamepad(GamepadAxisType::RightStickY);
+        DualAxis {
+            x: SingleAxis::with_threshold(axis_x, 0.0, 0.0),
+            y: SingleAxis::with_threshold(axis_y, 0.0, 0.0),
+            deadzone: Self::DEFAULT_DEADZONE_SHAPE,
+        }
     }
 
     /// Creates a [`DualAxis`] corresponding to horizontal and vertical [`MouseWheel`](bevy::input::mouse::MouseWheel) movement
@@ -363,7 +339,7 @@ pub struct VirtualDPad {
 
 impl VirtualDPad {
     /// Generates a [`VirtualDPad`] corresponding to the arrow keyboard keycodes
-    pub fn arrow_keys() -> VirtualDPad {
+    pub const fn arrow_keys() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::PhysicalKey(KeyCode::ArrowUp),
             down: InputKind::PhysicalKey(KeyCode::ArrowDown),
@@ -378,7 +354,7 @@ impl VirtualDPad {
     /// The _location_ of the keys is the same on all keyboard layouts.
     /// This ensures that the classic triangular shape is retained on all layouts,
     /// which enables comfortable movement controls.
-    pub fn wasd() -> VirtualDPad {
+    pub const fn wasd() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::PhysicalKey(KeyCode::KeyW),
             down: InputKind::PhysicalKey(KeyCode::KeyS),
@@ -389,7 +365,7 @@ impl VirtualDPad {
 
     #[allow(clippy::doc_markdown)] // False alarm because it thinks DPad is an un-quoted item
     /// Generates a [`VirtualDPad`] corresponding to the DPad on a gamepad
-    pub fn dpad() -> VirtualDPad {
+    pub const fn dpad() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::GamepadButton(GamepadButtonType::DPadUp),
             down: InputKind::GamepadButton(GamepadButtonType::DPadDown),
@@ -401,7 +377,7 @@ impl VirtualDPad {
     /// Generates a [`VirtualDPad`] corresponding to the face buttons on a gamepad
     ///
     /// North corresponds to up, west corresponds to left, east corresponds to right, south corresponds to down
-    pub fn gamepad_face_buttons() -> VirtualDPad {
+    pub const fn gamepad_face_buttons() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::GamepadButton(GamepadButtonType::North),
             down: InputKind::GamepadButton(GamepadButtonType::South),
@@ -411,7 +387,7 @@ impl VirtualDPad {
     }
 
     /// Generates a [`VirtualDPad`] corresponding to discretized mousewheel movements
-    pub fn mouse_wheel() -> VirtualDPad {
+    pub const fn mouse_wheel() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::MouseWheel(MouseWheelDirection::Up),
             down: InputKind::MouseWheel(MouseWheelDirection::Down),
@@ -421,7 +397,7 @@ impl VirtualDPad {
     }
 
     /// Generates a [`VirtualDPad`] corresponding to discretized mouse motions
-    pub fn mouse_motion() -> VirtualDPad {
+    pub const fn mouse_motion() -> VirtualDPad {
         VirtualDPad {
             up: InputKind::MouseMotion(MouseMotionDirection::Up),
             down: InputKind::MouseMotion(MouseMotionDirection::Down),
@@ -467,7 +443,7 @@ pub struct VirtualAxis {
 impl VirtualAxis {
     /// Helper function for generating a [`VirtualAxis`] from arbitrary keycodes, shorthand for
     /// wrapping each key in [`InputKind::PhysicalKey`]
-    pub fn from_keys(negative: KeyCode, positive: KeyCode) -> VirtualAxis {
+    pub const fn from_keys(negative: KeyCode, positive: KeyCode) -> VirtualAxis {
         VirtualAxis {
             negative: InputKind::PhysicalKey(negative),
             positive: InputKind::PhysicalKey(positive),
@@ -475,28 +451,28 @@ impl VirtualAxis {
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the horizontal arrow keyboard keycodes
-    pub fn horizontal_arrow_keys() -> VirtualAxis {
+    pub const fn horizontal_arrow_keys() -> VirtualAxis {
         VirtualAxis::from_keys(KeyCode::ArrowLeft, KeyCode::ArrowRight)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the horizontal arrow keyboard keycodes
-    pub fn vertical_arrow_keys() -> VirtualAxis {
+    pub const fn vertical_arrow_keys() -> VirtualAxis {
         VirtualAxis::from_keys(KeyCode::ArrowDown, KeyCode::ArrowUp)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the `AD` keyboard keycodes.
-    pub fn ad() -> VirtualAxis {
+    pub const fn ad() -> VirtualAxis {
         VirtualAxis::from_keys(KeyCode::KeyA, KeyCode::KeyD)
     }
 
     /// Generates a [`VirtualAxis`] corresponding to the `WS` keyboard keycodes.
-    pub fn ws() -> VirtualAxis {
+    pub const fn ws() -> VirtualAxis {
         VirtualAxis::from_keys(KeyCode::KeyS, KeyCode::KeyW)
     }
 
     #[allow(clippy::doc_markdown)]
     /// Generates a [`VirtualAxis`] corresponding to the horizontal DPad buttons on a gamepad.
-    pub fn horizontal_dpad() -> VirtualAxis {
+    pub const fn horizontal_dpad() -> VirtualAxis {
         VirtualAxis {
             negative: InputKind::GamepadButton(GamepadButtonType::DPadLeft),
             positive: InputKind::GamepadButton(GamepadButtonType::DPadRight),
@@ -505,10 +481,28 @@ impl VirtualAxis {
 
     #[allow(clippy::doc_markdown)]
     /// Generates a [`VirtualAxis`] corresponding to the vertical DPad buttons on a gamepad.
-    pub fn vertical_dpad() -> VirtualAxis {
+    pub const fn vertical_dpad() -> VirtualAxis {
         VirtualAxis {
             negative: InputKind::GamepadButton(GamepadButtonType::DPadDown),
             positive: InputKind::GamepadButton(GamepadButtonType::DPadUp),
+        }
+    }
+
+    #[allow(clippy::doc_markdown)]
+    /// Generates a [`VirtualAxis`] corresponding to the horizontal gamepad face buttons.
+    pub const fn horizontal_gamepad_face_buttons() -> VirtualAxis {
+        VirtualAxis {
+            negative: InputKind::GamepadButton(GamepadButtonType::West),
+            positive: InputKind::GamepadButton(GamepadButtonType::East),
+        }
+    }
+
+    #[allow(clippy::doc_markdown)]
+    /// Generates a [`VirtualAxis`] corresponding to the vertical gamepad face buttons.
+    pub const fn vertical_gamepad_face_buttons() -> VirtualAxis {
+        VirtualAxis {
+            negative: InputKind::GamepadButton(GamepadButtonType::South),
+            positive: InputKind::GamepadButton(GamepadButtonType::North),
         }
     }
 

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -212,19 +212,12 @@ fn virtual_axis_chord_clash(axis: &VirtualAxis, chord: &[InputKind]) -> bool {
 /// Does the `chord_a` clash with `chord_b`?
 #[must_use]
 fn chord_chord_clash(chord_a: &Vec<InputKind>, chord_b: &Vec<InputKind>) -> bool {
-    if chord_a.len() <= 1 || chord_b.len() <= 1 {
-        return false;
-    }
-
-    if chord_a == chord_b {
-        return false;
-    }
-
     fn is_subset(slice_a: &[InputKind], slice_b: &[InputKind]) -> bool {
         slice_a.iter().all(|a| slice_b.contains(a))
     }
 
-    is_subset(chord_a, chord_b) || is_subset(chord_b, chord_a)
+    let prerequisite = chord_a.len() > 1 && chord_b.len() > 1 && chord_a != chord_b;
+    prerequisite && (is_subset(chord_a, chord_b) || is_subset(chord_b, chord_a))
 }
 
 /// Given the `input_streams`, does the provided clash actually occur?

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -127,17 +127,13 @@ impl<A: Actionlike> InputMap<A> {
 
         // We can limit our search to the cached set of possibly clashing actions
         for clash in self.possible_clashes() {
-            let Some(data_a) = action_data.get(&clash.action_a) else {
-                continue;
-            };
-
-            let Some(data_b) = action_data.get(&clash.action_b) else {
-                continue;
+            let pressed = |action: &A| -> bool {
+                matches!(action_data.get(action), Some(data) if data.state.pressed())
             };
 
             // Clashes can only occur if both actions were triggered
             // This is not strictly necessary, but saves work
-            if data_a.state.pressed() && data_b.state.pressed() {
+            if pressed(&clash.action_a) && pressed(&clash.action_b) {
                 // Check if the potential clash occurred based on the pressed inputs
                 if let Some(clash) = check_clash(&clash, input_streams) {
                     clashes.push(clash)

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -302,12 +302,10 @@ impl<A: Actionlike> InputMap<A> {
         input_streams: &InputStreams,
         clash_strategy: ClashStrategy,
     ) -> bool {
-        let action_data = self.which_pressed(input_streams, clash_strategy);
-        let Some(action_datum) = action_data.get(action) else {
-            return false;
-        };
-
-        action_datum.state.pressed()
+        self.which_pressed(input_streams, clash_strategy)
+            .get(action)
+            .map(|datum| datum.state.pressed())
+            .unwrap_or_default()
     }
 
     /// Returns the actions that are currently pressed, and the responsible [`UserInput`] for each action

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -13,7 +13,7 @@ use bevy::ecs::component::Component;
 use bevy::ecs::system::Resource;
 use bevy::input::gamepad::Gamepad;
 use bevy::reflect::Reflect;
-use bevy::utils::{Entry, HashMap};
+use bevy::utils::HashMap;
 use serde::{Deserialize, Serialize};
 
 use core::fmt::Debug;
@@ -163,20 +163,9 @@ impl<A: Actionlike> InputMap<A> {
         let input = input.into();
 
         // Check for existing copies of the input: insertion should be idempotent
-        if let Some(vec) = self.map.get(&action) {
-            if vec.contains(&input) {
-                return self;
-            }
+        if !matches!(self.map.get(&action), Some(vec) if vec.contains(&input)) {
+            self.map.entry(action).or_default().push(input);
         }
-
-        match self.map.entry(action) {
-            Entry::Occupied(mut entry) => {
-                entry.get_mut().push(input);
-            }
-            Entry::Vacant(entry) => {
-                entry.insert(vec![input]);
-            }
-        };
 
         self
     }

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -458,10 +458,8 @@ impl<'a> MutableInputStreams<'a> {
     /// If an associated gamepad is set, use that.
     /// Otherwise use the first registered gamepad, if any.
     pub fn guess_gamepad(&self) -> Option<Gamepad> {
-        match self.associated_gamepad {
-            Some(gamepad) => Some(gamepad),
-            None => self.gamepads.iter().next(),
-        }
+        self.associated_gamepad
+            .or_else(|| self.gamepads.iter().next())
     }
 }
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -319,15 +319,13 @@ impl<'a> InputStreams<'a> {
     pub fn input_axis_pair(&self, input: &UserInput) -> Option<DualAxisData> {
         match input {
             UserInput::Chord(inputs) => {
-                for input_kind in inputs.iter() {
-                    // Exclude chord combining both button-like and axis-like inputs unless all buttons are pressed.
-                    if !self.button_pressed(*input_kind) {
-                        return None;
-                    }
-
-                    // Return result of the first dual axis in the chord.
-                    if let InputKind::DualAxis(dual_axis) = input_kind {
-                        return Some(self.extract_dual_axis_data(dual_axis).unwrap_or_default());
+                if self.all_buttons_pressed(inputs) {
+                    for input_kind in inputs.iter() {
+                        // Return result of the first dual axis in the chord.
+                        if let InputKind::DualAxis(dual_axis) = input_kind {
+                            let data = self.extract_dual_axis_data(dual_axis).unwrap_or_default();
+                            return Some(data);
+                        }
                     }
                 }
                 None

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -13,7 +13,7 @@ use bevy::utils::HashSet;
 
 use crate::axislike::{
     deadzone_axis_value, AxisType, DualAxisData, MouseMotionAxisType, MouseWheelAxisType,
-    SingleAxis, VirtualAxis,
+    SingleAxis,
 };
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::prelude::DualAxis;
@@ -79,14 +79,8 @@ impl<'a> InputStreams<'a> {
     /// Is the `input` matched by the [`InputStreams`]?
     pub fn input_pressed(&self, input: &UserInput) -> bool {
         match input {
-            UserInput::Single(button) => self.button_pressed(*button),
             UserInput::Chord(buttons) => self.all_buttons_pressed(buttons),
-            UserInput::VirtualDPad(dpad) => [&dpad.up, &dpad.down, &dpad.left, &dpad.right]
-                .into_iter()
-                .any(|button| self.button_pressed(*button)),
-            UserInput::VirtualAxis(VirtualAxis { negative, positive }) => {
-                self.button_pressed(*negative) || self.button_pressed(*positive)
-            }
+            _ => input.iter().any(|button| self.button_pressed(button)),
         }
     }
 

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -113,11 +113,7 @@ mod orientation_trait {
         #[inline]
         fn distance(&self, other: Rotation) -> Rotation {
             let difference = self.micro_degrees_difference(other);
-            let micro_degrees = if difference <= Rotation::HALF_CIRCLE {
-                difference
-            } else {
-                Rotation::neg_micro_degrees(difference)
-            };
+            let micro_degrees = difference.min(Rotation::neg_micro_degrees(difference));
             Rotation { micro_degrees }
         }
     }

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -95,9 +95,7 @@ mod orientation_trait {
         #[inline]
         fn rotate_towards(&mut self, target_orientation: Self, max_rotation: Option<Rotation>) {
             if let Some(max_rotation) = max_rotation {
-                if self.distance(target_orientation) <= max_rotation {
-                    *self = target_orientation;
-                } else {
+                if self.distance(target_orientation) > max_rotation {
                     let delta_rotation = match self.rotation_direction(target_orientation) {
                         RotationDirection::CounterClockwise => max_rotation,
                         RotationDirection::Clockwise => -max_rotation,
@@ -107,9 +105,9 @@ mod orientation_trait {
 
                     *self = new_rotation.into();
                 }
-            } else {
-                *self = target_orientation;
+                return;
             }
+            *self = target_orientation;
         }
     }
 


### PR DESCRIPTION
Continue with #466, and found other points that can be further cleaned up while rewriting `UserInput` and `InputStreams`.

## Changelog

### Usability

- Added `with_threshold()` for const `SingleAxis` creation.
- Added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to  `VirtualDpad::gamepad_face_buttons()`.
- Changed various creations of `DualAxis`, `VirtualAxis`, `VirtualDpad` into const functions as they should be:
  - `left_stick()`, `right_stick()` for `DualAxis`.
  - `from_keys()`, `horizontal_arrow_keys()`, `vertical_arrow_keys()`, `ad()`, `ws()`, `horizontal_dpad()`, `vertical_dpad()` for `VirtualAxis`.
  - `arrow_keys()`, `wasd()`, `dpad()`, `gamepad_face_buttons()`, `mouse_wheel()`, `mouse_motion()` for `VirtualDpad`.

### Cleanup

- Removed the `DynActionMarker` derive. It was added in #306 but hasn't been functional since #447.

### Deduplication

- Added an inner helper `UserInputIter`.
- Extracted inner helper functions like `micro_degrees_difference()`, `neg_micro_degrees()`, `micro_degrees_sub_by()` for `Rotation`.
- Reused `RotationDirection::sign()`.
- Reused `TryFrom<Vec2>` in `From<Quat>` for `Direction`.
- Reused `all_button_pressed()` for calculating input axis pair.

### Style

- Reduced unnecessary nesting and branches.
- Used `unwrap_or_default()`, `ok_or()`, `ok_else()` for `Option` conversions.
- Used `or_default()` to ensure the existence of values in `HashMap`.

### Document

- Included mentions of breaking changes for version 0.13.1