### PR TITLE
docs: add multiplayer action usage example

### DIFF
--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -6,6 +6,7 @@ fn main() {
         .add_plugins(DefaultPlugins)
         .add_plugins(InputManagerPlugin::<Action>::default())
         .add_systems(Startup, spawn_players)
+        .add_systems(Update, move_players)
         .run();
 }
 
@@ -16,7 +17,7 @@ enum Action {
     Jump,
 }
 
-#[derive(Component)]
+#[derive(Component, Debug)]
 enum Player {
     One,
     Two,
@@ -74,4 +75,13 @@ fn spawn_players(mut commands: Commands) {
         player: Player::Two,
         input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::Two)),
     });
+}
+
+fn move_players(player_query: Query<(&Player, &ActionState<Action>)>) {
+    for (player, action_state) in player_query.iter() {
+        let actions = action_state.get_just_pressed();
+        if !actions.is_empty() {
+            info!("Player {player:?} performed actions {actions:?}");
+        }
+    }
 }


### PR DESCRIPTION
## What was the problem?

When reading the multiplayer example it wasn't entirely clear how to query for
each player state directly, as a lot of the examples the the ActionState as a
resource, thus making it a singleton. Adding this usage pattern in the example
makes it just a bit clearer.

## How did you fix it?

I added a system that uses the actions that were provided in the setup system in
the multiplayer example.
