### PR TITLE
Remove Direction in favour of Direction2d from Bevy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerfully direct stateful input manager for the Bevy game engine."
-version = "0.13.2"
+version = "0.13.3"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerfully direct stateful input manager for the Bevy game engine."
-version = "0.13.3"
+version = "0.14.0"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,11 +1,17 @@
 # Release Notes
 
+## Version 0.13.3
+
+### Breaking Changes
+
+- Removed `Direction` type. Use `bevy::math::primitives::Direction2d`.
+
 ## Version 0.13.2
 
 ### Usability
 
 - Added `with_threshold()` for const `SingleAxis` creation.
-- Added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to  `VirtualDpad::gamepad_face_buttons()`.
+- Added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to `VirtualDpad::gamepad_face_buttons()`.
 - Changed various creations of `DualAxis`, `VirtualAxis`, `VirtualDpad` into const functions as they should be:
   - `left_stick()`, `right_stick()` for `DualAxis`.
   - `from_keys()`, `horizontal_arrow_keys()`, `vertical_arrow_keys()`, `ad()`, `ws()`, `horizontal_dpad()`, `vertical_dpad()` for `VirtualAxis`.
@@ -171,7 +177,7 @@
 ### Enhancements
 
 - Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver
-to update multiple entities if needed.
+  to update multiple entities if needed.
 - Added builder-style functions to `SingleAxis`, `DualAxis`, and `VirtualDPad` that invert their output values, allowing, for example, binding inverted camera controls.
 
 ### Docs

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,6 +1,6 @@
 # Release Notes
 
-## Version 0.13.3
+## Version 0.14.0 (Unreleased)
 
 ### Breaking Changes
 

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -1,6 +1,5 @@
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
-use leafwing_input_manager::{errors::NearlySingularConversion, orientation::Direction};
 
 fn main() {
     App::new()
@@ -44,12 +43,12 @@ impl ArpgAction {
         ArpgAction::Right,
     ];
 
-    fn direction(self) -> Option<Direction> {
+    fn direction(self) -> Option<Direction2d> {
         match self {
-            ArpgAction::Up => Some(Direction::NORTH),
-            ArpgAction::Down => Some(Direction::SOUTH),
-            ArpgAction::Left => Some(Direction::WEST),
-            ArpgAction::Right => Some(Direction::EAST),
+            ArpgAction::Up => Some(Direction2d::Y),
+            ArpgAction::Down => Some(Direction2d::NEG_Y),
+            ArpgAction::Left => Some(Direction2d::NEG_X),
+            ArpgAction::Right => Some(Direction2d::X),
             _ => None,
         }
     }
@@ -136,14 +135,13 @@ fn player_dash(query: Query<&ActionState<ArpgAction>, With<Player>>) {
             if action_state.pressed(&input_direction) {
                 if let Some(direction) = input_direction.direction() {
                     // Sum the directions as 2D vectors
-                    direction_vector += Vec2::from(direction);
+                    direction_vector += *direction;
                 }
             }
         }
 
         // Then reconvert at the end, normalizing the magnitude
-        let net_direction: Result<Direction, NearlySingularConversion> =
-            direction_vector.try_into();
+        let net_direction = Direction2d::new(direction_vector);
 
         if let Ok(direction) = net_direction {
             println!("Dashing in {direction:?}");
@@ -153,7 +151,7 @@ fn player_dash(query: Query<&ActionState<ArpgAction>, With<Player>>) {
 
 #[derive(Event)]
 pub struct PlayerWalk {
-    pub direction: Direction,
+    pub direction: Direction2d,
 }
 
 fn player_walks(
@@ -168,13 +166,13 @@ fn player_walks(
         if action_state.pressed(&input_direction) {
             if let Some(direction) = input_direction.direction() {
                 // Sum the directions as 2D vectors
-                direction_vector += Vec2::from(direction);
+                direction_vector += *direction;
             }
         }
     }
 
     // Then reconvert at the end, normalizing the magnitude
-    let net_direction: Result<Direction, NearlySingularConversion> = direction_vector.try_into();
+    let net_direction = Direction2d::new(direction_vector);
 
     if let Ok(direction) = net_direction {
         event_writer.send(PlayerWalk { direction });

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -1,12 +1,13 @@
 //! Tools for working with directional axis-like user inputs (gamesticks, D-Pads and emulated equivalents)
 
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
-use crate::orientation::{Direction, Rotation};
+use crate::orientation::Rotation;
 use crate::user_input::InputKind;
 use bevy::input::{
     gamepad::{GamepadAxisType, GamepadButtonType},
     keyboard::KeyCode,
 };
+use bevy::math::primitives::Direction2d;
 use bevy::math::Vec2;
 use bevy::reflect::Reflect;
 use bevy::utils::FloatOrd;
@@ -673,14 +674,13 @@ impl DualAxisData {
         self.xy
     }
 
-    /// The [`Direction`] that this axis is pointing towards, if any
+    /// The [`Direction2d`] that this axis is pointing towards, if any
     ///
     /// If the axis is neutral (x,y) = (0,0), a (0, 0) `None` will be returned
     #[must_use]
     #[inline]
-    pub fn direction(&self) -> Option<Direction> {
-        // TODO: replace this quick-n-dirty hack once Direction::new no longer panics
-        (self.xy.length() > 0.00001).then(|| Direction::new(self.xy))
+    pub fn direction(&self) -> Option<Direction2d> {
+        Direction2d::new(self.xy).ok()
     }
 
     /// The [`Rotation`] (measured clockwise from midnight) that this axis is pointing towards, if any

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -303,7 +303,7 @@ mod rotation {
 
     // Conversion methods
     impl Rotation {
-        /// Constructs a [`Rotation`](crate::orientation::Rotation) from an (x,y) Euclidean coordinate
+        /// Constructs a [`Rotation`] from an (x,y) Euclidean coordinate
         ///
         /// If both x and y are nearly 0 (the magnitude is less than [`EPSILON`](f32::EPSILON)),
         /// [`Err(NearlySingularConversion)`] will be returned instead.
@@ -333,7 +333,7 @@ mod rotation {
             Vec2::new(radians.cos(), radians.sin())
         }
 
-        /// Construct a [`Rotation`](crate::orientation::Rotation) from radians,
+        /// Construct a [`Rotation`] from radians,
         /// measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
@@ -352,7 +352,7 @@ mod rotation {
             self.micro_degrees as f32 * (TAU / Rotation::FULL_CIRCLE as f32)
         }
 
-        /// Construct a [`Rotation`](crate::orientation::Rotation) from degrees, measured counterclockwise from the positive x-axis
+        /// Construct a [`Rotation`] from degrees, measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
         pub fn from_degrees(degrees: impl Into<f32>) -> Rotation {
@@ -363,7 +363,7 @@ mod rotation {
             }
         }
 
-        /// Construct a [`Rotation`](crate::orientation::Rotation) from a whole number of degrees, measured counterclockwise from the positive x-axis
+        /// Construct a [`Rotation`] from a whole number of degrees, measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
         pub const fn from_degrees_int(degrees: u32) -> Rotation {

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -1,12 +1,12 @@
 //! Direction and rotation for spinning around in 2 dimensions
 
-pub use direction::Direction;
 pub use orientation_trait::Orientation;
 pub use rotation::Rotation;
 pub use rotation_direction::RotationDirection;
 
 mod orientation_trait {
-    use super::{Direction, Rotation, RotationDirection};
+    use super::{Rotation, RotationDirection};
+    use bevy::math::primitives::Direction2d;
     use bevy::math::Quat;
     use bevy::transform::components::{GlobalTransform, Transform};
     use core::fmt::Debug;
@@ -119,8 +119,8 @@ mod orientation_trait {
         }
     }
 
-    impl Orientation for Direction {
-        fn distance(&self, other: Direction) -> Rotation {
+    impl Orientation for Direction2d {
+        fn distance(&self, other: Direction2d) -> Rotation {
             let self_rotation: Rotation = (*self).into();
             let other_rotation: Rotation = other.into();
             self_rotation.distance(other_rotation)
@@ -467,184 +467,22 @@ mod rotation {
     }
 }
 
-mod direction {
-    use bevy::ecs::prelude::Component;
-    use bevy::math::{Vec2, Vec3};
-    use core::ops::{Add, Div, Mul, Neg, Sub};
-    use derive_more::Display;
-    use std::f32::consts::SQRT_2;
-
-    /// A 2D unit vector that represents a direction
-    ///
-    /// Its magnitude is always `1.0`.
-    ///
-    /// # Example
-    /// ```rust
-    /// use leafwing_input_manager::orientation::Direction;
-    /// use bevy::math::Vec2;
-    ///
-    /// assert_eq!(Direction::NORTH.unit_vector(), Vec2::new(0.0, 1.0));
-    /// assert_eq!(Direction::try_from(Vec2::ONE), Ok(Direction::NORTHEAST));
-    ///
-    /// assert_eq!(Direction::SOUTH * 3.0, Vec2::new(0.0, -3.0));
-    /// assert_eq!(Direction::EAST / 2.0, Vec2::new(0.5, 0.0));
-    /// ```
-    #[derive(Component, Clone, Copy, Debug, PartialEq, Display)]
-    pub struct Direction {
-        pub(crate) unit_vector: Vec2,
-    }
-
-    impl Default for Direction {
-        /// [`Direction::EAST`] is the default direction,
-        /// as it is consistent with the default [`Rotation`](crate::orientation::Rotation)
-        fn default() -> Direction {
-            Direction::EAST
-        }
-    }
-
-    impl Direction {
-        /// Creates a new [`Direction`] from a [`Vec2`]
-        ///
-        /// The [`Vec2`] stored internally will be normalized to have a magnitude of `1.0`.
-        ///
-        /// # Panics
-        ///
-        /// Panics if the length of the supplied vector has length zero or cannot be determined.
-        /// Use [`try_from`](TryFrom) to get a [`Result`] instead.
-        #[must_use]
-        #[inline]
-        pub fn new(vec2: Vec2) -> Self {
-            Self::try_from(vec2).unwrap()
-        }
-
-        /// Returns the raw underlying [`Vec2`] unit vector of this direction
-        ///
-        /// This will always have a length of `1.0`
-        #[must_use]
-        #[inline]
-        pub const fn unit_vector(&self) -> Vec2 {
-            self.unit_vector
-        }
-    }
-
-    // Constants
-    impl Direction {
-        /// The direction that points straight up
-        pub const NORTH: Direction = Direction {
-            unit_vector: Vec2::new(0.0, 1.0),
-        };
-        /// The direction that points straight right
-        pub const EAST: Direction = Direction {
-            unit_vector: Vec2::new(1.0, 0.0),
-        };
-        /// The direction that points straight down
-        pub const SOUTH: Direction = Direction {
-            unit_vector: Vec2::new(0.0, -1.0),
-        };
-        /// The direction that points straight left
-        pub const WEST: Direction = Direction {
-            unit_vector: Vec2::new(-1.0, 0.0),
-        };
-
-        /// The direction that points halfway between up and right
-        pub const NORTHEAST: Direction = Direction {
-            unit_vector: Vec2::new(SQRT_2 / 2.0, SQRT_2 / 2.0),
-        };
-        /// The direction that points halfway between down and right
-        pub const SOUTHEAST: Direction = Direction {
-            unit_vector: Vec2::new(SQRT_2 / 2.0, -SQRT_2 / 2.0),
-        };
-        /// The direction that points halfway between down and left
-        pub const SOUTHWEST: Direction = Direction {
-            unit_vector: Vec2::new(-SQRT_2 / 2.0, -SQRT_2 / 2.0),
-        };
-        /// The direction that points halfway between left and up
-        pub const NORTHWEST: Direction = Direction {
-            unit_vector: Vec2::new(-SQRT_2 / 2.0, SQRT_2 / 2.0),
-        };
-    }
-
-    impl Add for Direction {
-        type Output = Vec2;
-        fn add(self, other: Direction) -> Vec2 {
-            self.unit_vector + other.unit_vector
-        }
-    }
-
-    impl Sub for Direction {
-        type Output = Vec2;
-
-        fn sub(self, rhs: Direction) -> Vec2 {
-            self.unit_vector - rhs.unit_vector
-        }
-    }
-
-    impl Mul<f32> for Direction {
-        type Output = Vec2;
-
-        fn mul(self, rhs: f32) -> Vec2 {
-            self.unit_vector * rhs
-        }
-    }
-
-    impl Mul<Direction> for f32 {
-        type Output = Vec2;
-
-        fn mul(self, rhs: Direction) -> Vec2 {
-            self * rhs.unit_vector
-        }
-    }
-
-    impl Div<f32> for Direction {
-        type Output = Vec2;
-
-        fn div(self, rhs: f32) -> Vec2 {
-            self.unit_vector / rhs
-        }
-    }
-
-    impl Div<Direction> for f32 {
-        type Output = Vec2;
-
-        fn div(self, rhs: Direction) -> Vec2 {
-            self / rhs.unit_vector
-        }
-    }
-
-    impl From<Direction> for Vec3 {
-        fn from(direction: Direction) -> Vec3 {
-            direction.unit_vector.extend(0.0)
-        }
-    }
-
-    impl Neg for Direction {
-        type Output = Self;
-
-        fn neg(self) -> Self {
-            Self {
-                unit_vector: -self.unit_vector,
-            }
-        }
-    }
-}
-
 mod conversions {
-    use super::{Direction, Rotation};
+    use super::Rotation;
     use crate::errors::NearlySingularConversion;
+    use bevy::math::primitives::Direction2d;
     use bevy::math::{Quat, Vec2, Vec3};
     use bevy::transform::components::{GlobalTransform, Transform};
 
-    impl From<Rotation> for Direction {
-        fn from(rotation: Rotation) -> Direction {
-            Direction {
-                unit_vector: rotation.into_xy(),
-            }
+    impl From<Rotation> for Direction2d {
+        fn from(rotation: Rotation) -> Direction2d {
+            Direction2d::new_unchecked(rotation.into_xy())
         }
     }
 
-    impl From<Direction> for Rotation {
-        fn from(direction: Direction) -> Rotation {
-            let radians = direction.unit_vector.y.atan2(direction.unit_vector.x);
+    impl From<Direction2d> for Rotation {
+        fn from(direction: Direction2d) -> Rotation {
+            let radians = direction.y.atan2(direction.x);
             // This dirty little trick helps us nudge the two (of eight) cardinal directions onto
             // the correct microdegree. 32-bit floating point math rounds to the wrong microdegree,
             // which usually isn't a big deal, but can result in unexpected surprises when people
@@ -679,25 +517,10 @@ mod conversions {
         }
     }
 
-    impl TryFrom<Vec2> for Direction {
-        type Error = NearlySingularConversion;
-
-        fn try_from(vec2: Vec2) -> Result<Direction, NearlySingularConversion> {
-            vec2.try_normalize()
-                .map(|unit_vector| Direction { unit_vector })
-                .ok_or(NearlySingularConversion)
-        }
-    }
-
-    impl From<Direction> for Vec2 {
-        fn from(direction: Direction) -> Vec2 {
-            direction.unit_vector()
-        }
-    }
-
     impl From<Quat> for Rotation {
         fn from(quaternion: Quat) -> Rotation {
-            let direction: Direction = quaternion.into();
+            let direction: Direction2d =
+                quaternion.mul_vec3(Vec3::X).truncate().try_into().unwrap();
             direction.into()
         }
     }
@@ -705,43 +528,6 @@ mod conversions {
     impl From<Rotation> for Quat {
         fn from(rotation: Rotation) -> Self {
             Quat::from_rotation_z(rotation.into_radians())
-        }
-    }
-
-    impl From<Quat> for Direction {
-        fn from(quaternion: Quat) -> Self {
-            quaternion.mul_vec3(Vec3::X).truncate().try_into().unwrap()
-        }
-    }
-
-    impl From<Direction> for Quat {
-        fn from(direction: Direction) -> Quat {
-            let rotation: Rotation = direction.into();
-            rotation.into()
-        }
-    }
-
-    impl From<Transform> for Direction {
-        fn from(transform: Transform) -> Self {
-            transform.rotation.into()
-        }
-    }
-
-    impl From<GlobalTransform> for Direction {
-        fn from(transform: GlobalTransform) -> Self {
-            transform.to_scale_rotation_translation().1.into()
-        }
-    }
-
-    impl From<Direction> for Transform {
-        fn from(direction: Direction) -> Self {
-            Transform::from_rotation(direction.into())
-        }
-    }
-
-    impl From<Direction> for GlobalTransform {
-        fn from(direction: Direction) -> Self {
-            GlobalTransform::from_rotation(direction.into())
         }
     }
 
@@ -772,53 +558,58 @@ mod conversions {
 
 #[cfg(test)]
 mod test {
+    use bevy::math::primitives::Direction2d;
+
     use super::*;
 
     #[test]
     fn directions_end_up_even() {
-        let north_rot: Rotation = Direction::NORTH.into();
+        let north_rot: Rotation = Direction2d::Y.into();
         assert_eq!(
             north_rot,
             Rotation::from_degrees_int(90),
             "we want north to end up exact in microdegrees"
         );
-        let northeast_rot: Rotation = Direction::NORTHEAST.into();
+        let northeast_rot: Rotation = Direction2d::from_xy(1.0, 1.0).unwrap().into();
         assert_eq!(
             northeast_rot,
             Rotation::from_degrees_int(45),
             "we want northeast to end up exact in microdegrees"
         );
-        let northwest_rot: Rotation = Direction::NORTHWEST.into();
+        let northwest_rot: Rotation = Direction2d::from_xy(-1.0, 1.0).unwrap().into();
+
         assert_eq!(
             northwest_rot,
             Rotation::from_degrees_int(135),
             "we want northwest to end up exact in microdegrees"
         );
-        let south_rot: Rotation = Direction::SOUTH.into();
+        let south_rot: Rotation = Direction2d::NEG_Y.into();
         assert_eq!(
             south_rot,
             Rotation::from_degrees_int(270),
             "we want south to end up exact in microdegrees"
         );
-        let southeast_rot: Rotation = Direction::SOUTHEAST.into();
+        let southeast_rot: Rotation = Direction2d::from_xy(1.0, -1.0).unwrap().into();
+
         assert_eq!(
             southeast_rot,
             Rotation::from_degrees_int(315),
             "we want southeast to end up exact in microdegrees"
         );
-        let southwest_rot: Rotation = Direction::SOUTHWEST.into();
+        let southwest_rot: Rotation = Direction2d::from_xy(-1.0, -1.0).unwrap().into();
+
         assert_eq!(
             southwest_rot,
             Rotation::from_degrees_int(225),
             "we want southwest to end up exact in microdegrees"
         );
-        let east_rot: Rotation = Direction::EAST.into();
+        let east_rot: Rotation = Direction2d::X.into();
         assert_eq!(
             east_rot,
             Rotation::from_degrees_int(0),
             "we want east to end up exact in microdegrees"
         );
-        let west_rot: Rotation = Direction::WEST.into();
+        let west_rot: Rotation = Direction2d::NEG_X.into();
         assert_eq!(
             west_rot,
             Rotation::from_degrees_int(180),

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -20,9 +20,10 @@ mod orientation_trait {
         ///
         /// # Example
         /// ```rust
-        /// use leafwing_input_manager::orientation::{Orientation, Direction, Rotation};
+        /// use leafwing_input_manager::orientation::{Orientation, Rotation};
+        /// use bevy::math::primitives::Direction2d;
         ///
-        /// Direction::NORTH.distance(Direction::SOUTHWEST).assert_approx_eq(Rotation::from_degrees(135.));
+        /// Direction2d::Y.distance(Direction2d::from_xy(-1.0, -1.0).unwrap()).assert_approx_eq(Rotation::from_degrees(135.));
         /// ```
         #[must_use]
         fn distance(&self, other: Self) -> Rotation;
@@ -50,16 +51,17 @@ mod orientation_trait {
         ///
         /// # Example
         /// ```rust
-        /// use leafwing_input_manager::orientation::{Direction, Orientation, RotationDirection};
+        /// use leafwing_input_manager::orientation::{Orientation, RotationDirection};
+        /// use bevy::math::primitives::Direction2d;
         ///
-        /// assert_eq!(Direction::NORTH.rotation_direction(Direction::NORTH), RotationDirection::Clockwise);
-        /// assert_eq!(Direction::NORTH.rotation_direction(Direction::SOUTH), RotationDirection::Clockwise);
+        /// assert_eq!(Direction2d::Y.rotation_direction(Direction2d::Y), RotationDirection::Clockwise);
+        /// assert_eq!(Direction2d::Y.rotation_direction(Direction2d::NEG_Y), RotationDirection::Clockwise);
         ///
-        /// assert_eq!(Direction::NORTH.rotation_direction(Direction::EAST), RotationDirection::Clockwise);
-        /// assert_eq!(Direction::NORTH.rotation_direction(Direction::WEST), RotationDirection::CounterClockwise);
+        /// assert_eq!(Direction2d::Y.rotation_direction(Direction2d::X), RotationDirection::Clockwise);
+        /// assert_eq!(Direction2d::Y.rotation_direction(Direction2d::NEG_X), RotationDirection::CounterClockwise);
         ///
-        /// assert_eq!(Direction::WEST.rotation_direction(Direction::SOUTH), RotationDirection::CounterClockwise);
-        /// assert_eq!(Direction::SOUTH.rotation_direction(Direction::WEST), RotationDirection::Clockwise);
+        /// assert_eq!(Direction2d::NEG_X.rotation_direction(Direction2d::NEG_Y), RotationDirection::CounterClockwise);
+        /// assert_eq!(Direction2d::NEG_Y.rotation_direction(Direction2d::NEG_X), RotationDirection::Clockwise);
         /// ```
         #[inline]
         #[must_use]
@@ -215,7 +217,8 @@ mod rotation {
     ///
     /// # Example
     /// ```rust
-    /// use leafwing_input_manager::orientation::{Rotation, Direction, Orientation};
+    /// use leafwing_input_manager::orientation::{Rotation, Orientation};
+    /// use bevy::math::primitives::Direction2d;
     /// use core::f32::consts::{FRAC_PI_2, PI, TAU};
     ///
     /// let east = Rotation::from_radians(0.0);
@@ -233,7 +236,7 @@ mod rotation {
     ///
     /// north.assert_approx_eq(Rotation::NORTH);
     ///
-    /// Direction::from(west).assert_approx_eq(Direction::WEST);
+    /// Direction2d::from(west).assert_approx_eq(Direction2d::NEG_X);
     /// ```
     #[derive(Component, Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Default, Display)]
     pub struct Rotation {

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -303,7 +303,7 @@ mod rotation {
 
     // Conversion methods
     impl Rotation {
-        /// Constructs a [`Rotation`](crate::orientation::Direction) from an (x,y) Euclidean coordinate
+        /// Constructs a [`Rotation`](crate::orientation::Rotation) from an (x,y) Euclidean coordinate
         ///
         /// If both x and y are nearly 0 (the magnitude is less than [`EPSILON`](f32::EPSILON)),
         /// [`Err(NearlySingularConversion)`] will be returned instead.
@@ -325,7 +325,7 @@ mod rotation {
             }
         }
 
-        /// Converts this direction into an (x, y) pair with magnitude 1
+        /// Converts this rotation into an (x, y) pair with magnitude 1
         #[inline]
         #[must_use]
         pub fn into_xy(self) -> Vec2 {
@@ -333,7 +333,7 @@ mod rotation {
             Vec2::new(radians.cos(), radians.sin())
         }
 
-        /// Construct a [`Direction`](crate::orientation::Direction) from radians,
+        /// Construct a [`Rotation`](crate::orientation::Rotation) from radians,
         /// measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
@@ -345,14 +345,14 @@ mod rotation {
             }
         }
 
-        /// Converts this direction into radians, measured counterclockwise from the positive x-axis
+        /// Converts this rotation into radians, measured counterclockwise from the positive x-axis
         #[inline]
         #[must_use]
         pub fn into_radians(self) -> f32 {
             self.micro_degrees as f32 * (TAU / Rotation::FULL_CIRCLE as f32)
         }
 
-        /// Construct a [`Direction`](crate::orientation::Direction) from degrees, measured counterclockwise from the positive x-axis
+        /// Construct a [`Rotation`](crate::orientation::Rotation) from degrees, measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
         pub fn from_degrees(degrees: impl Into<f32>) -> Rotation {
@@ -363,7 +363,7 @@ mod rotation {
             }
         }
 
-        /// Construct a [`Direction`](crate::orientation::Direction) from a whole number of degrees, measured counterclockwise from the positive x-axis
+        /// Construct a [`Rotation`](crate::orientation::Rotation) from a whole number of degrees, measured counterclockwise from the positive x-axis
         #[must_use]
         #[inline]
         pub const fn from_degrees_int(degrees: u32) -> Rotation {
@@ -372,7 +372,7 @@ mod rotation {
             }
         }
 
-        /// Converts this direction into degrees, measured counterclockwise from the positive x-axis
+        /// Converts this rotation into degrees, measured counterclockwise from the positive x-axis
         #[inline]
         #[must_use]
         pub fn into_degrees(self) -> f32 {


### PR DESCRIPTION
Remove `Direction` and replace all usages with `Direction2d` from Bevy, preserving all conversions and replacing usages.

Fixes #487