### PR TITLE
Remove the hacky `value` field and `from_value` method of axis-like inputs in favor of a new input mocking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ and a single input can result in multiple actions being triggered, which can be 
 - Local multiplayer support: freely bind keys to distinct entities, rather than worrying about singular global state
 - Networked multiplayer support: serializable structs, and a space-conscious `ActionDiff` representation to send on the wire
 - Powerful and easy-to-use input mocking API for integration testing your Bevy applications
-  - `app.send_input(KeyCode::KeyB)` or `world.send_input(UserInput::chord([KeyCode::KeyB, KeyCode::KeyE, KeyCode::KeyV, KeyCode::KeyY])`
+  - `app.press_input(KeyCode::KeyB)` or `world.press_input(UserInput::chord([KeyCode::KeyB, KeyCode::KeyE, KeyCode::KeyV, KeyCode::KeyY])`
 - Control which state this plugin is active in: stop wandering around while in a menu!
 - Leafwing Studio's trademark `#![forbid(missing_docs)]`
 

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -4,7 +4,7 @@
 
 1. Ensure that `reset_inputs` for `MutableInputStreams` is resetting all relevant fields.
 2. Ensure that `RawInputs` struct has fields that cover all necessary input types.
-3. Ensure that `send_input` and `release_input` check all possible fields on `RawInputs`.
+3. Ensure that `press_input`, `send_axis_values` and `release_input` check all possible fields on `RawInputs`.
 
 ## Before release
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -15,7 +15,7 @@
 - split `MockInput::send_input` method to two methods:
   - `fn press_input(&self, input: UserInput)` for focusing on simulating button and key presses.
   - `fn send_axis_values(&self, input: UserInput, values: impl IntoIterator<Item = f32>)` for sending value changed events to each axis of the input.
-- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking (see 'Usability: Input Mocking' for details).
+- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking.
 
 ### Enhancements
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,10 @@
   - if you're using leafwing-input-manager with `default_features = false`, you can readd it by adding `bevy/bevy_gilrs` as a dependency.
 - removed `InputMap::build` method in favor of new fluent builder pattern (see 'Usability: InputMap' for details).
 - renamed `InputMap::which_pressed` method to `process_actions` to better reflect its current functionality for clarity.
+- split `MockInput::send_input` method to two methods:
+  - `fn press_input(&self, input: UserInput)` for focusing on simulating button and key presses.
+  - `fn send_axis_values(&self, input: UserInput, values: impl IntoIterator<Item = f32>)` for sending value changed events to each axis of the input.
+- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking (see 'Usability: Input Mocking' for details).
 
 ### Enhancements
 
@@ -28,7 +32,7 @@ Input processors allow you to create custom logic for axis-like input manipulati
 - implemented `WithAxisProcessorExt` to manage processors for `SingleAxis` and `VirtualAxis`.
 - implemented `WithDualAxisProcessorExt` to manage processors for `DualAxis` and `VirtualDpad`.
 - added App extensions: `register_axis_processor` and `register_dual_axis_processor` for registration of processors.
-- added built-in processor variants (no variant versions implemented `Into<Processor>`):
+- added built-in processors (variants of processor enums and `Into<Processor>` implementors):
   - Pipelines: Handle input values sequentially through a sequence of processors.
     - `AxisProcessor::Pipeline`: Pipeline for single-axis inputs.
     - `DualAxisProcessor::Pipeline`: Pipeline for dual-axis inputs.

--- a/benches/input_map.rs
+++ b/benches/input_map.rs
@@ -77,8 +77,8 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     // Constructing our test app / input stream outside the timed benchmark
     let mut app = App::new();
     app.add_plugins(InputPlugin);
-    app.send_input(KeyCode::KeyA);
-    app.send_input(KeyCode::KeyB);
+    app.press_input(KeyCode::KeyA);
+    app.press_input(KeyCode::KeyB);
     app.update();
 
     let input_streams = InputStreams::from_world(&app.world, None);

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -69,8 +69,8 @@ fn main() {
     client_app.update();
 
     // Sending inputs to the client
-    client_app.send_input(KeyCode::Space);
-    client_app.send_input(MouseButton::Left);
+    client_app.press_input(KeyCode::Space);
+    client_app.press_input(MouseButton::Left);
 
     // These are converted into actions when the client_app's `Schedule` runs
     client_app.update();

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -655,7 +655,7 @@ mod tests {
         assert!(!action_state.just_released(&Action::Run));
 
         // Pressing
-        app.send_input(KeyCode::KeyR);
+        app.press_input(KeyCode::KeyR);
         // Process the input events into Input<KeyCode> data
         app.update();
         let input_streams = InputStreams::from_world(&app.world, None);
@@ -729,7 +729,7 @@ mod tests {
         assert!(action_state.released(&Action::OneAndTwo));
 
         // Pressing One
-        app.send_input(Digit1);
+        app.press_input(Digit1);
         app.update();
         let input_streams = InputStreams::from_world(&app.world, None);
 
@@ -750,7 +750,7 @@ mod tests {
         assert!(action_state.released(&Action::OneAndTwo));
 
         // Pressing Two
-        app.send_input(Digit2);
+        app.press_input(Digit2);
         app.update();
         let input_streams = InputStreams::from_world(&app.world, None);
 

--- a/src/buttonlike.rs
+++ b/src/buttonlike.rs
@@ -1,5 +1,6 @@
 //! Tools for working with button-like user inputs (mouse clicks, gamepad button, keyboard inputs and so on)
 //!
+use crate::axislike::DualAxisDirection;
 use bevy::reflect::Reflect;
 use serde::{Deserialize, Serialize};
 
@@ -99,6 +100,19 @@ pub enum MouseWheelDirection {
     Left,
 }
 
+impl MouseWheelDirection {
+    /// Returns the corresponding [`DualAxisDirection`].
+    #[inline]
+    pub fn direction(&self) -> DualAxisDirection {
+        match self {
+            Self::Up => DualAxisDirection::Up,
+            Self::Down => DualAxisDirection::Down,
+            Self::Right => DualAxisDirection::Right,
+            Self::Left => DualAxisDirection::Left,
+        }
+    }
+}
+
 /// A buttonlike-input triggered by [`MouseMotion`](bevy::input::mouse::MouseMotion) events
 ///
 /// These will be considered pressed if non-zero net movement in the correct direction is detected.
@@ -112,4 +126,17 @@ pub enum MouseMotionDirection {
     Right,
     /// Corresponds to `-x`
     Left,
+}
+
+impl MouseMotionDirection {
+    /// Returns the corresponding [`DualAxisDirection`].
+    #[inline]
+    pub fn direction(&self) -> DualAxisDirection {
+        match self {
+            Self::Up => DualAxisDirection::Up,
+            Self::Down => DualAxisDirection::Down,
+            Self::Right => DualAxisDirection::Right,
+            Self::Left => DualAxisDirection::Left,
+        }
+    }
 }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -467,8 +467,8 @@ mod tests {
 
             let input_map = test_input_map();
             let simple_clash = input_map.possible_clash(&One, &OneAndTwo).unwrap();
-            app.send_input(Digit1);
-            app.send_input(Digit2);
+            app.press_input(Digit1);
+            app.press_input(Digit2);
             app.update();
 
             let input_streams = InputStreams::from_world(&app.world, None);
@@ -495,7 +495,7 @@ mod tests {
             let chord_clash = input_map
                 .possible_clash(&OneAndTwo, &OneAndTwoAndThree)
                 .unwrap();
-            app.send_input(Digit3);
+            app.press_input(Digit3);
             app.update();
 
             let input_streams = InputStreams::from_world(&app.world, None);
@@ -516,8 +516,8 @@ mod tests {
             app.add_plugins(InputPlugin);
             let input_map = test_input_map();
 
-            app.send_input(Digit1);
-            app.send_input(Digit2);
+            app.press_input(Digit1);
+            app.press_input(Digit2);
             app.update();
 
             let mut action_data = HashMap::new();
@@ -547,8 +547,8 @@ mod tests {
             app.add_plugins(InputPlugin);
             let input_map = test_input_map();
 
-            app.send_input(ControlLeft);
-            app.send_input(ArrowUp);
+            app.press_input(ControlLeft);
+            app.press_input(ArrowUp);
             app.update();
 
             let mut action_data = HashMap::new();
@@ -575,9 +575,9 @@ mod tests {
             app.add_plugins(InputPlugin);
             let input_map = test_input_map();
 
-            app.send_input(Digit1);
-            app.send_input(Digit2);
-            app.send_input(ControlLeft);
+            app.press_input(Digit1);
+            app.press_input(Digit2);
+            app.press_input(ControlLeft);
             app.update();
 
             let action_data = input_map.process_actions(

--- a/src/input_processing/dual_axis/circle.rs
+++ b/src/input_processing/dual_axis/circle.rs
@@ -3,7 +3,7 @@
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
-use bevy::prelude::*;
+use bevy::prelude::{Reflect, Vec2};
 use bevy::utils::FloatOrd;
 use serde::{Deserialize, Serialize};
 
@@ -399,6 +399,7 @@ impl Hash for CircleDeadZone {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use bevy::prelude::FloatExt;
 
     #[test]
     fn test_circle_value_bounds() {

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -1,10 +1,9 @@
 //! Processors for dual-axis input values
 
-use bevy::math::BVec2;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
-use bevy::prelude::{Reflect, Vec2};
+use bevy::prelude::{BVec2, Reflect, Vec2};
 use bevy::utils::FloatOrd;
 use serde::{Deserialize, Serialize};
 

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -488,7 +488,7 @@ mod tests {
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(!InputStreams::from(&input_streams).pressed(Modifier::Control));
 
-        input_streams.send_input(KeyCode::ControlLeft);
+        input_streams.press_input(KeyCode::ControlLeft);
         app.update();
 
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
@@ -500,7 +500,7 @@ mod tests {
         let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
         assert!(!InputStreams::from(&input_streams).pressed(Modifier::Control));
 
-        input_streams.send_input(KeyCode::ControlRight);
+        input_streams.press_input(KeyCode::ControlRight);
         app.update();
 
         let input_streams = MutableInputStreams::from_world(&mut app.world, None);

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -111,8 +111,8 @@ fn two_inputs_clash_handling() {
     let mut app = test_app();
 
     // Two inputs
-    app.send_input(Digit1);
-    app.send_input(Digit2);
+    app.press_input(Digit1);
+    app.press_input(Digit2);
     app.update();
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, Two, OneAndTwo]);
@@ -128,9 +128,9 @@ fn three_inputs_clash_handling() {
 
     // Three inputs
     app.reset_inputs();
-    app.send_input(Digit1);
-    app.send_input(Digit2);
-    app.send_input(Digit3);
+    app.press_input(Digit1);
+    app.press_input(Digit2);
+    app.press_input(Digit3);
     app.update();
 
     app.assert_input_map_actions_eq(
@@ -149,10 +149,10 @@ fn modifier_clash_handling() {
 
     // Modifier
     app.reset_inputs();
-    app.send_input(Digit1);
-    app.send_input(Digit2);
-    app.send_input(Digit3);
-    app.send_input(ControlLeft);
+    app.press_input(Digit1);
+    app.press_input(Digit2);
+    app.press_input(Digit3);
+    app.press_input(ControlLeft);
     app.update();
 
     app.assert_input_map_actions_eq(
@@ -174,9 +174,9 @@ fn multiple_modifiers_clash_handling() {
 
     // Multiple modifiers
     app.reset_inputs();
-    app.send_input(Digit1);
-    app.send_input(ControlLeft);
-    app.send_input(AltLeft);
+    app.press_input(Digit1);
+    app.press_input(ControlLeft);
+    app.press_input(AltLeft);
     app.update();
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [One, CtrlOne, AltOne, CtrlAltOne]);
@@ -192,8 +192,8 @@ fn action_order_clash_handling() {
 
     // Action order
     app.reset_inputs();
-    app.send_input(Digit3);
-    app.send_input(Digit2);
+    app.press_input(Digit3);
+    app.press_input(Digit2);
     app.update();
 
     app.assert_input_map_actions_eq(ClashStrategy::PressAll, [Two, TwoAndThree]);

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -3,7 +3,7 @@ use bevy::input::gamepad::{
 };
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::axislike::{AxisType, DualAxisData};
+use leafwing_input_manager::axislike::DualAxisData;
 use leafwing_input_manager::prelude::*;
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
@@ -75,13 +75,9 @@ fn game_pad_single_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [-1.0]);
 
-    app.send_input(input);
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 1);
 }
@@ -93,13 +89,9 @@ fn game_pad_dual_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = DualAxis {
-        x_axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        y_axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        processor: CircleDeadZone::default().into(),
-        value: Some(Vec2::X),
-    };
-    app.send_input(input);
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [1.0, 0.0]);
+
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
@@ -120,79 +112,51 @@ fn game_pad_single_axis() {
     ]));
 
     // +X
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
     // Usually a small deadzone threshold will be set
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: Some(0.0),
-        processor: AxisDeadZone::default().into(),
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, [0.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
-    // None
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: None,
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    // No value
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, []);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // Scaled value
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(0.2),
-        processor: AxisDeadZone::default().into(),
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [0.2]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
@@ -218,48 +182,32 @@ fn game_pad_single_axis_inverted() {
     ]));
 
     // +X
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(1.),
-        processor: AxisProcessor::Inverted,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
     assert_eq!(action_state.value(&AxislikeTestAction::X), -1.0);
 
     // -X
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickX),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickX);
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
     assert_eq!(action_state.value(&AxislikeTestAction::X), 1.0);
 
     // +Y
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
     assert_eq!(action_state.value(&AxislikeTestAction::Y), -1.0);
 
     // -Y
-    let input = SingleAxis {
-        axis_type: AxisType::Gamepad(GamepadAxisType::LeftStickY),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::new(GamepadAxisType::LeftStickY);
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
@@ -271,17 +219,12 @@ fn game_pad_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::default()),
+        DualAxis::left_stick().replace_processor(DualAxisDeadZone::magnitude_all(0.1)),
     )]));
 
     // Test that an input inside the dual-axis deadzone is filtered out.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.04,
-        0.1,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.04, 0.1]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -293,13 +236,8 @@ fn game_pad_dual_axis_deadzone() {
     );
 
     // Test that an input outside the dual-axis deadzone is not filtered out.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        1.0,
-        0.2,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [1.0, 0.2]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -311,13 +249,8 @@ fn game_pad_dual_axis_deadzone() {
     );
 
     // Test that each axis of the dual-axis deadzone is filtered independently.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.8,
-        0.1,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.8, 0.1]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -334,17 +267,12 @@ fn game_pad_circle_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(CircleDeadZone::default()),
+        DualAxis::left_stick().replace_processor(CircleDeadZone::new(0.1)),
     )]));
 
     // Test that an input inside the circle deadzone is filtered out, assuming values of 0.1
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.06,
-        0.06,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.06, 0.06]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -356,13 +284,8 @@ fn game_pad_circle_deadzone() {
     );
 
     // Test that an input outside the circle deadzone is not filtered out, assuming values of 0.1
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.2,
-        0.0,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.2, 0.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -379,17 +302,12 @@ fn test_zero_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::ZERO),
+        DualAxis::left_stick().replace_processor(DualAxisDeadZone::magnitude_all(0.0)),
     )]));
 
     // Test that an input of zero will be `None` even with no deadzone.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.0,
-        0.0,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.0, 0.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -406,17 +324,12 @@ fn test_zero_circle_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(CircleDeadZone::ZERO),
+        DualAxis::left_stick().replace_processor(CircleDeadZone::new(0.0)),
     )]));
 
     // Test that an input of zero will be `None` even with no deadzone.
-    app.send_input(DualAxis::from_value(
-        GamepadAxisType::LeftStickX,
-        GamepadAxisType::LeftStickY,
-        0.0,
-        0.0,
-    ));
-
+    let input = DualAxis::left_stick();
+    app.send_axis_values(input, [0.0, 0.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -437,17 +350,17 @@ fn game_pad_virtual_dpad() {
         VirtualDPad::dpad(),
     )]));
 
-    app.send_input(GamepadButtonType::DPadLeft);
+    app.press_input(GamepadButtonType::DPadLeft);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
-    // This should be a unit length, because we're working with a VirtualDpad
+    // This should be a unit length, because we're working with a VirtualDPad
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 1.0);
     assert_eq!(
         action_state.axis_pair(&AxislikeTestAction::XY).unwrap(),
-        // This should be a unit length, because we're working with a VirtualDpad
+        // This should be a unit length, because we're working with a VirtualDPad
         DualAxisData::new(-1.0, 0.0)
     );
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -71,7 +71,7 @@ fn disable_input() {
         .add_systems(PreUpdate, respect_fades);
 
     // Press F to pay respects
-    app.send_input(KeyCode::KeyF);
+    app.press_input(KeyCode::KeyF);
     app.update();
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(true));
@@ -86,7 +86,7 @@ fn disable_input() {
     assert_eq!(*respect, Respect(false));
 
     // And even pressing F cannot bring it back
-    app.send_input(KeyCode::KeyF);
+    app.press_input(KeyCode::KeyF);
     app.update();
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(false));
@@ -113,7 +113,7 @@ fn release_when_input_map_removed() {
         .add_systems(PreUpdate, respect_fades);
 
     // Press F to pay respects
-    app.send_input(KeyCode::KeyF);
+    app.press_input(KeyCode::KeyF);
     app.update();
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(true));
@@ -129,7 +129,7 @@ fn release_when_input_map_removed() {
     assert_eq!(*respect, Respect(false));
 
     // And even pressing F cannot bring it back
-    app.send_input(KeyCode::KeyF);
+    app.press_input(KeyCode::KeyF);
     app.update();
     let respect = app.world.resource::<Respect>();
     assert_eq!(*respect, Respect(false));
@@ -243,7 +243,7 @@ fn duration() {
     app.update();
 
     // Press
-    app.send_input(KeyCode::KeyF);
+    app.press_input(KeyCode::KeyF);
 
     // Hold
     std::thread::sleep(2 * RESPECTFUL_DURATION);

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -1,7 +1,7 @@
 use bevy::input::mouse::MouseMotion;
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::axislike::{AxisType, DualAxisData, MouseMotionAxisType};
+use leafwing_input_manager::axislike::DualAxisData;
 use leafwing_input_manager::buttonlike::MouseMotionDirection;
 use leafwing_input_manager::prelude::*;
 
@@ -48,7 +48,7 @@ fn raw_mouse_motion_events() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::X,
-        SingleAxis::from_value(AxisType::MouseMotion(MouseMotionAxisType::Y), 1.0),
+        SingleAxis::mouse_motion_y(),
     )]));
 
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
@@ -67,7 +67,7 @@ fn mouse_motion_discrete_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
-    app.send_input(MouseMotionDirection::Up);
+    app.press_input(MouseMotionDirection::Up);
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
 
     assert_eq!(events.drain().count(), 1);
@@ -79,13 +79,9 @@ fn mouse_motion_single_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
+    let input = SingleAxis::mouse_motion_x();
+    app.send_axis_values(input, [-1.0]);
 
-    app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 1);
 }
@@ -96,13 +92,9 @@ fn mouse_motion_dual_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = DualAxis {
-        x_axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
-        y_axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-        processor: DualAxisProcessor::None,
-        value: Some(Vec2::X),
-    };
-    app.send_input(input);
+    let input = DualAxis::mouse_motion();
+    app.send_axis_values(input, [1.0, 0.0]);
+
     let mut events = app.world.resource_mut::<Events<MouseMotion>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
@@ -123,7 +115,7 @@ fn mouse_motion_buttonlike() {
         // Get the first associated input
         let input = input_map.get(action).unwrap().first().unwrap().clone();
 
-        app.send_input(input.clone());
+        app.press_input(input.clone());
         app.update();
 
         let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
@@ -141,8 +133,8 @@ fn mouse_motion_buttonlike_cancels() {
         (ButtonlikeTestAction::Right, MouseMotionDirection::Right),
     ]));
 
-    app.send_input(MouseMotionDirection::Up);
-    app.send_input(MouseMotionDirection::Down);
+    app.press_input(MouseMotionDirection::Up);
+    app.press_input(MouseMotionDirection::Down);
 
     // Correctly flushes the world
     app.update();
@@ -162,68 +154,43 @@ fn mouse_motion_single_axis() {
     ]));
 
     // +X
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_x();
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::X),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_x();
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_y();
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_y();
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
-    // Usually a small deadzone threshold will be set
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-        value: Some(0.0),
-        processor: AxisDeadZone::default().into(),
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_y();
+    app.send_axis_values(input, [0.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // None
-    let input = SingleAxis {
-        axis_type: AxisType::MouseMotion(MouseMotionAxisType::Y),
-        value: None,
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_motion_y();
+    app.send_axis_values(input, []);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
@@ -237,13 +204,8 @@ fn mouse_motion_dual_axis() {
         DualAxis::mouse_motion(),
     )]));
 
-    app.send_input(DualAxis::from_value(
-        MouseMotionAxisType::X,
-        MouseMotionAxisType::Y,
-        5.0,
-        0.0,
-    ));
-
+    let input = DualAxis::mouse_motion();
+    app.send_axis_values(input, [5.0, 0.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -264,22 +226,18 @@ fn mouse_motion_virtual_dpad() {
         VirtualDPad::mouse_motion(),
     )]));
 
-    app.send_input(DualAxis::from_value(
-        MouseMotionAxisType::X,
-        MouseMotionAxisType::Y,
-        0.0,
-        -2.0,
-    ));
+    let input = DualAxis::mouse_motion();
+    app.send_axis_values(input, [0.0, -2.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
-    // This should be a unit length, because we're working with a VirtualDpad
+    // This should be a unit length, because we're working with a VirtualDPad
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 1.0);
     assert_eq!(
         action_state.axis_pair(&AxislikeTestAction::XY).unwrap(),
-        // This should be a unit length, because we're working with a VirtualDpad
+        // This should be a unit length, because we're working with a VirtualDPad
         DualAxisData::new(0.0, -1.0)
     );
 }
@@ -300,13 +258,9 @@ fn mouse_drag() {
 
     app.insert_resource(input_map);
 
-    app.send_input(DualAxis::from_value(
-        MouseMotionAxisType::X,
-        MouseMotionAxisType::Y,
-        5.0,
-        0.0,
-    ));
-    app.send_input(MouseButton::Right);
+    let input = DualAxis::mouse_motion();
+    app.send_axis_values(input, [5.0, 0.0]);
+    app.press_input(MouseButton::Right);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -1,7 +1,7 @@
 use bevy::input::mouse::{MouseScrollUnit, MouseWheel};
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
-use leafwing_input_manager::axislike::{AxisType, DualAxisData};
+use leafwing_input_manager::axislike::DualAxisData;
 use leafwing_input_manager::prelude::*;
 
 #[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
@@ -64,7 +64,7 @@ fn mouse_wheel_discrete_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
-    app.send_input(MouseWheelDirection::Up);
+    app.press_input(MouseWheelDirection::Up);
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
 
     assert_eq!(events.drain().count(), 1);
@@ -76,13 +76,9 @@ fn mouse_wheel_single_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
+    let input = SingleAxis::mouse_wheel_x();
+    app.send_axis_values(input, [-1.0]);
 
-    app.send_input(input);
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 1);
 }
@@ -93,13 +89,9 @@ fn mouse_wheel_dual_axis_mocking() {
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
-    let input = DualAxis {
-        x_axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
-        y_axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-        processor: DualAxisProcessor::None,
-        value: Some(Vec2::X),
-    };
-    app.send_input(input);
+    let input = DualAxis::mouse_wheel();
+    app.send_axis_values(input, [-1.0]);
+
     let mut events = app.world.resource_mut::<Events<MouseWheel>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
@@ -120,7 +112,7 @@ fn mouse_wheel_buttonlike() {
         // Get the first associated input
         let input = input_map.get(action).unwrap().first().unwrap().clone();
 
-        app.send_input(input.clone());
+        app.press_input(input.clone());
         app.update();
 
         let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
@@ -138,8 +130,8 @@ fn mouse_wheel_buttonlike_cancels() {
         (ButtonlikeTestAction::Right, MouseWheelDirection::Right),
     ]));
 
-    app.send_input(MouseWheelDirection::Up);
-    app.send_input(MouseWheelDirection::Down);
+    app.press_input(MouseWheelDirection::Up);
+    app.press_input(MouseWheelDirection::Down);
 
     // Correctly flushes the world
     app.update();
@@ -159,68 +151,43 @@ fn mouse_wheel_single_axis() {
     ]));
 
     // +X
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_x();
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::X),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_x();
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-        value: Some(1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_y();
+    app.send_axis_values(input, [1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-        value: Some(-1.),
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_y();
+    app.send_axis_values(input, [-1.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
-    // Usually a small deadzone threshold will be set
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-        value: Some(0.0),
-        processor: AxisDeadZone::default().into(),
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_y();
+    app.send_axis_values(input, [0.0]);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // None
-    let input = SingleAxis {
-        axis_type: AxisType::MouseWheel(MouseWheelAxisType::Y),
-        value: None,
-        processor: AxisProcessor::None,
-    };
-    app.send_input(input);
+    let input = SingleAxis::mouse_wheel_y();
+    app.send_axis_values(input, []);
     app.update();
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
@@ -234,13 +201,8 @@ fn mouse_wheel_dual_axis() {
         DualAxis::mouse_wheel(),
     )]));
 
-    app.send_input(DualAxis::from_value(
-        MouseWheelAxisType::X,
-        MouseWheelAxisType::Y,
-        5.0,
-        0.0,
-    ));
-
+    let input = DualAxis::mouse_wheel();
+    app.send_axis_values(input, [5.0, 0.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
@@ -261,22 +223,18 @@ fn mouse_wheel_virtualdpad() {
         VirtualDPad::mouse_wheel(),
     )]));
 
-    app.send_input(DualAxis::from_value(
-        MouseWheelAxisType::X,
-        MouseWheelAxisType::Y,
-        0.0,
-        -2.0,
-    ));
+    let input = DualAxis::mouse_wheel();
+    app.send_axis_values(input, [0.0, -2.0]);
     app.update();
 
     let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
-    // This should be a unit length, because we're working with a VirtualDpad
+    // This should be a unit length, because we're working with a VirtualDPad
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 1.0);
     assert_eq!(
         action_state.axis_pair(&AxislikeTestAction::XY).unwrap(),
-        // This should be a unit length, because we're working with a VirtualDpad
+        // This should be a unit length, because we're working with a VirtualDPad
         DualAxisData::new(0.0, -1.0)
     );
 }


### PR DESCRIPTION
- should be merged once #514 was merged.
- added new methods for sending value changed events to each axis within the input:
  - `fn send_axis_values(&self, input: UserInput, values: impl IntoIterator<Item = f32>)`.
  - `fn send_axis_values_as_gamepad(&self, input: UserInput, values: impl IntoIterator<Item = f32>, gamepad: Option<Gamepad>)`.
- renamed `MockInput::send_input` method to `MockInput::press_input` to better reflect its current functionality for clarity.
- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking API.

# Migration Guide

If you were using the `send_input` method for buttons and keys to send simulated pressed events, simply update the method name to `press_input`.

If you were using the `value` field or the `from_value` method to create a `SingleAxis` or `DualAxis` instance for sending simulated input events, you can remove them entirely.
Simply use a normal version of these inputs and call the `send_axis_values` method with your desired values.