### PR TITLE
Enhance consistency of methods for processors and `WithProcessorExt` traits

### DIFF
--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -36,7 +36,7 @@ fn spawn_player(mut commands: Commands) {
             // Add an AxisDeadzone to process horizontal values of the right stick.
             // This will trigger if the axis is moved 10% or more in either direction.
             Action::Rudder,
-            SingleAxis::new(GamepadAxisType::RightStickX).with_deadzone_magnitude(0.1),
+            SingleAxis::new(GamepadAxisType::RightStickX).with_deadzone_symmetric(0.1),
         );
     commands
         .spawn(InputManagerBundle::with_map(input_map))

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -202,6 +202,13 @@ pub trait WithDualAxisProcessorExt: Sized {
     }
 
     /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting values within the same range `[-threshold, threshold]` on both axes.
+    #[inline]
+    fn with_bounds_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisBounds::symmetric_all(threshold))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
     /// only restricting values within the range `[min, max]` on the X-axis.
     #[inline]
     fn with_bounds_x(self, min: f32, max: f32) -> Self {
@@ -209,10 +216,24 @@ pub trait WithDualAxisProcessorExt: Sized {
     }
 
     /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting values within the range `[-threshold, threshold]` on the X-axis.
+    #[inline]
+    fn with_bounds_x_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisBounds::symmetric_all(threshold))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
     /// only restricting values within the range `[min, max]` on the Y-axis.
     #[inline]
     fn with_bounds_y(self, min: f32, max: f32) -> Self {
         self.with_processor(DualAxisBounds::only_y(min, max))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting values within the range `[-threshold, threshold]` on the Y-axis.
+    #[inline]
+    fn with_bounds_y_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisBounds::symmetric_all(threshold))
     }
 
     /// Appends a [`CircleBounds`] processor as the next processing step,
@@ -223,33 +244,63 @@ pub trait WithDualAxisProcessorExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[-threshold, threshold]` on both axes,
+    /// excluding values within the dead zone range `[min, max]` on both axes,
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::magnitude_all(1.0)`](DualAxisBounds::default)
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
     /// after dead zone exclusion.
     #[inline]
-    fn with_deadzone(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::magnitude_all(threshold))
+    fn with_deadzone(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::all(min, max))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// excluding values within the dead zone range `[-threshold, threshold]` on both axes,
+    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
+    /// after dead zone exclusion.
+    #[inline]
+    fn with_deadzone_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::symmetric_all(threshold))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// excluding values within the dead zone range `[min, max]` on the X-axis,
+    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
+    /// after dead zone exclusion.
+    #[inline]
+    fn with_deadzone_x(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_x(min, max))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// excluding values within the dead zone range `[-threshold, threshold]` on the X-axis,
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::magnitude_all(1.0)`](DualAxisBounds::default)
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
     /// after dead zone exclusion.
     #[inline]
-    fn with_deadzone_x(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::magnitude_only_x(threshold))
+    fn with_deadzone_x_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::symmetric_only_x(threshold))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// excluding values within the dead zone range `[min, max]` on the Y-axis,
+    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
+    /// after dead zone exclusion.
+    #[inline]
+    fn with_deadzone_y(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_y(min, max))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// excluding values within the deadzone range `[-threshold, threshold]` on the Y-axis,
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::magnitude_all(1.0)`](DualAxisBounds::default)
+    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
     /// after dead zone exclusion.
     #[inline]
-    fn with_deadzone_y(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::magnitude_only_y(threshold))
+    fn with_deadzone_y_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::symmetric_only_y(threshold))
     }
 
     /// Appends a [`CircleDeadZone`] processor as the next processing step,
@@ -263,27 +314,51 @@ pub trait WithDualAxisProcessorExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// ignoring values within the dead zone range `[min, max]` on both axes,
+    /// treating them as zeros.
+    #[inline]
+    fn with_deadzone_unscaled(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::all(min, max))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// ignoring values within the dead zone range `[-threshold, threshold]` on both axes,
     /// treating them as zeros.
     #[inline]
-    fn with_deadzone_unscaled(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisExclusion::magnitude_all(threshold))
+    fn with_deadzone_symmetric_unscaled(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisExclusion::symmetric_all(threshold))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only ignoring values within the dead zone range `[min, max]` on the X-axis,
+    /// treating them as zeros.
+    #[inline]
+    fn with_deadzone_x_unscaled(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_x(min, max))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// only ignoring values within the dead zone range `[-threshold, threshold]` on the X-axis,
     /// treating them as zeros.
     #[inline]
-    fn with_deadzone_x_unscaled(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisExclusion::magnitude_only_x(threshold))
+    fn with_deadzone_x_symmetric_unscaled(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisExclusion::symmetric_only_x(threshold))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only ignoring values within the dead zone range `[min, max]` on the Y-axis,
+    /// treating them as zeros.
+    #[inline]
+    fn with_deadzone_y_unscaled(self, min: f32, max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_y(min, max))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// only ignoring values within the dead zone range `[-threshold, threshold]` on the Y-axis,
     /// treating them as zeros.
     #[inline]
-    fn with_deadzone_y_unscaled(self, threshold: f32) -> Self {
-        self.with_processor(DualAxisExclusion::magnitude_only_y(threshold))
+    fn with_deadzone_y_symmetric_unscaled(self, threshold: f32) -> Self {
+        self.with_processor(DualAxisExclusion::symmetric_only_y(threshold))
     }
 
     /// Appends a [`CircleExclusion`] processor as the next processing step,

--- a/src/input_processing/dual_axis/range.rs
+++ b/src/input_processing/dual_axis/range.rs
@@ -131,12 +131,12 @@ impl DualAxisBounds {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold_x: f32, threshold_y: f32) -> Self {
+    pub fn symmetric(threshold_x: f32, threshold_y: f32) -> Self {
         Self {
-            bounds_x: AxisBounds::magnitude(threshold_x),
-            bounds_y: AxisBounds::magnitude(threshold_y),
+            bounds_x: AxisBounds::symmetric(threshold_x),
+            bounds_y: AxisBounds::symmetric(threshold_y),
         }
     }
 
@@ -149,10 +149,10 @@ impl DualAxisBounds {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_all")]
+    #[doc(alias = "magnitude_all")]
     #[inline]
-    pub fn magnitude_all(threshold: f32) -> Self {
-        Self::magnitude(threshold, threshold)
+    pub fn symmetric_all(threshold: f32) -> Self {
+        Self::symmetric(threshold, threshold)
     }
 
     /// Creates a [`DualAxisBounds`] that only restricts X values within the range `[-threshold, threshold]`.
@@ -164,11 +164,11 @@ impl DualAxisBounds {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_x")]
+    #[doc(alias = "magnitude_only_x")]
     #[inline]
-    pub fn magnitude_only_x(threshold: f32) -> Self {
+    pub fn symmetric_only_x(threshold: f32) -> Self {
         Self {
-            bounds_x: AxisBounds::magnitude(threshold),
+            bounds_x: AxisBounds::symmetric(threshold),
             ..Self::FULL_RANGE
         }
     }
@@ -182,11 +182,11 @@ impl DualAxisBounds {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_y")]
+    #[doc(alias = "magnitude_only_y")]
     #[inline]
-    pub fn magnitude_only_y(threshold: f32) -> Self {
+    pub fn symmetric_only_y(threshold: f32) -> Self {
         Self {
-            bounds_y: AxisBounds::magnitude(threshold),
+            bounds_y: AxisBounds::symmetric(threshold),
             ..Self::FULL_RANGE
         }
     }
@@ -488,12 +488,12 @@ impl DualAxisExclusion {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold_x: f32, threshold_y: f32) -> Self {
+    pub fn symmetric(threshold_x: f32, threshold_y: f32) -> Self {
         Self {
-            exclusion_x: AxisExclusion::magnitude(threshold_x),
-            exclusion_y: AxisExclusion::magnitude(threshold_y),
+            exclusion_x: AxisExclusion::symmetric(threshold_x),
+            exclusion_y: AxisExclusion::symmetric(threshold_y),
         }
     }
 
@@ -506,10 +506,10 @@ impl DualAxisExclusion {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_all")]
+    #[doc(alias = "magnitude_all")]
     #[inline]
-    pub fn magnitude_all(threshold: f32) -> Self {
-        Self::magnitude(threshold, threshold)
+    pub fn symmetric_all(threshold: f32) -> Self {
+        Self::symmetric(threshold, threshold)
     }
 
     /// Creates a [`DualAxisExclusion`] that only ignores X values within the range `[-threshold, threshold]`.
@@ -521,11 +521,11 @@ impl DualAxisExclusion {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_x")]
+    #[doc(alias = "magnitude_only_x")]
     #[inline]
-    pub fn magnitude_only_x(threshold: f32) -> Self {
+    pub fn symmetric_only_x(threshold: f32) -> Self {
         Self {
-            exclusion_x: AxisExclusion::magnitude(threshold),
+            exclusion_x: AxisExclusion::symmetric(threshold),
             ..Self::ZERO
         }
     }
@@ -539,11 +539,11 @@ impl DualAxisExclusion {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_y")]
+    #[doc(alias = "magnitude_only_y")]
     #[inline]
-    pub fn magnitude_only_y(threshold: f32) -> Self {
+    pub fn symmetric_only_y(threshold: f32) -> Self {
         Self {
-            exclusion_y: AxisExclusion::magnitude(threshold),
+            exclusion_y: AxisExclusion::symmetric(threshold),
             ..Self::ZERO
         }
     }
@@ -660,7 +660,7 @@ impl From<AxisExclusion> for DualAxisProcessor {
 }
 
 /// A scaled version of [`DualAxisExclusion`] with the bounds
-/// set to [`DualAxisBounds::magnitude_all(1.0)`](DualAxisBounds::default)
+/// set to [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
 /// that normalizes non-excluded input values into the "live zone",
 /// the remaining range within the bounds after dead zone exclusion.
 ///
@@ -791,12 +791,12 @@ impl DualAxisDeadZone {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold_x: f32, threshold_y: f32) -> Self {
+    pub fn symmetric(threshold_x: f32, threshold_y: f32) -> Self {
         Self {
-            deadzone_x: AxisDeadZone::magnitude(threshold_x),
-            deadzone_y: AxisDeadZone::magnitude(threshold_y),
+            deadzone_x: AxisDeadZone::symmetric(threshold_x),
+            deadzone_y: AxisDeadZone::symmetric(threshold_y),
         }
     }
 
@@ -809,10 +809,10 @@ impl DualAxisDeadZone {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_all")]
+    #[doc(alias = "magnitude_all")]
     #[inline]
-    pub fn magnitude_all(threshold: f32) -> Self {
-        Self::magnitude(threshold, threshold)
+    pub fn symmetric_all(threshold: f32) -> Self {
+        Self::symmetric(threshold, threshold)
     }
 
     /// Creates a [`DualAxisDeadZone`] that only excludes X values within the range `[-threshold, threshold]`.
@@ -824,11 +824,11 @@ impl DualAxisDeadZone {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_x")]
+    #[doc(alias = "magnitude_only_x")]
     #[inline]
-    pub fn magnitude_only_x(threshold: f32) -> Self {
+    pub fn symmetric_only_x(threshold: f32) -> Self {
         Self {
-            deadzone_x: AxisDeadZone::magnitude(threshold),
+            deadzone_x: AxisDeadZone::symmetric(threshold),
             ..Self::ZERO
         }
     }
@@ -842,11 +842,11 @@ impl DualAxisDeadZone {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric_only_y")]
+    #[doc(alias = "magnitude_only_y")]
     #[inline]
-    pub fn magnitude_only_y(threshold: f32) -> Self {
+    pub fn symmetric_only_y(threshold: f32) -> Self {
         Self {
-            deadzone_y: AxisDeadZone::magnitude(threshold),
+            deadzone_y: AxisDeadZone::symmetric(threshold),
             ..Self::ZERO
         }
     }
@@ -1078,16 +1078,16 @@ mod tests {
         let bounds = DualAxisBounds::only_y(-1.0, 1.5);
         test_bounds(bounds, full_range, (-1.0, 1.5));
 
-        let bounds = DualAxisBounds::magnitude(2.0, 2.5);
+        let bounds = DualAxisBounds::symmetric(2.0, 2.5);
         test_bounds(bounds, (-2.0, 2.0), (-2.5, 2.5));
 
-        let bounds = DualAxisBounds::magnitude_all(2.5);
+        let bounds = DualAxisBounds::symmetric_all(2.5);
         test_bounds(bounds, (-2.5, 2.5), (-2.5, 2.5));
 
-        let bounds = DualAxisBounds::magnitude_only_x(2.5);
+        let bounds = DualAxisBounds::symmetric_only_x(2.5);
         test_bounds(bounds, (-2.5, 2.5), full_range);
 
-        let bounds = DualAxisBounds::magnitude_only_y(2.5);
+        let bounds = DualAxisBounds::symmetric_only_y(2.5);
         test_bounds(bounds, full_range, (-2.5, 2.5));
 
         let bounds = DualAxisBounds::at_least(2.0, 2.5);
@@ -1214,16 +1214,16 @@ mod tests {
         let exclusion = DualAxisExclusion::only_y(-0.1, 0.4);
         test_exclusion(exclusion, zero_size, (-0.1, 0.4));
 
-        let exclusion = DualAxisExclusion::magnitude(0.2, 0.3);
+        let exclusion = DualAxisExclusion::symmetric(0.2, 0.3);
         test_exclusion(exclusion, (-0.2, 0.2), (-0.3, 0.3));
 
-        let exclusion = DualAxisExclusion::magnitude_all(0.3);
+        let exclusion = DualAxisExclusion::symmetric_all(0.3);
         test_exclusion(exclusion, (-0.3, 0.3), (-0.3, 0.3));
 
-        let exclusion = DualAxisExclusion::magnitude_only_x(0.3);
+        let exclusion = DualAxisExclusion::symmetric_only_x(0.3);
         test_exclusion(exclusion, (-0.3, 0.3), zero_size);
 
-        let exclusion = DualAxisExclusion::magnitude_only_y(0.3);
+        let exclusion = DualAxisExclusion::symmetric_only_y(0.3);
         test_exclusion(exclusion, zero_size, (-0.3, 0.3));
 
         let exclusion_x = AxisExclusion::new(-0.2, 0.3);
@@ -1353,16 +1353,16 @@ mod tests {
         let deadzone = DualAxisDeadZone::only_y(-0.1, 0.4);
         test_deadzone(deadzone, zero_size, (-0.1, 0.4));
 
-        let deadzone = DualAxisDeadZone::magnitude(0.2, 0.3);
+        let deadzone = DualAxisDeadZone::symmetric(0.2, 0.3);
         test_deadzone(deadzone, (-0.2, 0.2), (-0.3, 0.3));
 
-        let deadzone = DualAxisDeadZone::magnitude_all(0.3);
+        let deadzone = DualAxisDeadZone::symmetric_all(0.3);
         test_deadzone(deadzone, (-0.3, 0.3), (-0.3, 0.3));
 
-        let deadzone = DualAxisDeadZone::magnitude_only_x(0.3);
+        let deadzone = DualAxisDeadZone::symmetric_only_x(0.3);
         test_deadzone(deadzone, (-0.3, 0.3), zero_size);
 
-        let deadzone = DualAxisDeadZone::magnitude_only_y(0.3);
+        let deadzone = DualAxisDeadZone::symmetric_only_y(0.3);
         test_deadzone(deadzone, zero_size, (-0.3, 0.3));
 
         let deadzone_x = AxisDeadZone::new(-0.2, 0.3);

--- a/src/input_processing/mod.rs
+++ b/src/input_processing/mod.rs
@@ -80,10 +80,10 @@
 //! the remaining region within the bounds after dead zone exclusion.
 //!
 //! - [`AxisDeadZone`]: A scaled version of [`AxisExclusion`] with the bounds
-//!     set to [`AxisBounds::magnitude(1.0)`](AxisBounds::default),
+//!     set to [`AxisBounds::symmetric(1.0)`](AxisBounds::default),
 //!     implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
 //! - [`DualAxisDeadZone`]: A scaled version of [`DualAxisExclusion`] with the bounds
-//!     set to [`DualAxisBounds::magnitude_all(1.0)`](DualAxisBounds::default), implemented [`Into<DualAxisProcessor>`].
+//!     set to [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default), implemented [`Into<DualAxisProcessor>`].
 //! - [`CircleDeadZone`]: A scaled version of [`CircleExclusion`] with the bounds
 //!     set to [`CircleBounds::new(1.0)`](CircleBounds::default), implemented [`Into<DualAxisProcessor>`].
 

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -200,8 +200,8 @@ pub trait WithAxisProcessorExt: Sized {
     /// Appends an [`AxisBounds`] processor as the next processing step,
     /// restricting values to a `threshold` magnitude.
     #[inline]
-    fn with_symmetric_bounds(self, threshold: f32) -> Self {
-        self.with_processor(AxisBounds::magnitude(threshold))
+    fn with_bounds_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(AxisBounds::symmetric(threshold))
     }
 
     /// Appends an [`AxisDeadZone`] processor as the next processing step,
@@ -215,13 +215,13 @@ pub trait WithAxisProcessorExt: Sized {
     }
 
     /// Appends an [`AxisDeadZone`] processor as the next processing step,
-    /// excluding values below a `threshold` magnitude, treating them as zeros
-    /// then normalizing non-excluded input values into the "live zone",
+    /// excluding values within the dead zone range `[-threshold, threshold]` on the axis,
+    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`AxisBounds::magnitude(1.0)`](AxisBounds::default)
     /// after dead zone exclusion.
     #[inline]
-    fn with_deadzone_magnitude(self, threshold: f32) -> Self {
-        self.with_processor(AxisDeadZone::magnitude(threshold))
+    fn with_deadzone_symmetric(self, threshold: f32) -> Self {
+        self.with_processor(AxisDeadZone::symmetric(threshold))
     }
 
     /// Appends an [`AxisExclusion`] processor as the next processing step,
@@ -233,10 +233,11 @@ pub trait WithAxisProcessorExt: Sized {
     }
 
     /// Appends an [`AxisExclusion`] processor as the next processing step,
-    /// ignoring values below a `threshold` magnitude, treating them as zeros.
+    /// ignoring values within the dead zone range `[-threshold, threshold]` on the axis,
+    /// treating them as zeros.
     #[inline]
-    fn with_deadzone_magnitude_unscaled(self, threshold: f32) -> Self {
-        self.with_processor(AxisExclusion::magnitude(threshold))
+    fn with_deadzone_symmetric_unscaled(self, threshold: f32) -> Self {
+        self.with_processor(AxisExclusion::symmetric(threshold))
     }
 }
 

--- a/src/input_processing/single_axis/range.rs
+++ b/src/input_processing/single_axis/range.rs
@@ -69,9 +69,9 @@ impl AxisBounds {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold: f32) -> Self {
+    pub fn symmetric(threshold: f32) -> Self {
         Self::new(-threshold, threshold)
     }
 
@@ -231,9 +231,9 @@ impl AxisExclusion {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold: f32) -> Self {
+    pub fn symmetric(threshold: f32) -> Self {
         Self::new(-threshold, threshold)
     }
 
@@ -418,9 +418,9 @@ impl AxisDeadZone {
     /// # Panics
     ///
     /// Panics if the requirements aren't met.
-    #[doc(alias = "symmetric")]
+    #[doc(alias = "magnitude")]
     #[inline]
-    pub fn magnitude(threshold: f32) -> Self {
+    pub fn symmetric(threshold: f32) -> Self {
         AxisDeadZone::new(-threshold, threshold)
     }
 
@@ -565,7 +565,7 @@ mod tests {
         let bounds = AxisBounds::new(-2.0, 2.5);
         test_bounds(bounds, -2.0, 2.5);
 
-        let bounds = AxisBounds::magnitude(2.0);
+        let bounds = AxisBounds::symmetric(2.0);
         test_bounds(bounds, -2.0, 2.0);
 
         let bounds = AxisBounds::at_least(-1.0);
@@ -609,7 +609,7 @@ mod tests {
         let exclusion = AxisExclusion::new(-2.0, 2.5);
         test_exclusion(exclusion, -2.0, 2.5);
 
-        let exclusion = AxisExclusion::magnitude(1.5);
+        let exclusion = AxisExclusion::symmetric(1.5);
         test_exclusion(exclusion, -1.5, 1.5);
     }
 
@@ -673,7 +673,7 @@ mod tests {
         let deadzone = AxisDeadZone::new(-0.2, 0.3);
         test_deadzone(deadzone, -0.2, 0.3);
 
-        let deadzone = AxisDeadZone::magnitude(0.4);
+        let deadzone = AxisDeadZone::symmetric(0.4);
         test_deadzone(deadzone, -0.4, 0.4);
     }
 }

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -53,7 +53,7 @@ fn raw_gamepad_axis_events() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         ButtonlikeTestAction::Up,
-        SingleAxis::new(GamepadAxisType::RightStickX).with_deadzone_magnitude(0.1),
+        SingleAxis::new(GamepadAxisType::RightStickX).with_deadzone_symmetric(0.1),
     )]));
 
     let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
@@ -103,11 +103,11 @@ fn game_pad_single_axis() {
     app.insert_resource(InputMap::new([
         (
             AxislikeTestAction::X,
-            SingleAxis::new(GamepadAxisType::LeftStickX).with_deadzone_magnitude(0.1),
+            SingleAxis::new(GamepadAxisType::LeftStickX).with_deadzone_symmetric(0.1),
         ),
         (
             AxislikeTestAction::Y,
-            SingleAxis::new(GamepadAxisType::LeftStickY).with_deadzone_magnitude(0.1),
+            SingleAxis::new(GamepadAxisType::LeftStickY).with_deadzone_symmetric(0.1),
         ),
     ]));
 
@@ -170,13 +170,13 @@ fn game_pad_single_axis_inverted() {
         (
             AxislikeTestAction::X,
             SingleAxis::new(GamepadAxisType::LeftStickX)
-                .with_deadzone_magnitude(0.1)
+                .with_deadzone_symmetric(0.1)
                 .inverted(),
         ),
         (
             AxislikeTestAction::Y,
             SingleAxis::new(GamepadAxisType::LeftStickY)
-                .with_deadzone_magnitude(0.1)
+                .with_deadzone_symmetric(0.1)
                 .inverted(),
         ),
     ]));
@@ -219,7 +219,7 @@ fn game_pad_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::magnitude_all(0.1)),
+        DualAxis::left_stick().replace_processor(DualAxisDeadZone::symmetric_all(0.1)),
     )]));
 
     // Test that an input inside the dual-axis deadzone is filtered out.
@@ -302,7 +302,7 @@ fn test_zero_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::magnitude_all(0.0)),
+        DualAxis::left_stick().replace_processor(DualAxisDeadZone::symmetric_all(0.0)),
     )]));
 
     // Test that an input of zero will be `None` even with no deadzone.


### PR DESCRIPTION
- Renamed all `magnitude_` methods of range processors and WithProcessorExt traits to `_symmetric` for clarity
- Added more methods that append range processor for both negative and positive sides, as well as symmetrical ranges