### PR TITLE
Add `InputManagerBundle::with_map` and fix a mishandling of DualAxis

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,8 @@ struct Player;
 
 fn spawn_player(mut commands: Commands) {
     commands
-        .spawn(InputManagerBundle::<Action> {
-            // Stores "which actions are currently pressed"
-            action_state: ActionState::default(),
-            // Describes how to convert from player inputs into those actions
-            input_map: InputMap::new([(Action::Jump, KeyCode::Space)]),
-        })
+        // Describes how to convert from player inputs into those actions
+        .spawn(InputManagerBundle::with_map(InputMap::new([(Action::Jump, KeyCode::Space)])))
         .insert(Player);
 }
 

--- a/README.md
+++ b/README.md
@@ -87,9 +87,10 @@ enum Action {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
+    // Describes how to convert from player inputs into those actions
+    let input_map = InputMap::new([(Action::Jump, KeyCode::Space)]);
     commands
-        // Describes how to convert from player inputs into those actions
-        .spawn(InputManagerBundle::with_map(InputMap::new([(Action::Jump, KeyCode::Space)])))
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -180,7 +180,8 @@
 
 ### Enhancements
 
-- Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver to update multiple entities if needed.
+- Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver
+  to update multiple entities if needed.
 - Added builder-style functions to `SingleAxis`, `DualAxis`, and `VirtualDPad` that invert their output values, allowing, for example, binding inverted camera controls.
 
 ### Docs

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,15 @@
 # Release Notes
 
+## Version 0.13.3
+
+### Bugs
+
+- fixed a bug where `DualAxis` was being considered pressed even when its data was [0.0, 0.0].
+
+### Usability
+
+- added `InputManagerBundle::with_map(InputMap)` allowing you to create the bundle with the given `InputMap` and default `ActionState`.
+
 ## Version 0.13.2
 
 ### Usability
@@ -171,7 +181,7 @@
 ### Enhancements
 
 - Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver
-to update multiple entities if needed.
+  to update multiple entities if needed.
 - Added builder-style functions to `SingleAxis`, `DualAxis`, and `VirtualDPad` that invert their output values, allowing, for example, binding inverted camera controls.
 
 ### Docs

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,9 +14,9 @@
 
 ### Usability
 
-- Added `with_threshold()` for const `SingleAxis` creation.
-- Added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to  `VirtualDpad::gamepad_face_buttons()`.
-- Changed various creations of `DualAxis`, `VirtualAxis`, `VirtualDpad` into const functions as they should be:
+- added `with_threshold()` for const `SingleAxis` creation.
+- added `horizontal_gamepad_face_buttons()` and `vertical_gamepad_face_buttons()` for `VirtualAxis`, similar to `VirtualDpad::gamepad_face_buttons()`.
+- changed various creations of `DualAxis`, `VirtualAxis`, `VirtualDpad` into const functions as they should be:
   - `left_stick()`, `right_stick()` for `DualAxis`.
   - `from_keys()`, `horizontal_arrow_keys()`, `vertical_arrow_keys()`, `ad()`, `ws()`, `horizontal_dpad()`, `vertical_dpad()` for `VirtualAxis`.
   - `arrow_keys()`, `wasd()`, `dpad()`, `gamepad_face_buttons()`, `mouse_wheel()`, `mouse_motion()` for `VirtualDpad`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -180,8 +180,7 @@
 
 ### Enhancements
 
-- Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver
-  to update multiple entities if needed.
+- Changed `entity` field of `ActionStateDriver` to `targets: ActionStateDriverTarget` with variants for 0, 1, or multiple targets, to allow for one driver to update multiple entities if needed.
 - Added builder-style functions to `SingleAxis`, `DualAxis`, and `VirtualDPad` that invert their output values, allowing, for example, binding inverted camera controls.
 
 ### Docs

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -25,24 +25,21 @@ enum Action {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
+    // Describes how to convert from player inputs into those actions
+    let input_map = InputMap::default()
+        // Configure the left stick as a dual-axis
+        .insert(Action::Move, DualAxis::left_stick())
+        // Let's bind the right gamepad trigger to the throttle action
+        .insert(Action::Throttle, GamepadButtonType::RightTrigger2)
+        // And we'll use the right stick's x-axis as a rudder control
+        .insert(
+            // This will trigger if the axis is moved 10% or more in either direction.
+            Action::Rudder,
+            SingleAxis::symmetric(GamepadAxisType::RightStickX, 0.1),
+        )
+        .build();
     commands
-        .spawn(InputManagerBundle::<Action> {
-            // Stores "which actions are currently activated"
-            action_state: ActionState::default(),
-            // Describes how to convert from player inputs into those actions
-            input_map: InputMap::default()
-                // Configure the left stick as a dual-axis
-                .insert(Action::Move, DualAxis::left_stick())
-                // Let's bind the right gamepad trigger to the throttle action
-                .insert(Action::Throttle, GamepadButtonType::RightTrigger2)
-                // And we'll use the right stick's x-axis as a rudder control
-                .insert(
-                    // This will trigger if the axis is moved 10% or more in either direction.
-                    Action::Rudder,
-                    SingleAxis::symmetric(GamepadAxisType::RightStickX, 0.1),
-                )
-                .build(),
-        })
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 
@@ -62,8 +59,8 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
 
     if action_state.pressed(&Action::Throttle) {
         // Note that some gamepad buttons are also tied to axes, so even though we used a
-        // GamepadbuttonType::RightTrigger2 binding to trigger the throttle action, we can get a
-        // variable value here if you have a variable right trigger on your gamepad.
+        // GamepadButtonType::RightTrigger2 binding to trigger the throttle action,
+        // we can get a variable value here if you have a variable right trigger on your gamepad.
         //
         // If you don't have a variable trigger, this will just return 0.0 when not pressed and 1.0
         // when pressed.

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -44,10 +44,7 @@ fn spawn_input_map(mut commands: Commands) {
 
     input_map.insert_chord(OneAndTwoAndThree, [Digit1, Digit2, Digit3]);
 
-    commands.spawn(InputManagerBundle {
-        input_map,
-        ..Default::default()
-    });
+    commands.spawn(InputManagerBundle::with_map(input_map));
 }
 
 fn report_pressed_actions(

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -20,32 +20,21 @@ enum PlayerAction {
 }
 
 impl PlayerAction {
-    // The `strum` crate provides a derivable trait for this!
-    fn variants() -> &'static [PlayerAction] {
-        &[Self::Run, Self::Jump, Self::UseItem]
-    }
-}
+    /// Define the default binding to the input
+    fn default_input_map() -> InputMap<Self> {
+        let mut input_map = InputMap::default();
 
-// Exhaustively match `PlayerAction` and define the default binding to the input
-impl PlayerAction {
-    fn default_keyboard_mouse_input(&self) -> UserInput {
-        // Match against the provided action to get the correct default keyboard-mouse input
-        match self {
-            Self::Run => UserInput::VirtualDPad(VirtualDPad::wasd()),
-            Self::Jump => UserInput::Single(InputKind::PhysicalKey(KeyCode::Space)),
-            Self::UseItem => UserInput::Single(InputKind::Mouse(MouseButton::Left)),
-        }
-    }
+        // Default gamepad input bindings
+        input_map.insert(Self::Run, DualAxis::left_stick());
+        input_map.insert(Self::Jump, GamepadButtonType::South);
+        input_map.insert(Self::UseItem, GamepadButtonType::RightTrigger2);
 
-    fn default_gamepad_input(&self) -> UserInput {
-        // Match against the provided action to get the correct default gamepad input
-        match self {
-            Self::Run => UserInput::Single(InputKind::DualAxis(DualAxis::left_stick())),
-            Self::Jump => UserInput::Single(InputKind::GamepadButton(GamepadButtonType::South)),
-            Self::UseItem => {
-                UserInput::Single(InputKind::GamepadButton(GamepadButtonType::RightTrigger2))
-            }
-        }
+        // Default kbm input bindings
+        input_map.insert(Self::Run, VirtualDPad::wasd());
+        input_map.insert(Self::Jump, KeyCode::Space);
+        input_map.insert(Self::UseItem, MouseButton::Left);
+
+        input_map
     }
 }
 
@@ -53,19 +42,11 @@ impl PlayerAction {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
-    // Create an `InputMap` to add default inputs to
-    let mut input_map = InputMap::default();
-
-    // Loop through each action in `PlayerAction` and get the default `UserInput`,
-    // then insert each default input into input_map
-    for action in PlayerAction::variants() {
-        input_map.insert(*action, PlayerAction::default_keyboard_mouse_input(action));
-        input_map.insert(*action, PlayerAction::default_gamepad_input(action));
-    }
-
-    // Spawn the player with the populated input_map
+    // Spawn the player with the default input_map
     commands
-        .spawn(InputManagerBundle::with_map(input_map))
+        .spawn(InputManagerBundle::with_map(
+            PlayerAction::default_input_map(),
+        ))
         .insert(Player);
 }
 

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -20,7 +20,7 @@ enum PlayerAction {
 }
 
 impl PlayerAction {
-    // The `strum` crate provides a deriveable trait for this!
+    // The `strum` crate provides a derivable trait for this!
     fn variants() -> &'static [PlayerAction] {
         &[Self::Run, Self::Jump, Self::UseItem]
     }
@@ -65,10 +65,7 @@ fn spawn_player(mut commands: Commands) {
 
     // Spawn the player with the populated input_map
     commands
-        .spawn(InputManagerBundle::<PlayerAction> {
-            input_map,
-            ..default()
-        })
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -25,13 +25,10 @@ enum Action {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
+    // Describes how to convert from player inputs into those actions
+    let input_map = InputMap::new([(Action::Jump, KeyCode::Space)]);
     commands
-        .spawn(InputManagerBundle::<Action> {
-            // Stores "which actions are currently pressed"
-            action_state: ActionState::default(),
-            // Describes how to convert from player inputs into those actions
-            input_map: InputMap::new([(Action::Jump, KeyCode::Space)]),
-        })
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -16,16 +16,15 @@ enum CameraMovement {
 }
 
 fn setup(mut commands: Commands) {
+    let input_map = InputMap::new([
+        // This will capture the total continuous value, for direct use.
+        // Note that you can also use discrete gesture-like motion,
+        // via the `MouseMotionDirection` enum.
+        (CameraMovement::Pan, DualAxis::mouse_motion()),
+    ]);
     commands
         .spawn(Camera2dBundle::default())
-        .insert(InputManagerBundle::<CameraMovement> {
-            input_map: InputMap::default()
-                // This will capture the total continuous value, for direct use.
-                // Note that you can also use discrete gesture-like motion, via the `MouseMotionDirection` enum.
-                .insert(CameraMovement::Pan, DualAxis::mouse_motion())
-                .build(),
-            ..default()
-        });
+        .insert(InputManagerBundle::with_map(input_map));
 
     commands.spawn(SpriteBundle {
         transform: Transform::from_scale(Vec3::new(100., 100., 1.)),

--- a/examples/mouse_position.rs
+++ b/examples/mouse_position.rs
@@ -49,7 +49,7 @@ fn update_cursor_state_from_window(
     window_query: Query<(&Window, &ActionStateDriver<BoxMovement>)>,
     mut action_state_query: Query<&mut ActionState<BoxMovement>>,
 ) {
-    // Update each actionstate with the mouse position from the window
+    // Update each action state with the mouse position from the window
     // by using the referenced entities in ActionStateDriver and the stored action as
     // a key into the action data
     for (window, driver) in window_query.iter() {

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -19,23 +19,21 @@ enum CameraMovement {
 }
 
 fn setup(mut commands: Commands) {
+    let input_map = InputMap::default()
+        // This will capture the total continuous value, for direct use.
+        .insert(CameraMovement::Zoom, SingleAxis::mouse_wheel_y())
+        // This will return a binary button-like output.
+        .insert(CameraMovement::PanLeft, MouseWheelDirection::Left)
+        .insert(CameraMovement::PanRight, MouseWheelDirection::Right)
+        // Alternatively, you could model this as a virtual Dpad.
+        // It's extremely useful for modeling 4-directional button-like inputs with the mouse wheel
+        // .insert(VirtualDpad::mouse_wheel(), Pan)
+        // Or even a continuous `DualAxis`!
+        // .insert(DualAxis::mouse_wheel(), Pan)
+        .build();
     commands
         .spawn(Camera2dBundle::default())
-        .insert(InputManagerBundle::<CameraMovement> {
-            input_map: InputMap::default()
-                // This will capture the total continuous value, for direct use.
-                .insert(CameraMovement::Zoom, SingleAxis::mouse_wheel_y())
-                // This will return a binary button-like output.
-                .insert(CameraMovement::PanLeft, MouseWheelDirection::Left)
-                .insert(CameraMovement::PanRight, MouseWheelDirection::Right)
-                // Alternatively, you could model this as a virtual Dpad.
-                // It's extremely useful for modeling 4-directional button-like inputs with the mouse wheel
-                // .insert(VirtualDpad::mouse_wheel(), Pan)
-                // Or even a continuous `DualAxis`!
-                // .insert(DualAxis::mouse_wheel(), Pan)
-                .build(),
-            ..default()
-        });
+        .insert(InputManagerBundle::with_map(input_map));
 
     commands.spawn(SpriteBundle {
         transform: Transform::from_scale(Vec3::new(100., 100., 1.)),

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -67,17 +67,11 @@ impl PlayerBundle {
 fn spawn_players(mut commands: Commands) {
     commands.spawn(PlayerBundle {
         player: Player::One,
-        input_manager: InputManagerBundle {
-            input_map: PlayerBundle::input_map(Player::One),
-            ..Default::default()
-        },
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::One)),
     });
 
     commands.spawn(PlayerBundle {
         player: Player::Two,
-        input_manager: InputManagerBundle {
-            input_map: PlayerBundle::input_map(Player::Two),
-            ..Default::default()
-        },
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::Two)),
     });
 }

--- a/examples/press_duration.rs
+++ b/examples/press_duration.rs
@@ -59,10 +59,7 @@ fn spawn_player(mut commands: Commands) {
     commands.spawn(PlayerBundle {
         player: Player,
         velocity: Velocity { x: 0.0 },
-        input_manager: InputManagerBundle {
-            input_map: PlayerBundle::default_input_map(),
-            ..default()
-        },
+        input_manager: InputManagerBundle::with_map(PlayerBundle::default_input_map()),
         sprite: SpriteBundle {
             transform: Transform {
                 scale: Vec3::new(40.0, 80.0, 0.0),

--- a/examples/register_gamepads.rs
+++ b/examples/register_gamepads.rs
@@ -44,16 +44,15 @@ fn join(
             if !joined_players.0.contains_key(&gamepad) {
                 println!("Player {} has joined the game!", gamepad.id);
 
+                let input_map = InputMap::new([
+                    (Action::Jump, GamepadButtonType::South),
+                    (Action::Disconnect, GamepadButtonType::Select),
+                ])
+                // Make sure to set the gamepad or all gamepads will be used!
+                .set_gamepad(gamepad)
+                .build();
                 let player = commands
-                    .spawn(InputManagerBundle::<Action> {
-                        action_state: ActionState::default(),
-                        input_map: InputMap::default()
-                            .insert(Action::Jump, GamepadButtonType::South)
-                            .insert(Action::Disconnect, GamepadButtonType::Select)
-                            // Make sure to set the gamepad or all gamepads will be used!
-                            .set_gamepad(gamepad)
-                            .build(),
-                    })
+                    .spawn(InputManagerBundle::with_map(input_map))
                     .insert(Player { gamepad })
                     .id();
 

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -125,13 +125,11 @@ fn spawn_player(mut commands: Commands) {
     use FpsAction::*;
     use KeyCode::*;
 
+    let input_map = InputMap::new([(MoveLeft, KeyW), (MoveRight, KeyD), (Jump, Space)])
+        .insert(Shoot, MouseButton::Left)
+        .build();
     commands
-        .spawn(InputManagerBundle {
-            input_map: InputMap::new([(MoveLeft, KeyW), (MoveRight, KeyD), (Jump, Space)])
-                .insert(Shoot, MouseButton::Left)
-                .build(),
-            ..default()
-        })
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -111,10 +111,7 @@ impl PlayerBundle {
 fn spawn_player(mut commands: Commands) {
     commands.spawn(PlayerBundle {
         player: Player,
-        input_manager: InputManagerBundle {
-            input_map: PlayerBundle::default_input_map(),
-            ..default()
-        },
+        input_manager: InputManagerBundle::with_map(PlayerBundle::default_input_map()),
     });
 }
 

--- a/examples/twin_stick_controller.rs
+++ b/examples/twin_stick_controller.rs
@@ -39,6 +39,7 @@ pub enum PlayerAction {
 }
 
 impl PlayerAction {
+    /// Define the default binding to the input
     fn default_input_map() -> InputMap<Self> {
         let mut input_map = InputMap::default();
 

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -24,9 +24,10 @@ enum Action {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
-    let mut input_map = InputMap::default();
-    input_map.insert(Action::Left, KeyCode::ArrowLeft);
-    input_map.insert(Action::Right, KeyCode::ArrowRight);
+    let input_map = InputMap::new([
+        (Action::Left, KeyCode::ArrowLeft),
+        (Action::Right, KeyCode::ArrowRight),
+    ]);
 
     commands
         .spawn(SpriteBundle {
@@ -40,10 +41,7 @@ fn spawn_player(mut commands: Commands) {
             },
             ..Default::default()
         })
-        .insert(InputManagerBundle::<Action> {
-            input_map,
-            ..Default::default()
-        })
+        .insert(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -23,22 +23,19 @@ enum Action {
 struct Player;
 
 fn spawn_player(mut commands: Commands) {
+    // Stores "which actions are currently activated"
+    // Map some arbitrary keys into a virtual direction pad that triggers our move action
+    let input_map = InputMap::new([(
+        Action::Move,
+        VirtualDPad {
+            up: KeyCode::KeyW.into(),
+            down: KeyCode::KeyS.into(),
+            left: KeyCode::KeyA.into(),
+            right: KeyCode::KeyD.into(),
+        },
+    )]);
     commands
-        .spawn(InputManagerBundle::<Action> {
-            // Stores "which actions are currently activated"
-            // Map some arbitrary keys into a virtual direction pad that triggers our move action
-            input_map: InputMap::new([(
-                Action::Move,
-                VirtualDPad {
-                    up: KeyCode::KeyW.into(),
-                    down: KeyCode::KeyS.into(),
-                    left: KeyCode::KeyA.into(),
-                    right: KeyCode::KeyD.into(),
-                },
-            )])
-            .build(),
-            ..default()
-        })
+        .spawn(InputManagerBundle::with_map(input_map))
         .insert(Player);
 }
 

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -1,4 +1,4 @@
-//! Tools for working with directional axis-like user inputs (gamesticks, D-Pads and emulated equivalents)
+//! Tools for working with directional axis-like user inputs (game sticks, D-Pads and emulated equivalents)
 
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
 use crate::orientation::{Direction, Rotation};

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -536,7 +536,7 @@ mod tests {
             assert_eq!(action_data, expected);
         }
 
-        // Checks that a clash between a VirtualDPad and a chord choses the chord
+        // Checks that a clash between a VirtualDPad and a chord chooses the chord
         #[test]
         fn handle_clashes_dpad_chord() {
             let mut app = App::new();

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -94,7 +94,9 @@ impl<'a> InputStreams<'a> {
     #[must_use]
     pub fn button_pressed(&self, button: InputKind) -> bool {
         match button {
-            InputKind::DualAxis(axis) => self.extract_dual_axis_data(&axis).is_some(),
+            InputKind::DualAxis(axis) => self
+                .extract_dual_axis_data(&axis)
+                .is_some_and(|data| data.xy() != Vec2::ZERO),
             InputKind::SingleAxis(axis) => {
                 let value = self.input_value(&button.into(), false);
 
@@ -323,8 +325,8 @@ impl<'a> InputStreams<'a> {
                     for input_kind in inputs.iter() {
                         // Return result of the first dual axis in the chord.
                         if let InputKind::DualAxis(dual_axis) = input_kind {
-                            let data = self.extract_dual_axis_data(dual_axis).unwrap_or_default();
-                            return Some(data);
+                            let data = self.extract_dual_axis_data(dual_axis);
+                            return Some(data.unwrap_or_default());
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,3 +107,13 @@ impl<A: Actionlike> Default for InputManagerBundle<A> {
         }
     }
 }
+
+impl<A: Actionlike> InputManagerBundle<A> {
+    /// Creates a [`InputManagerBundle`] with the given [`InputMap`].
+    pub fn with_map(input_map: InputMap<A>) -> Self {
+        Self {
+            input_map,
+            action_state: ActionState::default(),
+        }
+    }
+}

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -113,7 +113,7 @@ mod orientation_trait {
     impl Orientation for Rotation {
         #[inline]
         fn distance(&self, other: Rotation) -> Rotation {
-            let difference = self.micro_degrees_difference(other);
+            let difference = self.micro_degrees_between(other);
             let micro_degrees = difference.min(Rotation::neg_micro_degrees(difference));
             Rotation { micro_degrees }
         }
@@ -379,7 +379,7 @@ mod rotation {
         /// Calculates the difference in micro-degrees between `self` and `rhs`.
         #[inline]
         #[must_use]
-        pub(crate) fn micro_degrees_difference(&self, rhs: Self) -> u32 {
+        pub(crate) fn micro_degrees_between(&self, rhs: Self) -> u32 {
             (self.micro_degrees as i32 - rhs.micro_degrees as i32).unsigned_abs()
         }
 
@@ -394,7 +394,7 @@ mod rotation {
         #[inline]
         #[must_use]
         pub(crate) fn micro_degrees_sub_by(&self, rhs: Self) -> u32 {
-            let difference = self.micro_degrees_difference(rhs);
+            let difference = self.micro_degrees_between(rhs);
             if self.micro_degrees >= rhs.micro_degrees {
                 difference
             } else {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -42,10 +42,10 @@ struct Player;
 
 fn spawn_player(mut commands: Commands) {
     commands
-        .spawn(InputManagerBundle::<Action> {
-            input_map: InputMap::<Action>::new([(Action::PayRespects, KeyCode::KeyF)]),
-            ..Default::default()
-        })
+        .spawn(InputManagerBundle::with_map(InputMap::new([(
+            Action::PayRespects,
+            KeyCode::KeyF,
+        )])))
         .insert(Player);
 }
 
@@ -148,10 +148,10 @@ fn action_state_driver() {
 
     fn setup(mut commands: Commands) {
         let player_entity = commands
-            .spawn(InputManagerBundle::<Action> {
-                input_map: InputMap::<Action>::new([(Action::PayRespects, KeyCode::KeyF)]),
-                ..Default::default()
-            })
+            .spawn(InputManagerBundle::with_map(InputMap::new([(
+                Action::PayRespects,
+                KeyCode::KeyF,
+            )])))
             .insert(Player)
             .id();
 


### PR DESCRIPTION
Some thoughts after going through all the examples

## Bugs

Fixed a bug where `DualAxis` is being considered pressed even when its data is [0.0, 0.0] (since #438)

Found by [this chat](https://discord.com/channels/691052431525675048/1034547742262951966/1210379439544729751)

## Usability

Added `InputManagerBundle::with_map(InputMap)`.

This allows you to create the bundle with the given `InputMap` and default `ActionState`

```rust
// before
InputManagerBundle {
  input_map,
  ..Default::default()
};
// after
InputManagerBundle::with_map(input_map);
```

### Changelog

- simplified the usage of `InputManagerBundle` and `InputMap` via `InputManagerBundle::with_map`, `InputMap::new`, and `InputMap::insert` in examples and comments if it's possible
- removed incorrect description in the comments of twin_stick_controller.rs
- fixed all possible typos in comments