### PR TITLE
Fixes a bug where gamepads are not filtered

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,10 @@
 
 - Removed `Direction` type. Use `bevy::math::primitives::Direction2d`.
 
+### Bugs
+
+- fixed a bug in `InputStreams::button_pressed()` where unrelated gamepads were not filtered out when an `associated_gamepad` is defined.
+
 ## Version 0.13.3
 
 ### Bugs

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -6,6 +6,10 @@
 
 - Removed `Direction` type. Use `bevy::math::primitives::Direction2d`.
 
+### Usability
+
+- added `InputMap::set_exclusive_gamepad()` that restricts input to the specified [`Gamepad`] for the entity controlled by this input map.
+
 ### Bugs
 
 - fixed a bug in `InputStreams::button_pressed()` where unrelated gamepads were not filtered out when an `associated_gamepad` is defined.

--- a/examples/register_gamepads.rs
+++ b/examples/register_gamepads.rs
@@ -49,7 +49,9 @@ fn join(
                     (Action::Disconnect, GamepadButtonType::Select),
                 ])
                 // Make sure to set the gamepad or all gamepads will be used!
-                .set_gamepad(gamepad)
+                // If you don't want a specified exclusive gamepad,
+                // use `set_gamepad()` instead.
+                .set_exclusive_gamepad(gamepad)
                 .build();
                 let player = commands
                     .spawn(InputManagerBundle::with_map(input_map))

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -9,7 +9,7 @@
 
 use crate::axislike::{AxisType, MouseMotionAxisType, MouseWheelAxisType};
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
-use crate::input_streams::{InputStreams, MutableInputStreams};
+use crate::input_streams::{GamepadValueSource, InputStreams, MutableInputStreams};
 use crate::user_input::{RawInputs, UserInput};
 
 use bevy::app::App;
@@ -303,7 +303,7 @@ impl QueryInput for InputStreams<'_> {
 
     fn pressed_for_gamepad(&self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) -> bool {
         let mut input_streams = self.clone();
-        input_streams.associated_gamepad = gamepad;
+        input_streams.gamepad_source = gamepad.map(GamepadValueSource::Prefer).unwrap_or_default();
 
         input_streams.input_pressed(&input.into())
     }

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -103,9 +103,14 @@ impl<'a> InputStreams<'a> {
                 value < axis.negative_low || value > axis.positive_low
             }
             InputKind::GamepadButton(button_type) => self
-                .associated_gamepad
-                .into_iter()
-                .chain(self.gamepads.iter())
+                .gamepads
+                .iter()
+                .filter(|gamepad| {
+                    if let Some(associated_gamepad) = self.associated_gamepad {
+                        return gamepad == &associated_gamepad;
+                    }
+                    self.associated_gamepad.is_none()
+                })
                 .any(|gamepad| {
                     self.gamepad_buttons.pressed(GamepadButton {
                         gamepad,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,7 @@ pub mod prelude {
     #[cfg(feature = "ui")]
     pub use crate::input_mocking::MockUIInteraction;
     pub use crate::input_mocking::{MockInput, QueryInput};
+    pub use crate::input_streams::GamepadValueSource;
     pub use crate::user_input::{InputKind, Modifier, UserInput};
 
     pub use crate::plugin::InputManagerPlugin;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -125,6 +125,7 @@ pub fn update_action_state<A: Actionlike>(
 
     for (mut action_state, input_map) in query.iter_mut().chain(resources) {
         let input_streams = InputStreams {
+            gamepad_source: input_map.gamepad_source(),
             gamepad_buttons,
             gamepad_button_axes,
             gamepad_axes,
@@ -133,7 +134,6 @@ pub fn update_action_state<A: Actionlike>(
             mouse_buttons,
             mouse_wheel: mouse_wheel.clone(),
             mouse_motion: mouse_motion.clone(),
-            associated_gamepad: input_map.gamepad(),
         };
 
         action_state.update(input_map.which_pressed(&input_streams, *clash_strategy));


### PR DESCRIPTION
Fixes #500. I believe the issue was caused by the `InputStreams::button_pressed()` function. I rewrote the associated block to filter out unassociated gamepads, but also to let through any gamepad if no associated gamepad is defined. 

I make no guarantees regarding if this is a well-written solution. Feedback is appreciated!