### PR TITLE
Rename `WithProcessorExt` to `WithProcessingPipelineExt` and add methods for processors

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -29,8 +29,6 @@ Input processors allow you to create custom logic for axis-like input manipulati
 - added processor traits for defining custom processors:
   - `CustomAxisProcessor`: Handles single-axis values.
   - `CustomDualAxisProcessor`: Handles dual-axis values.
-- implemented `WithAxisProcessorExt` to manage processors for `SingleAxis` and `VirtualAxis`.
-- implemented `WithDualAxisProcessorExt` to manage processors for `DualAxis` and `VirtualDpad`.
 - added App extensions: `register_axis_processor` and `register_dual_axis_processor` for registration of processors.
 - added built-in processors (variants of processor enums and `Into<Processor>` implementors):
   - Pipelines: Handle input values sequentially through a sequence of processors.
@@ -58,6 +56,8 @@ Input processors allow you to create custom logic for axis-like input manipulati
       - `AxisDeadZone`: Normalizes single-axis values based on `AxisExclusion` and `AxisBounds::default`, implemented `Into<AxisProcessor>` and `Into<DualAxisProcessor>`.
       - `DualAxisDeadZone`: Normalizes dual-axis values based on `DualAxisExclusion` and `DualAxisBounds::default`, implemented `Into<DualAxisProcessor>`.
       - `CircleDeadZone`: Normalizes dual-axis values based on `CircleExclusion` and `CircleBounds::default`, implemented `Into<DualAxisProcessor>`.
+- implemented `WithAxisProcessingPipelineExt` to manage processors for `SingleAxis` and `VirtualAxis`, integrating the common processing configuration.
+- implemented `WithDualAxisProcessingPipelineExt` to manage processors for `DualAxis` and `VirtualDpad`, integrating the common processing configuration.
 
 ### Usability
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -63,17 +63,15 @@ Input processors allow you to create custom logic for axis-like input manipulati
 
 #### InputMap
 
-Introduce new fluent builders for creating a new `InputMap<A>` with short configurations:
+- added new fluent builders for creating a new `InputMap<A>` with short configurations:
+  - `fn with(mut self, action: A, input: impl Into<UserInput>)`.
+  - `fn with_one_to_many(mut self, action: A, inputs: impl IntoIterator<Item = UserInput>)`.
+  - `fn with_multiple(mut self, bindings: impl IntoIterator<Item = (A, UserInput)>) -> Self`.
+  - `fn with_gamepad(mut self, gamepad: Gamepad) -> Self`.
 
-- `fn with(mut self, action: A, input: impl Into<UserInput>)`.
-- `fn with_one_to_many(mut self, action: A, inputs: impl IntoIterator<Item = UserInput>)`.
-- `fn with_multiple(mut self, bindings: impl IntoIterator<Item = (A, UserInput)>) -> Self`.
-- `fn with_gamepad(mut self, gamepad: Gamepad) -> Self`.
-
-Introduce new iterators over `InputMap<A>`:
-
-- `bindings(&self) -> impl Iterator<Item = (&A, &UserInput)>` for iterating over all registered action-input bindings.
-- `actions(&self) -> impl Iterator<Item = &A>` for iterating over all registered actions.
+- added new iterators over `InputMap<A>`:
+  - `actions(&self) -> impl Iterator<Item = &A>` for iterating over all registered actions.
+  - `bindings(&self) -> impl Iterator<Item = (&A, &UserInput)>` for iterating over all registered action-input bindings.
 
 ### Bugs
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -37,8 +37,8 @@ Input processors allow you to create custom logic for axis-like input manipulati
     - `AxisProcessor::Pipeline`: Pipeline for single-axis inputs.
     - `DualAxisProcessor::Pipeline`: Pipeline for dual-axis inputs.
     - you can also create them by these methods:
-      - `AxisProcessor::with_processor` or `FromIterator<AxisProcessor>::from_iter` for `AxisProcessor::Pipeline`.
-      - `DualAxisProcessor::with_processor` or `FromIterator<DualAxisProcessor>::from_iter` for `DualAxisProcessor::Pipeline`.
+      - `AxisProcessor::pipeline` or `AxisProcessor::with_processor` for `AxisProcessor::Pipeline`.
+      - `DualAxisProcessor::pipeline` or `DualAxisProcessor::with_processor` for `DualAxisProcessor::Pipeline`.
   - Inversion: Reverses control (positive becomes negative, etc.)
     - `AxisProcessor::Inverted`: Single-axis inversion.
     - `DualAxisInverted`: Dual-axis inversion, implemented `Into<DualAxisProcessor>`.

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -4,18 +4,18 @@
 
 ### Breaking Changes
 
-- removed `Direction` type in favor of `bevy::math::primitives::Direction2d`.
-- replaced axis-like input handling with new input processors (see 'Enhancements: Input Processors' for details).
-  - removed `DeadZoneShape` in favor of new dead zone processors.
-- made the dependency on bevy's `bevy_gilrs` feature optional.
-  - it is still enabled by leafwing-input-manager's default features.
-  - if you're using leafwing-input-manager with `default_features = false`, you can readd it by adding `bevy/bevy_gilrs` as a dependency.
 - removed `InputMap::build` method in favor of new fluent builder pattern (see 'Usability: InputMap' for details).
 - renamed `InputMap::which_pressed` method to `process_actions` to better reflect its current functionality for clarity.
+- replaced axis-like input handling with new input processors (see 'Enhancements: Input Processors' for details).
+  - removed `DeadZoneShape` in favor of new dead zone processors.
+- removed `Direction` type in favor of `bevy::math::primitives::Direction2d`.
+- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking.
 - split `MockInput::send_input` method to two methods:
   - `fn press_input(&self, input: UserInput)` for focusing on simulating button and key presses.
   - `fn send_axis_values(&self, input: UserInput, values: impl IntoIterator<Item = f32>)` for sending value changed events to each axis of the input.
-- removed the hacky `value` field and `from_value` method from `SingleAxis` and `DualAxis`, in favor of new input mocking.
+- made the dependency on bevy's `bevy_gilrs` feature optional.
+  - it is still enabled by leafwing-input-manager's default features.
+  - if you're using leafwing-input-manager with `default_features = false`, you can readd it by adding `bevy/bevy_gilrs` as a dependency.
 
 ### Enhancements
 
@@ -65,7 +65,7 @@ Input processors allow you to create custom logic for axis-like input manipulati
 
 Introduce new fluent builders for creating a new `InputMap<A>` with short configurations:
 
-- `fn with(mut self, action: A, input: impl Into<Item = UserInput>)`.
+- `fn with(mut self, action: A, input: impl Into<UserInput>)`.
 - `fn with_one_to_many(mut self, action: A, inputs: impl IntoIterator<Item = UserInput>)`.
 - `fn with_multiple(mut self, bindings: impl IntoIterator<Item = (A, UserInput)>) -> Self`.
 - `fn with_gamepad(mut self, gamepad: Gamepad) -> Self`.

--- a/examples/input_processing.rs
+++ b/examples/input_processing.rs
@@ -45,7 +45,7 @@ fn spawn_player(mut commands: Commands) {
         .with(
             Action::LookAround,
             // You can also use a sequence of processors as the processing pipeline.
-            DualAxis::mouse_motion().replace_processor(DualAxisProcessor::from_iter([
+            DualAxis::mouse_motion().replace_processor(DualAxisProcessor::pipeline([
                 // The first processor is a circular deadzone.
                 CircleDeadZone::new(0.1).into(),
                 // The next processor doubles inputs normalized by the deadzone.

--- a/examples/input_processing.rs
+++ b/examples/input_processing.rs
@@ -38,14 +38,14 @@ fn spawn_player(mut commands: Commands) {
             Action::Move,
             DualAxis::left_stick()
                 // You can replace the currently used pipeline with another processor.
-                .replace_processor(CircleDeadZone::default())
-                // Or remove the pipeline directly, leaving no any processing applied.
-                .no_processor(),
+                .replace_processing_pipeline(CircleDeadZone::default())
+                // Or reset the pipeline directly, leaving no any processing applied.
+                .reset_processing_pipeline(),
         )
         .with(
             Action::LookAround,
             // You can also use a sequence of processors as the processing pipeline.
-            DualAxis::mouse_motion().replace_processor(DualAxisProcessor::pipeline([
+            DualAxis::mouse_motion().replace_processing_pipeline(DualAxisProcessor::pipeline([
                 // The first processor is a circular deadzone.
                 CircleDeadZone::new(0.1).into(),
                 // The next processor doubles inputs normalized by the deadzone.

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -76,15 +76,15 @@ impl SingleAxis {
     }
 }
 
-impl WithAxisProcessorExt for SingleAxis {
+impl WithAxisProcessingPipelineExt for SingleAxis {
     #[inline]
-    fn no_processor(mut self) -> Self {
+    fn reset_processing_pipeline(mut self) -> Self {
         self.processor = AxisProcessor::None;
         self
     }
 
     #[inline]
-    fn replace_processor(mut self, processor: impl Into<AxisProcessor>) -> Self {
+    fn replace_processing_pipeline(mut self, processor: impl Into<AxisProcessor>) -> Self {
         self.processor = processor.into();
         self
     }
@@ -188,15 +188,15 @@ impl DualAxis {
     }
 }
 
-impl WithDualAxisProcessorExt for DualAxis {
+impl WithDualAxisProcessingPipelineExt for DualAxis {
     #[inline]
-    fn no_processor(mut self) -> Self {
+    fn reset_processing_pipeline(mut self) -> Self {
         self.processor = DualAxisProcessor::None;
         self
     }
 
     #[inline]
-    fn replace_processor(mut self, processor: impl Into<DualAxisProcessor>) -> Self {
+    fn replace_processing_pipeline(mut self, processor: impl Into<DualAxisProcessor>) -> Self {
         self.processor = processor.into();
         self
     }
@@ -333,15 +333,15 @@ impl VirtualDPad {
     }
 }
 
-impl WithDualAxisProcessorExt for VirtualDPad {
+impl WithDualAxisProcessingPipelineExt for VirtualDPad {
     #[inline]
-    fn no_processor(mut self) -> Self {
+    fn reset_processing_pipeline(mut self) -> Self {
         self.processor = DualAxisProcessor::None;
         self
     }
 
     #[inline]
-    fn replace_processor(mut self, processor: impl Into<DualAxisProcessor>) -> Self {
+    fn replace_processing_pipeline(mut self, processor: impl Into<DualAxisProcessor>) -> Self {
         self.processor = processor.into();
         self
     }
@@ -438,27 +438,6 @@ impl VirtualAxis {
         }
     }
 
-    /// Appends the given [`AxisProcessor`] as the next processing step.
-    #[inline]
-    pub fn with_processor(mut self, processor: impl Into<AxisProcessor>) -> Self {
-        self.processor = self.processor.with_processor(processor);
-        self
-    }
-
-    /// Replaces the current [`AxisProcessor`] with the specified `processor`.
-    #[inline]
-    pub fn replace_processor(mut self, processor: impl Into<AxisProcessor>) -> Self {
-        self.processor = processor.into();
-        self
-    }
-
-    /// Removes the current used [`AxisProcessor`].
-    #[inline]
-    pub fn no_processor(mut self) -> Self {
-        self.processor = AxisProcessor::None;
-        self
-    }
-
     /// Get the "value" of the axis.
     /// If a processor is set, it will compute and return the processed value.
     /// Otherwise, pass the `input_value` through unchanged.
@@ -469,15 +448,15 @@ impl VirtualAxis {
     }
 }
 
-impl WithAxisProcessorExt for VirtualAxis {
+impl WithAxisProcessingPipelineExt for VirtualAxis {
     #[inline]
-    fn no_processor(mut self) -> Self {
+    fn reset_processing_pipeline(mut self) -> Self {
         self.processor = AxisProcessor::None;
         self
     }
 
     #[inline]
-    fn replace_processor(mut self, processor: impl Into<AxisProcessor>) -> Self {
+    fn replace_processing_pipeline(mut self, processor: impl Into<AxisProcessor>) -> Self {
         self.processor = processor.into();
         self
     }

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -528,7 +528,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_axis_processing_pipeline() {
+    fn test_dual_axis_processing_pipeline() {
         let pipeline = DualAxisProcessor::Pipeline(vec![
             Arc::new(DualAxisInverted::ALL.into()),
             Arc::new(DualAxisSensitivity::all(2.0).into()),

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -148,12 +148,12 @@ impl FromIterator<DualAxisProcessor> for DualAxisProcessor {
 }
 
 /// Provides methods for configuring and manipulating the processing pipeline for dual-axis input.
-pub trait WithDualAxisProcessorExt: Sized {
-    /// Remove the current used [`DualAxisProcessor`].
-    fn no_processor(self) -> Self;
+pub trait WithDualAxisProcessingPipelineExt: Sized {
+    /// Reset the current processing pipeline, removing any currently applied processors.
+    fn reset_processing_pipeline(self) -> Self;
 
-    /// Replaces the current pipeline with the specified [`DualAxisProcessor`].
-    fn replace_processor(self, processor: impl Into<DualAxisProcessor>) -> Self;
+    /// Replaces the current processing pipeline with the specified [`DualAxisProcessor`].
+    fn replace_processing_pipeline(self, processor: impl Into<DualAxisProcessor>) -> Self;
 
     /// Appends the given [`DualAxisProcessor`] as the next processing step.
     fn with_processor(self, processor: impl Into<DualAxisProcessor>) -> Self;

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -53,7 +53,7 @@ pub enum DualAxisProcessor {
     /// one for the current step and the other for the next step.
     ///
     /// For a straightforward creation of a [`DualAxisProcessor::Pipeline`],
-    /// you can use [`DualAxisProcessor::with_processor`] or [`FromIterator<DualAxisProcessor>::from_iter`] methods.
+    /// you can use [`DualAxisProcessor::pipeline`] or [`DualAxisProcessor::with_processor`] methods.
     ///
     /// ```rust
     /// use std::sync::Arc;
@@ -83,6 +83,12 @@ pub enum DualAxisProcessor {
 }
 
 impl DualAxisProcessor {
+    /// Creates a [`DualAxisProcessor::Pipeline`] from the given `processors`.
+    #[inline]
+    pub fn pipeline(processors: impl IntoIterator<Item = DualAxisProcessor>) -> Self {
+        Self::from_iter(processors)
+    }
+
     /// Computes the result by processing the `input_value`.
     #[must_use]
     #[inline]
@@ -522,7 +528,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_axis_processor_pipeline() {
+    fn test_axis_processing_pipeline() {
         let pipeline = DualAxisProcessor::Pipeline(vec![
             Arc::new(DualAxisInverted::ALL.into()),
             Arc::new(DualAxisSensitivity::all(2.0).into()),
@@ -540,15 +546,35 @@ mod tests {
     }
 
     #[test]
-    fn test_dual_axis_processor_from_iter() {
+    fn test_dual_axis_processing_pipeline_creation() {
+        assert_eq!(
+            DualAxisProcessor::pipeline([]),
+            DualAxisProcessor::Pipeline(vec![])
+        );
         assert_eq!(
             DualAxisProcessor::from_iter([]),
             DualAxisProcessor::Pipeline(vec![])
         );
 
         assert_eq!(
+            DualAxisProcessor::pipeline([DualAxisInverted::ALL.into()]),
+            DualAxisProcessor::Pipeline(vec![Arc::new(DualAxisInverted::ALL.into())])
+        );
+
+        assert_eq!(
             DualAxisProcessor::from_iter([DualAxisInverted::ALL.into()]),
             DualAxisProcessor::Pipeline(vec![Arc::new(DualAxisInverted::ALL.into())])
+        );
+
+        assert_eq!(
+            DualAxisProcessor::pipeline([
+                DualAxisInverted::ALL.into(),
+                DualAxisSensitivity::all(2.0).into(),
+            ]),
+            DualAxisProcessor::Pipeline(vec![
+                Arc::new(DualAxisInverted::ALL.into()),
+                Arc::new(DualAxisSensitivity::all(2.0).into()),
+            ])
         );
 
         assert_eq!(

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -149,7 +149,7 @@ impl FromIterator<DualAxisProcessor> for DualAxisProcessor {
 
 /// Provides methods for configuring and manipulating the processing pipeline for dual-axis input.
 pub trait WithDualAxisProcessingPipelineExt: Sized {
-    /// Reset the current processing pipeline, removing any currently applied processors.
+    /// Resets the processing pipeline, removing any currently applied processors.
     fn reset_processing_pipeline(self) -> Self;
 
     /// Replaces the current processing pipeline with the specified [`DualAxisProcessor`].

--- a/src/input_processing/mod.rs
+++ b/src/input_processing/mod.rs
@@ -26,8 +26,8 @@
 //!
 //! You can also use these methods to create a pipeline.
 //!
-//! - [`AxisProcessor::with_processor`] or [`FromIterator<AxisProcessor>::from_iter`] for [`AxisProcessor::Pipeline`].
-//! - [`DualAxisProcessor::with_processor`] or [`FromIterator<DualAxisProcessor>::from_iter`] for [`DualAxisProcessor::Pipeline`].
+//! - [`AxisProcessor::pipeline`] or [`AxisProcessor::with_processor`] for [`AxisProcessor::Pipeline`].
+//! - [`DualAxisProcessor::pipeline`] or [`DualAxisProcessor::with_processor`] for [`DualAxisProcessor::Pipeline`].
 //!
 //! ## Inversion
 //!

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -172,12 +172,12 @@ impl Hash for AxisProcessor {
 }
 
 /// Provides methods for configuring and manipulating the processing pipeline for single-axis input.
-pub trait WithAxisProcessorExt: Sized {
-    /// Remove the current used [`AxisProcessor`].
-    fn no_processor(self) -> Self;
+pub trait WithAxisProcessingPipelineExt: Sized {
+    /// Resets the processing pipeline, removing any currently applied processors.
+    fn reset_processing_pipeline(self) -> Self;
 
-    /// Replaces the current pipeline with the specified [`AxisProcessor`].
-    fn replace_processor(self, processor: impl Into<AxisProcessor>) -> Self;
+    /// Replaces the current processing pipeline with the specified [`AxisProcessor`].
+    fn replace_processing_pipeline(self, processor: impl Into<AxisProcessor>) -> Self;
 
     /// Appends the given [`AxisProcessor`] as the next processing step.
     fn with_processor(self, processor: impl Into<AxisProcessor>) -> Self;

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -61,7 +61,7 @@ pub enum AxisProcessor {
     /// Processes input values sequentially through a sequence of [`AxisProcessor`]s.
     ///
     /// For a straightforward creation of a [`AxisProcessor::Pipeline`],
-    /// you can use [`AxisProcessor::with_processor`] or [`FromIterator<AxisProcessor>::from_iter`] methods.
+    /// you can use [`AxisProcessor::pipeline`] or [`AxisProcessor::with_processor`] methods.
     ///
     /// ```rust
     /// use std::sync::Arc;
@@ -92,6 +92,12 @@ pub enum AxisProcessor {
 }
 
 impl AxisProcessor {
+    /// Creates an [`AxisProcessor::Pipeline`] from the given `processors`.
+    #[inline]
+    pub fn pipeline(processors: impl IntoIterator<Item = AxisProcessor>) -> Self {
+        Self::from_iter(processors)
+    }
+
     /// Computes the result by processing the `input_value`.
     #[must_use]
     #[inline]
@@ -270,7 +276,7 @@ mod tests {
     }
 
     #[test]
-    fn test_axis_processor_pipeline() {
+    fn test_axis_processing_pipeline() {
         let pipeline = AxisProcessor::Pipeline(vec![
             Arc::new(AxisProcessor::Inverted),
             Arc::new(AxisProcessor::Sensitivity(2.0)),
@@ -284,15 +290,30 @@ mod tests {
     }
 
     #[test]
-    fn test_axis_processor_from_iter() {
+    fn test_axis_processing_pipeline_creation() {
+        assert_eq!(AxisProcessor::pipeline([]), AxisProcessor::Pipeline(vec![]));
+
         assert_eq!(
             AxisProcessor::from_iter([]),
             AxisProcessor::Pipeline(vec![])
         );
 
         assert_eq!(
+            AxisProcessor::pipeline([AxisProcessor::Inverted]),
+            AxisProcessor::Pipeline(vec![Arc::new(AxisProcessor::Inverted)]),
+        );
+
+        assert_eq!(
             AxisProcessor::from_iter([AxisProcessor::Inverted]),
             AxisProcessor::Pipeline(vec![Arc::new(AxisProcessor::Inverted)]),
+        );
+
+        assert_eq!(
+            AxisProcessor::pipeline([AxisProcessor::Inverted, AxisProcessor::Sensitivity(2.0)]),
+            AxisProcessor::Pipeline(vec![
+                Arc::new(AxisProcessor::Inverted),
+                Arc::new(AxisProcessor::Sensitivity(2.0)),
+            ])
         );
 
         assert_eq!(

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -219,7 +219,7 @@ fn game_pad_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::symmetric_all(0.1)),
+        DualAxis::left_stick().replace_processing_pipeline(DualAxisDeadZone::symmetric_all(0.1)),
     )]));
 
     // Test that an input inside the dual-axis deadzone is filtered out.
@@ -267,7 +267,7 @@ fn game_pad_circle_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(CircleDeadZone::new(0.1)),
+        DualAxis::left_stick().replace_processing_pipeline(CircleDeadZone::new(0.1)),
     )]));
 
     // Test that an input inside the circle deadzone is filtered out, assuming values of 0.1
@@ -302,7 +302,7 @@ fn test_zero_dual_axis_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(DualAxisDeadZone::symmetric_all(0.0)),
+        DualAxis::left_stick().replace_processing_pipeline(DualAxisDeadZone::symmetric_all(0.0)),
     )]));
 
     // Test that an input of zero will be `None` even with no deadzone.
@@ -324,7 +324,7 @@ fn test_zero_circle_deadzone() {
     let mut app = test_app();
     app.insert_resource(InputMap::new([(
         AxislikeTestAction::XY,
-        DualAxis::left_stick().replace_processor(CircleDeadZone::new(0.0)),
+        DualAxis::left_stick().replace_processing_pipeline(CircleDeadZone::new(0.0)),
     )]));
 
     // Test that an input of zero will be `None` even with no deadzone.


### PR DESCRIPTION
- renamed `WithProcessorExt` to `WithProcessingPipelineExt`
- added `Processor::pipeline` methods

Additionally, removed a missing duplicate in `VirtualAxis` and rearranged the RELEASES.md