### PR TITLE
Update to 0.14 release candidate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ bevy = { version = "0.14.0-rc.2", default-features = false, features = [
   "bevy_ui",
   "bevy_render",
   "bevy_core_pipeline",
+  "bevy_state",
   "x11",
 ] }
 bevy_egui = "0.27"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,10 @@ bevy = { version = "0.14.0-rc.2", default-features = false, features = [
   "bevy_core_pipeline",
   "bevy_state",
   "x11",
+  # TODO Remove these before release. See https://github.com/bevyengine/bevy/issues/13728
+  "ktx2",
+  "zstd",
+  "bevy_pbr",
 ] }
 bevy_egui = "0.27"
 serde_test = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,5 +98,4 @@ path = "examples/press_duration.rs"
 required-features = ["timing"]
 
 [patch.crates-io]
-# bevy = { version = "0.14.0-rc.2" }
-bevy_egui = { git = "https://github.com/ChristopherBiscardi/bevy_egui.git", branch = "0.14-rc" }
+bevy_egui = { git = "https://github.com/Friz64/bevy_egui.git", branch = "bevy-0.14" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,9 +41,10 @@ egui = ['dep:bevy_egui']
 
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.13" }
-bevy = { version = "0.13", default-features = false, features = [
+bevy = { version = "0.14.0-rc.2", default-features = false, features = [
   "serialize",
 ] }
+bevy_ecs = { version = "0.14.0-rc.2", features = ["serde"] }
 bevy_egui = { version = "0.27", optional = true }
 
 derive_more = { version = "0.99", default-features = false, features = [
@@ -59,7 +60,8 @@ dyn-hash = "0.2"
 once_cell = "1.19"
 
 [dev-dependencies]
-bevy = { version = "0.13", default-features = false, features = [
+bevy_ecs = { version = "0.14.0-rc.2", features = ["serde"] }
+bevy = { version = "0.14.0-rc.2", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "bevy_text",
@@ -89,3 +91,7 @@ path = "src/lib.rs"
 name = "press_duration"
 path = "examples/press_duration.rs"
 required-features = ["timing"]
+
+[patch.crates-io]
+# bevy = { version = "0.14.0-rc.2" }
+bevy_egui = { git = "https://github.com/ChristopherBiscardi/bevy_egui.git", branch = "0.14-rc" }

--- a/benches/input_map.rs
+++ b/benches/input_map.rs
@@ -81,7 +81,7 @@ pub fn criterion_benchmark(c: &mut Criterion) {
     app.press_input(KeyCode::KeyB);
     app.update();
 
-    let input_streams = InputStreams::from_world(&app.world, None);
+    let input_streams = InputStreams::from_world(app.world(), None);
 
     for clash_strategy in ClashStrategy::variants() {
         which_pressed_group.bench_function(format!("{:?}", clash_strategy), |b| {

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -14,7 +14,7 @@ fn main() {
         .add_systems(Update, report_pressed_actions)
         // Change the value of this resource to change how clashes should be handled in your game
         .insert_resource(ClashStrategy::PrioritizeLongest)
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]

--- a/examples/consuming_actions.rs
+++ b/examples/consuming_actions.rs
@@ -25,7 +25,7 @@ fn main() {
         .add_systems(Update, close_menu::<SubMenu>.before(close_menu::<MainMenu>))
         // We can do this by ordering our systems and using `ActionState::consume`
         .add_systems(Update, close_menu::<MainMenu>)
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, Debug, Clone, Reflect, PartialEq, Eq, Hash)]

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(InputManagerPlugin::<PlayerAction>::default())
         .add_systems(Startup, spawn_player)
         .add_systems(Update, use_actions)
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -7,7 +7,7 @@ fn main() {
         .add_plugins(InputManagerPlugin::<CameraMovement>::default())
         .add_systems(Startup, setup)
         .add_systems(Update, pan_camera)
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Hash, Reflect)]

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -8,7 +8,7 @@ fn main() {
         .add_systems(Startup, setup)
         .add_systems(Update, zoom_camera)
         .add_systems(Update, pan_camera.after(zoom_camera))
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, Clone, Debug, Copy, PartialEq, Eq, Hash, Reflect)]

--- a/examples/register_gamepads.rs
+++ b/examples/register_gamepads.rs
@@ -9,7 +9,7 @@ fn main() {
         .add_plugins(InputManagerPlugin::<Action>::default())
         .init_resource::<JoinedPlayers>()
         .add_systems(Update, (join, jump, disconnect))
-        .run()
+        .run();
 }
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -75,8 +75,8 @@ fn main() {
     // These are converted into actions when the client_app's `Schedule` runs
     client_app.update();
 
-    let mut player_state_query = client_app.world.query::<&ActionState<FpsAction>>();
-    let player_state = player_state_query.iter(&client_app.world).next().unwrap();
+    let mut player_state_query = client_app.world_mut().query::<&ActionState<FpsAction>>();
+    let player_state = player_state_query.iter(&client_app.world()).next().unwrap();
     assert!(player_state.pressed(&FpsAction::Jump));
     assert!(player_state.pressed(&FpsAction::Shoot));
 
@@ -88,16 +88,16 @@ fn main() {
     server_app.update();
 
     // And the actions are pressed on the server!
-    let mut player_state_query = server_app.world.query::<&ActionState<FpsAction>>();
-    let player_state = player_state_query.iter(&server_app.world).next().unwrap();
+    let mut player_state_query = server_app.world_mut().query::<&ActionState<FpsAction>>();
+    let player_state = player_state_query.iter(&server_app.world()).next().unwrap();
     assert!(player_state.pressed(&FpsAction::Jump));
     assert!(player_state.pressed(&FpsAction::Shoot));
 
     // If we wait a tick, the buttons will be released
     client_app.reset_inputs();
     client_app.update();
-    let mut player_state_query = client_app.world.query::<&ActionState<FpsAction>>();
-    let player_state = player_state_query.iter(&client_app.world).next().unwrap();
+    let mut player_state_query = client_app.world_mut().query::<&ActionState<FpsAction>>();
+    let player_state = player_state_query.iter(&client_app.world()).next().unwrap();
     assert!(player_state.released(&FpsAction::Jump));
     assert!(player_state.released(&FpsAction::Shoot));
 
@@ -108,8 +108,8 @@ fn main() {
 
     server_app.update();
 
-    let mut player_state_query = server_app.world.query::<&ActionState<FpsAction>>();
-    let player_state = player_state_query.iter(&server_app.world).next().unwrap();
+    let mut player_state_query = server_app.world_mut().query::<&ActionState<FpsAction>>();
+    let player_state = player_state_query.iter(&server_app.world()).next().unwrap();
     assert!(player_state.released(&FpsAction::Jump));
     assert!(player_state.released(&FpsAction::Shoot));
 }
@@ -140,8 +140,8 @@ fn send_events<A: Send + Sync + 'static + Debug + Clone + Event>(
     server_app: &mut App,
     reader: Option<ManualEventReader<A>>,
 ) -> ManualEventReader<A> {
-    let client_events: &Events<A> = client_app.world.resource();
-    let mut server_events: Mut<Events<A>> = server_app.world.resource_mut();
+    let client_events: &Events<A> = client_app.world().resource();
+    let mut server_events: Mut<Events<A>> = server_app.world_mut().resource_mut();
 
     // Get an event reader, one way or another
     let mut reader = reader.unwrap_or_else(|| client_events.get_reader());

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -43,12 +43,12 @@ impl ArpgAction {
         ArpgAction::Right,
     ];
 
-    fn direction(self) -> Option<Direction2d> {
+    fn direction(self) -> Option<Dir2> {
         match self {
-            ArpgAction::Up => Some(Direction2d::Y),
-            ArpgAction::Down => Some(Direction2d::NEG_Y),
-            ArpgAction::Left => Some(Direction2d::NEG_X),
-            ArpgAction::Right => Some(Direction2d::X),
+            ArpgAction::Up => Some(Dir2::Y),
+            ArpgAction::Down => Some(Dir2::NEG_Y),
+            ArpgAction::Left => Some(Dir2::NEG_X),
+            ArpgAction::Right => Some(Dir2::X),
             _ => None,
         }
     }
@@ -138,7 +138,7 @@ fn player_dash(query: Query<&ActionState<ArpgAction>, With<Player>>) {
         }
 
         // Then reconvert at the end, normalizing the magnitude
-        let net_direction = Direction2d::new(direction_vector);
+        let net_direction = Dir2::new(direction_vector);
 
         if let Ok(direction) = net_direction {
             println!("Dashing in {direction:?}");
@@ -148,7 +148,7 @@ fn player_dash(query: Query<&ActionState<ArpgAction>, With<Player>>) {
 
 #[derive(Event)]
 pub struct PlayerWalk {
-    pub direction: Direction2d,
+    pub direction: Dir2,
 }
 
 fn player_walks(
@@ -169,7 +169,7 @@ fn player_walks(
     }
 
     // Then reconvert at the end, normalizing the magnitude
-    let net_direction = Direction2d::new(direction_vector);
+    let net_direction = Dir2::new(direction_vector);
 
     if let Ok(direction) = net_direction {
         event_writer.send(PlayerWalk { direction });

--- a/examples/twin_stick_controller.rs
+++ b/examples/twin_stick_controller.rs
@@ -133,7 +133,9 @@ fn player_mouse_look(
     if let Some(p) = window
         .cursor_position()
         .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor))
-        .and_then(|ray| Some(ray).zip(ray.intersect_plane(player_position, Plane3d::new(Vec3::Y))))
+        .and_then(|ray| {
+            Some(ray).zip(ray.intersect_plane(player_position, InfinitePlane3d::new(Vec3::Y)))
+        })
         .map(|(ray, p)| ray.get_point(p))
     {
         let diff = (p - player_position).xz();

--- a/examples/ui_driven_actions.rs
+++ b/examples/ui_driven_actions.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to connect `bevy::ui` buttons to [`ActionState`] components using the [`ActionStateDriver`] component on your button
 
-use bevy::prelude::*;
+use bevy::{color::palettes, prelude::*};
 use leafwing_input_manager::prelude::*;
 
 fn main() {
@@ -36,7 +36,7 @@ fn spawn_player(mut commands: Commands) {
                 ..Default::default()
             },
             sprite: Sprite {
-                color: Color::PINK,
+                color: palettes::css::PINK.into(),
                 ..Default::default()
             },
             ..Default::default()
@@ -54,15 +54,18 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
 
     // Left
     let left_button = commands
-        .spawn(ButtonBundle {
-            style: Style {
-                width: Val::Px(150.0),
-                height: Val::Px(150.0),
+        .spawn((
+            ButtonBundle {
+                style: Style {
+                    width: Val::Px(150.0),
+                    height: Val::Px(150.0),
+                    ..Default::default()
+                },
+
                 ..Default::default()
             },
-            background_color: Color::RED.into(),
-            ..Default::default()
-        })
+            BackgroundColor(palettes::css::RED.into()),
+        ))
         // This component links the button to the entity with the `ActionState` component
         .insert(ActionStateDriver {
             action: Action::Left,
@@ -72,15 +75,17 @@ fn spawn_ui(mut commands: Commands, player_query: Query<Entity, With<Player>>) {
 
     // Right
     let right_button = commands
-        .spawn(ButtonBundle {
-            style: Style {
-                width: Val::Px(150.0),
-                height: Val::Px(150.0),
+        .spawn((
+            ButtonBundle {
+                style: Style {
+                    width: Val::Px(150.0),
+                    height: Val::Px(150.0),
+                    ..Default::default()
+                },
                 ..Default::default()
             },
-            background_color: Color::BLUE.into(),
-            ..Default::default()
-        })
+            BackgroundColor(palettes::css::BLUE.into()),
+        ))
         .insert(ActionStateDriver {
             action: Action::Right,
             targets: player_entity.into(),

--- a/src/action_state.rs
+++ b/src/action_state.rs
@@ -745,7 +745,7 @@ mod tests {
         input_map.insert(Action::Run, KeyCode::KeyR);
 
         // Starting state
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
         action_state.update(input_map.process_actions(&input_streams, ClashStrategy::PressAll));
 
         assert!(!action_state.pressed(&Action::Run));
@@ -757,7 +757,7 @@ mod tests {
         app.press_input(KeyCode::KeyR);
         // Process the input events into Input<KeyCode> data
         app.update();
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
 
         action_state.update(input_map.process_actions(&input_streams, ClashStrategy::PressAll));
 
@@ -778,7 +778,7 @@ mod tests {
         // Releasing
         app.release_input(KeyCode::KeyR);
         app.update();
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
 
         action_state.update(input_map.process_actions(&input_streams, ClashStrategy::PressAll));
 
@@ -820,7 +820,7 @@ mod tests {
         let mut action_state = ActionState::<Action>::default();
 
         // Starting state
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
         action_state
             .update(input_map.process_actions(&input_streams, ClashStrategy::PrioritizeLongest));
         assert!(action_state.released(&Action::One));
@@ -830,7 +830,7 @@ mod tests {
         // Pressing One
         app.press_input(Digit1);
         app.update();
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
 
         action_state
             .update(input_map.process_actions(&input_streams, ClashStrategy::PrioritizeLongest));
@@ -851,7 +851,7 @@ mod tests {
         // Pressing Two
         app.press_input(Digit2);
         app.update();
-        let input_streams = InputStreams::from_world(&app.world, None);
+        let input_streams = InputStreams::from_world(app.world(), None);
 
         action_state
             .update(input_map.process_actions(&input_streams, ClashStrategy::PrioritizeLongest));

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -1,6 +1,6 @@
 //! Tools for working with directional axis-like user inputs (game sticks, D-Pads and emulated equivalents)
 
-use bevy::prelude::{Direction2d, GamepadAxisType, GamepadButtonType, KeyCode, Reflect, Vec2};
+use bevy::prelude::{Dir2, GamepadAxisType, GamepadButtonType, KeyCode, Reflect, Vec2};
 use serde::{Deserialize, Serialize};
 
 use crate::buttonlike::{MouseMotionDirection, MouseWheelDirection};
@@ -817,13 +817,13 @@ impl DualAxisData {
         self.xy
     }
 
-    /// The [`Direction2d`] that this axis is pointing towards, if any
+    /// The [`Dir2`] that this axis is pointing towards, if any
     ///
     /// If the axis is neutral (x,y) = (0,0), a (0, 0) `None` will be returned
     #[must_use]
     #[inline]
-    pub fn direction(&self) -> Option<Direction2d> {
-        Direction2d::new(self.xy).ok()
+    pub fn direction(&self) -> Option<Dir2> {
+        Dir2::new(self.xy).ok()
     }
 
     /// The [`Rotation`] (measured clockwise from midnight) that this axis is pointing towards, if any

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -470,7 +470,7 @@ mod tests {
             app.press_input(Digit2);
             app.update();
 
-            let input_streams = InputStreams::from_world(&app.world, None);
+            let input_streams = InputStreams::from_world(app.world(), None);
 
             assert_eq!(
                 resolve_clash(
@@ -497,7 +497,7 @@ mod tests {
             app.press_input(Digit3);
             app.update();
 
-            let input_streams = InputStreams::from_world(&app.world, None);
+            let input_streams = InputStreams::from_world(app.world(), None);
 
             assert_eq!(
                 resolve_clash(
@@ -529,7 +529,7 @@ mod tests {
 
             input_map.handle_clashes(
                 &mut action_data,
-                &InputStreams::from_world(&app.world, None),
+                &InputStreams::from_world(app.world(), None),
                 ClashStrategy::PrioritizeLongest,
             );
 
@@ -558,7 +558,7 @@ mod tests {
 
             input_map.handle_clashes(
                 &mut action_data,
-                &InputStreams::from_world(&app.world, None),
+                &InputStreams::from_world(app.world(), None),
                 ClashStrategy::PrioritizeLongest,
             );
 
@@ -580,7 +580,7 @@ mod tests {
             app.update();
 
             let action_data = input_map.process_actions(
-                &InputStreams::from_world(&app.world, None),
+                &InputStreams::from_world(app.world(), None),
                 ClashStrategy::PrioritizeLongest,
             );
 

--- a/src/input_mocking.rs
+++ b/src/input_mocking.rs
@@ -622,11 +622,11 @@ impl MockUIInteraction for World {
 
 impl MockInput for App {
     fn press_input(&mut self, input: impl Into<UserInput>) {
-        self.world.press_input(input);
+        self.world_mut().press_input(input);
     }
 
     fn press_input_as_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
-        self.world.press_input_as_gamepad(input, gamepad);
+        self.world_mut().press_input_as_gamepad(input, gamepad);
     }
 
     fn send_axis_values(
@@ -634,7 +634,7 @@ impl MockInput for App {
         input: impl Into<UserInput>,
         values: impl IntoIterator<Item = f32>,
     ) {
-        self.world.send_axis_values(input, values);
+        self.world_mut().send_axis_values(input, values);
     }
 
     fn send_axis_values_as_gamepad(
@@ -643,34 +643,34 @@ impl MockInput for App {
         values: impl IntoIterator<Item = f32>,
         gamepad: Option<Gamepad>,
     ) {
-        self.world
+        self.world_mut()
             .send_axis_values_as_gamepad(input, values, gamepad);
     }
 
     fn release_input(&mut self, input: impl Into<UserInput>) {
-        self.world.release_input(input);
+        self.world_mut().release_input(input);
     }
 
     fn release_input_as_gamepad(&mut self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) {
-        self.world.release_input_as_gamepad(input, gamepad);
+        self.world_mut().release_input_as_gamepad(input, gamepad);
     }
 
     fn reset_inputs(&mut self) {
-        self.world.reset_inputs();
+        self.world_mut().reset_inputs();
     }
 }
 
 impl QueryInput for App {
     fn pressed(&self, input: impl Into<UserInput>) -> bool {
-        self.world.pressed(input)
+        self.world().pressed(input)
     }
 
     fn pressed_on_gamepad(&self, input: impl Into<UserInput>, gamepad: Option<Gamepad>) -> bool {
-        self.world.pressed_on_gamepad(input, gamepad)
+        self.world().pressed_on_gamepad(input, gamepad)
     }
 
     fn read_axis_values(&self, input: impl Into<UserInput>) -> Vec<f32> {
-        self.world.read_axis_values(input)
+        self.world().read_axis_values(input)
     }
 
     fn read_axis_values_on_gamepad(
@@ -678,18 +678,18 @@ impl QueryInput for App {
         input: impl Into<UserInput>,
         gamepad: Option<Gamepad>,
     ) -> Vec<f32> {
-        self.world.read_axis_values_on_gamepad(input, gamepad)
+        self.world().read_axis_values_on_gamepad(input, gamepad)
     }
 }
 
 #[cfg(feature = "ui")]
 impl MockUIInteraction for App {
     fn click_button<Marker: Component>(&mut self) {
-        self.world.click_button::<Marker>();
+        self.world_mut().click_button::<Marker>();
     }
 
     fn hover_button<Marker: Component>(&mut self) {
-        self.world.hover_button::<Marker>();
+        self.world_mut().hover_button::<Marker>();
     }
 }
 
@@ -708,7 +708,7 @@ mod test {
         app.add_plugins(InputPlugin);
 
         let gamepad = Gamepad::new(0);
-        let mut gamepad_events = app.world.resource_mut::<Events<GamepadEvent>>();
+        let mut gamepad_events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
         gamepad_events.send(GamepadEvent::Connection(GamepadConnectionEvent {
             gamepad,
             connection: GamepadConnection::Connected(GamepadInfo {
@@ -735,7 +735,7 @@ mod test {
         app.update();
 
         // Verify that checking the resource value directly works
-        let keyboard_input = app.world.resource::<ButtonInput<KeyCode>>();
+        let keyboard_input = app.world().resource::<ButtonInput<KeyCode>>();
         assert!(keyboard_input.pressed(KeyCode::Space));
 
         // Test the convenient `pressed` API
@@ -848,17 +848,19 @@ mod test {
         app.add_plugins(InputPlugin);
 
         // Marked button
-        app.world.spawn((Interaction::None, ButtonMarker));
+        app.world_mut().spawn((Interaction::None, ButtonMarker));
 
         // Unmarked button
-        app.world.spawn(Interaction::None);
+        app.world_mut().spawn(Interaction::None);
 
         // Click the button
-        app.world.click_button::<ButtonMarker>();
+        app.world_mut().click_button::<ButtonMarker>();
         app.update();
 
-        let mut interaction_query = app.world.query::<(&Interaction, Option<&ButtonMarker>)>();
-        for (interaction, maybe_marker) in interaction_query.iter(&app.world) {
+        let mut interaction_query = app
+            .world_mut()
+            .query::<(&Interaction, Option<&ButtonMarker>)>();
+        for (interaction, maybe_marker) in interaction_query.iter(&app.world()) {
             match maybe_marker {
                 Some(_) => assert_eq!(*interaction, Interaction::Pressed),
                 None => assert_eq!(*interaction, Interaction::None),
@@ -866,10 +868,10 @@ mod test {
         }
 
         // Reset inputs
-        app.world.reset_inputs();
+        app.world_mut().reset_inputs();
 
-        let mut interaction_query = app.world.query::<&Interaction>();
-        for interaction in interaction_query.iter(&app.world) {
+        let mut interaction_query = app.world_mut().query::<&Interaction>();
+        for interaction in interaction_query.iter(&app.world()) {
             assert_eq!(*interaction, Interaction::None)
         }
 
@@ -877,8 +879,10 @@ mod test {
         app.hover_button::<ButtonMarker>();
         app.update();
 
-        let mut interaction_query = app.world.query::<(&Interaction, Option<&ButtonMarker>)>();
-        for (interaction, maybe_marker) in interaction_query.iter(&app.world) {
+        let mut interaction_query = app
+            .world_mut()
+            .query::<(&Interaction, Option<&ButtonMarker>)>();
+        for (interaction, maybe_marker) in interaction_query.iter(&app.world()) {
             match maybe_marker {
                 Some(_) => assert_eq!(*interaction, Interaction::Hovered),
                 None => assert_eq!(*interaction, Interaction::None),
@@ -886,10 +890,10 @@ mod test {
         }
 
         // Reset inputs
-        app.world.reset_inputs();
+        app.world_mut().reset_inputs();
 
-        let mut interaction_query = app.world.query::<&Interaction>();
-        for interaction in interaction_query.iter(&app.world) {
+        let mut interaction_query = app.world_mut().query::<&Interaction>();
+        for interaction in interaction_query.iter(&app.world()) {
             assert_eq!(*interaction, Interaction::None)
         }
     }

--- a/src/input_processing/dual_axis/circle.rs
+++ b/src/input_processing/dual_axis/circle.rs
@@ -3,8 +3,10 @@
 use std::fmt::Debug;
 use std::hash::{Hash, Hasher};
 
-use bevy::prelude::{Reflect, Vec2};
-use bevy::utils::FloatOrd;
+use bevy::{
+    math::FloatOrd,
+    prelude::{Reflect, Vec2},
+};
 use serde::{Deserialize, Serialize};
 
 use super::DualAxisProcessor;

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -193,6 +193,10 @@ impl Reflect for Box<dyn CustomDualAxisProcessor> {
     fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
     }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+        todo!()
+    }
 }
 
 impl Typed for Box<dyn CustomDualAxisProcessor> {

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -194,7 +194,7 @@ impl Reflect for Box<dyn CustomDualAxisProcessor> {
         Debug::fmt(self, f)
     }
 
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+    fn try_apply(&mut self, _value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
         todo!()
     }
 }

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -29,7 +29,7 @@ use crate::typetag::RegisterTypeTag;
 /// ```rust
 /// use std::hash::{Hash, Hasher};
 /// use bevy::prelude::*;
-/// use bevy::utils::FloatOrd;
+/// use bevy::math::FloatOrd;
 /// use serde::{Deserialize, Serialize};
 /// use leafwing_input_manager::prelude::*;
 ///

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -2,8 +2,10 @@
 
 use std::hash::{Hash, Hasher};
 
-use bevy::prelude::{BVec2, Reflect, Vec2};
-use bevy::utils::FloatOrd;
+use bevy::{
+    math::FloatOrd,
+    prelude::{BVec2, Reflect, Vec2},
+};
 use serde::{Deserialize, Serialize};
 
 use crate::input_processing::AxisProcessor;

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -193,7 +193,7 @@ impl Reflect for Box<dyn CustomAxisProcessor> {
         Debug::fmt(self, f)
     }
 
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+    fn try_apply(&mut self, _value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
         todo!()
     }
 }

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -192,6 +192,10 @@ impl Reflect for Box<dyn CustomAxisProcessor> {
     fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         Debug::fmt(self, f)
     }
+
+    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+        todo!()
+    }
 }
 
 impl Typed for Box<dyn CustomAxisProcessor> {

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -29,7 +29,7 @@ use crate::typetag::RegisterTypeTag;
 /// ```rust
 /// use std::hash::{Hash, Hasher};
 /// use bevy::prelude::*;
-/// use bevy::utils::FloatOrd;
+/// use bevy::math::FloatOrd;
 /// use serde::{Deserialize, Serialize};
 /// use leafwing_input_manager::prelude::*;
 ///

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -2,8 +2,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use bevy::prelude::Reflect;
-use bevy::utils::FloatOrd;
+use bevy::{math::FloatOrd, prelude::Reflect};
 use serde::{Deserialize, Serialize};
 
 pub use self::custom::*;

--- a/src/input_processing/single_axis/range.rs
+++ b/src/input_processing/single_axis/range.rs
@@ -2,8 +2,7 @@
 
 use std::hash::{Hash, Hasher};
 
-use bevy::prelude::Reflect;
-use bevy::utils::FloatOrd;
+use bevy::{math::FloatOrd, prelude::Reflect};
 use serde::{Deserialize, Serialize};
 
 use super::AxisProcessor;

--- a/src/input_streams.rs
+++ b/src/input_streams.rs
@@ -485,25 +485,25 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(InputPlugin);
 
-        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
+        let mut input_streams = MutableInputStreams::from_world(app.world_mut(), None);
         assert!(!InputStreams::from(&input_streams).pressed(Modifier::Control));
 
         input_streams.press_input(KeyCode::ControlLeft);
         app.update();
 
-        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
+        let mut input_streams = MutableInputStreams::from_world(app.world_mut(), None);
         assert!(InputStreams::from(&input_streams).pressed(Modifier::Control));
 
         input_streams.reset_inputs();
         app.update();
 
-        let mut input_streams = MutableInputStreams::from_world(&mut app.world, None);
+        let mut input_streams = MutableInputStreams::from_world(app.world_mut(), None);
         assert!(!InputStreams::from(&input_streams).pressed(Modifier::Control));
 
         input_streams.press_input(KeyCode::ControlRight);
         app.update();
 
-        let input_streams = MutableInputStreams::from_world(&mut app.world, None);
+        let input_streams = MutableInputStreams::from_world(app.world_mut(), None);
         assert!(InputStreams::from(&input_streams).pressed(Modifier::Control));
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -92,7 +92,9 @@ enum Machine {
     Client,
 }
 
-impl<A: Actionlike + TypePath> Plugin for InputManagerPlugin<A> {
+impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
+    for InputManagerPlugin<A>
+{
     fn build(&self, app: &mut App) {
         use crate::systems::*;
 

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -59,10 +59,10 @@ fn create_app() -> App {
 }
 
 fn get_events<E: Event>(app: &App) -> &Events<E> {
-    app.world.resource()
+    app.world().resource()
 }
 fn get_events_mut<E: Event>(app: &mut App) -> Mut<Events<E>> {
-    app.world.resource_mut()
+    app.world_mut().resource_mut()
 }
 
 fn send_action_diff(app: &mut App, action_diff: ActionDiffEvent<Action>) {
@@ -96,8 +96,8 @@ fn assert_action_diff_created(app: &mut App, predicate: impl Fn(&ActionDiffEvent
 }
 
 fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent<Action>) {
-    let mut action_state_query = app.world.query::<&ActionState<Action>>();
-    let action_state = action_state_query.get_single(&app.world).unwrap();
+    let mut action_state_query = app.world_mut().query::<&ActionState<Action>>();
+    let action_state = action_state_query.get_single(app.world()).unwrap();
     assert_eq!(action_diff_event.action_diffs.len(), 1);
     match action_diff_event.action_diffs.first().unwrap().clone() {
         ActionDiff::Pressed { action } => {
@@ -130,9 +130,9 @@ fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent
 fn generate_binary_action_diffs() {
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(app.world());
     app.add_systems(
         Update,
         pay_da_bills(|mut action_state| {
@@ -195,9 +195,9 @@ fn generate_value_action_diffs() {
     let input_value = 0.5;
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(&app.world());
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
@@ -263,9 +263,9 @@ fn generate_axis_action_diffs() {
     let input_axis_pair = Vec2 { x: 5., y: 8. };
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(app.world());
     app.add_systems(
         Update,
         pay_da_bills(move |mut action_state| {
@@ -330,9 +330,9 @@ fn generate_axis_action_diffs() {
 fn process_binary_action_diffs() {
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(app.world());
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff_event = ActionDiffEvent {
@@ -364,9 +364,9 @@ fn process_binary_action_diffs() {
 fn process_value_action_diff() {
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(app.world());
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff_event = ActionDiffEvent {
@@ -399,9 +399,9 @@ fn process_value_action_diff() {
 fn process_axis_action_diff() {
     let mut app = create_app();
     let entity = app
-        .world
+        .world_mut()
         .query_filtered::<Entity, With<ActionState<Action>>>()
-        .single(&app.world);
+        .single(app.world());
     app.add_systems(PreUpdate, process_action_diffs::<Action>);
 
     let action_diff_event = ActionDiffEvent {

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -80,22 +80,22 @@ impl ClashTestExt for App {
         let pressed_actions: HashSet<Action> = HashSet::from_iter(pressed_actions);
         // SystemState is love, SystemState is life
         let mut input_system_state: SystemState<Query<&InputMap<Action>>> =
-            SystemState::new(&mut self.world);
+            SystemState::new(self.world_mut());
 
-        let input_map_query = input_system_state.get(&self.world);
+        let input_map_query = input_system_state.get(self.world());
 
         let input_map = input_map_query.single();
-        let keyboard_input = self.world.resource::<ButtonInput<KeyCode>>();
+        let keyboard_input = self.world().resource::<ButtonInput<KeyCode>>();
 
         for action in Action::variants() {
             if pressed_actions.contains(action) {
                 assert!(
-                    input_map.pressed(action, &InputStreams::from_world(&self.world, None), clash_strategy),
+                    input_map.pressed(action, &InputStreams::from_world(self.world(), None), clash_strategy),
                     "{action:?} was incorrectly not pressed for {clash_strategy:?} when `Input<KeyCode>` was \n {keyboard_input:?}."
                 );
             } else {
                 assert!(
-                    !input_map.pressed(action, &InputStreams::from_world(&self.world, None), clash_strategy),
+                    !input_map.pressed(action, &InputStreams::from_world(self.world(), None), clash_strategy),
                     "{action:?} was incorrectly pressed for {clash_strategy:?} when `Input<KeyCode>` was \n {keyboard_input:?}"
                 );
             }

--- a/tests/gamepad_axis.rs
+++ b/tests/gamepad_axis.rs
@@ -31,7 +31,7 @@ fn test_app() -> App {
         .init_resource::<ActionState<AxislikeTestAction>>();
 
     // WARNING: you MUST register your gamepad during tests, or all gamepad input mocking will fail
-    let mut gamepad_events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut gamepad_events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     gamepad_events.send(GamepadEvent::Connection(GamepadConnectionEvent {
         // This MUST be consistent with any other mocked events
         gamepad: Gamepad { id: 1 },
@@ -56,7 +56,7 @@ fn raw_gamepad_axis_events() {
         SingleAxis::new(GamepadAxisType::RightStickX).with_deadzone_symmetric(0.1),
     )]));
 
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     events.send(GamepadEvent::Axis(GamepadAxisChangedEvent {
         gamepad: Gamepad { id: 1 },
         axis_type: GamepadAxisType::RightStickX,
@@ -64,7 +64,9 @@ fn raw_gamepad_axis_events() {
     }));
 
     app.update();
-    let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+    let action_state = app
+        .world_mut()
+        .resource::<ActionState<ButtonlikeTestAction>>();
     assert!(action_state.pressed(&ButtonlikeTestAction::Up));
 }
 
@@ -72,13 +74,13 @@ fn raw_gamepad_axis_events() {
 #[ignore = "Broken upstream; tracked in https://github.com/Leafwing-Studios/leafwing-input-manager/issues/419"]
 fn game_pad_single_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [-1.0]);
 
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 1);
 }
 
@@ -86,13 +88,13 @@ fn game_pad_single_axis_mocking() {
 #[ignore = "Broken upstream; tracked in https://github.com/Leafwing-Studios/leafwing-input-manager/issues/419"]
 fn game_pad_dual_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = DualAxis::left_stick();
     app.send_axis_values(input, [1.0, 0.0]);
 
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
 }
@@ -115,28 +117,28 @@ fn game_pad_single_axis() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
@@ -144,21 +146,21 @@ fn game_pad_single_axis() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, [0.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // No value
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, []);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // Scaled value
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [0.2]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
     assert_eq!(action_state.value(&AxislikeTestAction::X), 0.11111112);
 }
@@ -185,7 +187,7 @@ fn game_pad_single_axis_inverted() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
     assert_eq!(action_state.value(&AxislikeTestAction::X), -1.0);
 
@@ -193,7 +195,7 @@ fn game_pad_single_axis_inverted() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickX);
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
     assert_eq!(action_state.value(&AxislikeTestAction::X), 1.0);
 
@@ -201,7 +203,7 @@ fn game_pad_single_axis_inverted() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
     assert_eq!(action_state.value(&AxislikeTestAction::Y), -1.0);
 
@@ -209,7 +211,7 @@ fn game_pad_single_axis_inverted() {
     let input = SingleAxis::new(GamepadAxisType::LeftStickY);
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
     assert_eq!(action_state.value(&AxislikeTestAction::Y), 1.0);
 }
@@ -228,7 +230,7 @@ fn game_pad_dual_axis_deadzone() {
     app.send_axis_values(input, [0.04, 0.1]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.released(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.0);
     assert_eq!(
@@ -241,7 +243,7 @@ fn game_pad_dual_axis_deadzone() {
     app.send_axis_values(input, [1.0, 0.2]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 1.006_154);
     assert_eq!(
@@ -254,7 +256,7 @@ fn game_pad_dual_axis_deadzone() {
     app.send_axis_values(input, [0.8, 0.1]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.7777778);
     assert_eq!(
@@ -276,7 +278,7 @@ fn game_pad_circle_deadzone() {
     app.send_axis_values(input, [0.06, 0.06]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.released(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.0);
     assert_eq!(
@@ -289,7 +291,7 @@ fn game_pad_circle_deadzone() {
     app.send_axis_values(input, [0.2, 0.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.11111112);
     assert_eq!(
@@ -312,7 +314,7 @@ fn test_zero_dual_axis_deadzone() {
     app.send_axis_values(input, [0.0, 0.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.released(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.0);
     assert_eq!(
@@ -334,7 +336,7 @@ fn test_zero_circle_deadzone() {
     app.send_axis_values(input, [0.0, 0.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.released(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 0.0);
     assert_eq!(
@@ -355,7 +357,7 @@ fn game_pad_virtual_dpad() {
     app.press_input(GamepadButtonType::DPadLeft);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     // This should be a unit length, because we're working with a VirtualDPad

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -73,43 +73,43 @@ fn disable_input() {
     // Press F to pay respects
     app.press_input(KeyCode::KeyF);
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 
     // Disable the global input
-    let mut action_state = app.world.resource_mut::<ActionState<Action>>();
+    let mut action_state = app.world_mut().resource_mut::<ActionState<Action>>();
     action_state.disable_all();
 
     // But the player is still paying respects
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 
     // Disable the player's input too
     let mut action_state = app
-        .world
+        .world_mut()
         .query_filtered::<&mut ActionState<Action>, With<Player>>()
-        .single_mut(&mut app.world);
+        .single_mut(app.world_mut());
     action_state.disable_all();
 
     // Now, all respect has faded
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 
     // And even pressing F cannot bring it back
     app.press_input(KeyCode::KeyF);
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 
     // Re-enable the global input
-    let mut action_state = app.world.resource_mut::<ActionState<Action>>();
+    let mut action_state = app.world_mut().resource_mut::<ActionState<Action>>();
     action_state.enable_all();
 
     // And it will start paying respects again
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 }
 
@@ -136,23 +136,23 @@ fn release_when_input_map_removed() {
     // Press F to pay respects
     app.press_input(KeyCode::KeyF);
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 
     // Remove the InputMap
-    app.world.remove_resource::<InputMap<Action>>();
+    app.world_mut().remove_resource::<InputMap<Action>>();
     // Needs an extra frame for the resource removed detection to release inputs
     app.update();
 
     // Now, all respect has faded
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 
     // And even pressing F cannot bring it back
     app.press_input(KeyCode::KeyF);
     app.update();
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 }
 
@@ -196,34 +196,34 @@ fn action_state_driver() {
 
     app.update();
 
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 
     // Click the button to pay respects
     app.click_button::<ButtonMarker>();
 
     // Verify that the button was in fact clicked
-    let mut button_query = app.world.query::<&Interaction>();
-    let interaction = button_query.iter(&app.world).next().unwrap();
+    let mut button_query = app.world_mut().query::<&Interaction>();
+    let interaction = button_query.iter(app.world()).next().unwrap();
     assert_eq!(*interaction, Interaction::Pressed);
 
     // Run the app once to process the clicks
     app.update();
 
     // Check the action state
-    let mut action_state_query = app.world.query::<&ActionState<Action>>();
-    let action_state = action_state_query.iter(&app.world).next().unwrap();
+    let mut action_state_query = app.world_mut().query::<&ActionState<Action>>();
+    let action_state = action_state_query.iter(app.world()).next().unwrap();
     assert!(action_state.pressed(&Action::PayRespects));
 
     // Check the effects of that action state
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(true));
 
     // Clear inputs
     app.reset_inputs();
     app.update();
 
-    let respect = app.world.resource::<Respect>();
+    let respect = app.world().resource::<Respect>();
     assert_eq!(*respect, Respect(false));
 }
 
@@ -273,7 +273,7 @@ fn duration() {
     // Check
     app.update();
     assert!(app
-        .world
+        .world()
         .resource::<ActionState<Action>>()
         .pressed(&Action::PayRespects));
 }

--- a/tests/mouse_motion.rs
+++ b/tests/mouse_motion.rs
@@ -51,24 +51,24 @@ fn raw_mouse_motion_events() {
         SingleAxis::mouse_motion_y(),
     )]));
 
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     events.send(MouseMotion {
         delta: Vec2::new(0.0, 1.0),
     });
 
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 }
 
 #[test]
 fn mouse_motion_discrete_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
     app.press_input(MouseMotionDirection::Up);
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
 
     assert_eq!(events.drain().count(), 1);
 }
@@ -76,26 +76,26 @@ fn mouse_motion_discrete_mocking() {
 #[test]
 fn mouse_motion_single_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = SingleAxis::mouse_motion_x();
     app.send_axis_values(input, [-1.0]);
 
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 1);
 }
 
 #[test]
 fn mouse_motion_dual_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = DualAxis::mouse_motion();
     app.send_axis_values(input, [1.0, 0.0]);
 
-    let mut events = app.world.resource_mut::<Events<MouseMotion>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseMotion>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
 }
@@ -111,14 +111,14 @@ fn mouse_motion_buttonlike() {
     ]));
 
     for action in ButtonlikeTestAction::variants() {
-        let input_map = app.world.resource::<InputMap<ButtonlikeTestAction>>();
+        let input_map = app.world().resource::<InputMap<ButtonlikeTestAction>>();
         // Get the first associated input
         let input = input_map.get(action).unwrap().first().unwrap().clone();
 
         app.press_input(input.clone());
         app.update();
 
-        let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+        let action_state = app.world().resource::<ActionState<ButtonlikeTestAction>>();
         assert!(action_state.pressed(action), "failed for {input:?}");
     }
 }
@@ -139,7 +139,7 @@ fn mouse_motion_buttonlike_cancels() {
     // Correctly flushes the world
     app.update();
 
-    let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<ButtonlikeTestAction>>();
 
     assert!(!action_state.pressed(&ButtonlikeTestAction::Up));
     assert!(!action_state.pressed(&ButtonlikeTestAction::Down));
@@ -157,42 +157,42 @@ fn mouse_motion_single_axis() {
     let input = SingleAxis::mouse_motion_x();
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
     let input = SingleAxis::mouse_motion_x();
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
     let input = SingleAxis::mouse_motion_y();
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
     let input = SingleAxis::mouse_motion_y();
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
     let input = SingleAxis::mouse_motion_y();
     app.send_axis_values(input, [0.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // None
     let input = SingleAxis::mouse_motion_y();
     app.send_axis_values(input, []);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 }
 
@@ -208,7 +208,7 @@ fn mouse_motion_dual_axis() {
     app.send_axis_values(input, [5.0, 0.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 5.0);
@@ -230,7 +230,7 @@ fn mouse_motion_virtual_dpad() {
     app.send_axis_values(input, [0.0, -2.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     // This should be a unit length, because we're working with a VirtualDPad
@@ -263,7 +263,7 @@ fn mouse_drag() {
     app.press_input(MouseButton::Right);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(

--- a/tests/mouse_wheel.rs
+++ b/tests/mouse_wheel.rs
@@ -45,7 +45,7 @@ fn raw_mouse_wheel_events() {
         MouseWheelDirection::Up,
     )]));
 
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     events.send(MouseWheel {
         unit: MouseScrollUnit::Pixel,
         x: 0.0,
@@ -54,18 +54,18 @@ fn raw_mouse_wheel_events() {
     });
 
     app.update();
-    let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<ButtonlikeTestAction>>();
     assert!(action_state.pressed(&ButtonlikeTestAction::Up));
 }
 
 #[test]
 fn mouse_wheel_discrete_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
     app.press_input(MouseWheelDirection::Up);
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
 
     assert_eq!(events.drain().count(), 1);
 }
@@ -73,26 +73,26 @@ fn mouse_wheel_discrete_mocking() {
 #[test]
 fn mouse_wheel_single_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = SingleAxis::mouse_wheel_x();
     app.send_axis_values(input, [-1.0]);
 
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 1);
 }
 
 #[test]
 fn mouse_wheel_dual_axis_mocking() {
     let mut app = test_app();
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     assert_eq!(events.drain().count(), 0);
 
     let input = DualAxis::mouse_wheel();
     app.send_axis_values(input, [-1.0]);
 
-    let mut events = app.world.resource_mut::<Events<MouseWheel>>();
+    let mut events = app.world_mut().resource_mut::<Events<MouseWheel>>();
     // Dual axis events are split out
     assert_eq!(events.drain().count(), 2);
 }
@@ -108,14 +108,14 @@ fn mouse_wheel_buttonlike() {
     ]));
 
     for action in ButtonlikeTestAction::variants() {
-        let input_map = app.world.resource::<InputMap<ButtonlikeTestAction>>();
+        let input_map = app.world().resource::<InputMap<ButtonlikeTestAction>>();
         // Get the first associated input
         let input = input_map.get(action).unwrap().first().unwrap().clone();
 
         app.press_input(input.clone());
         app.update();
 
-        let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+        let action_state = app.world().resource::<ActionState<ButtonlikeTestAction>>();
         assert!(action_state.pressed(action), "failed for {input:?}");
     }
 }
@@ -136,7 +136,7 @@ fn mouse_wheel_buttonlike_cancels() {
     // Correctly flushes the world
     app.update();
 
-    let action_state = app.world.resource::<ActionState<ButtonlikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<ButtonlikeTestAction>>();
 
     assert!(!action_state.pressed(&ButtonlikeTestAction::Up));
     assert!(!action_state.pressed(&ButtonlikeTestAction::Down));
@@ -154,42 +154,42 @@ fn mouse_wheel_single_axis() {
     let input = SingleAxis::mouse_wheel_x();
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // -X
     let input = SingleAxis::mouse_wheel_x();
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::X));
 
     // +Y
     let input = SingleAxis::mouse_wheel_y();
     app.send_axis_values(input, [1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // -Y
     let input = SingleAxis::mouse_wheel_y();
     app.send_axis_values(input, [-1.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(action_state.pressed(&AxislikeTestAction::Y));
 
     // 0
     let input = SingleAxis::mouse_wheel_y();
     app.send_axis_values(input, [0.0]);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 
     // None
     let input = SingleAxis::mouse_wheel_y();
     app.send_axis_values(input, []);
     app.update();
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
     assert!(!action_state.pressed(&AxislikeTestAction::Y));
 }
 
@@ -205,7 +205,7 @@ fn mouse_wheel_dual_axis() {
     app.send_axis_values(input, [5.0, 0.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     assert_eq!(action_state.value(&AxislikeTestAction::XY), 5.0);
@@ -227,7 +227,7 @@ fn mouse_wheel_virtualdpad() {
     app.send_axis_values(input, [0.0, -2.0]);
     app.update();
 
-    let action_state = app.world.resource::<ActionState<AxislikeTestAction>>();
+    let action_state = app.world().resource::<ActionState<AxislikeTestAction>>();
 
     assert!(action_state.pressed(&AxislikeTestAction::XY));
     // This should be a unit length, because we're working with a VirtualDPad

--- a/tests/multiple_gamepads.rs
+++ b/tests/multiple_gamepads.rs
@@ -13,7 +13,7 @@ fn create_test_app() -> App {
     app.add_plugins(MinimalPlugins).add_plugins(InputPlugin);
     app.add_plugins(InputManagerPlugin::<MyAction>::default());
 
-    let mut gamepad_events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut gamepad_events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     gamepad_events.send(GamepadEvent::Connection(GamepadConnectionEvent {
         // Must be consistent with mocked events
         gamepad: Gamepad { id: 1 },
@@ -59,23 +59,23 @@ fn default_accepts_any() {
     app.init_resource::<ActionState<MyAction>>();
 
     // When we press the Jump button...
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     events.send(jump_button_press_event(FIRST_GAMEPAD));
     app.update();
 
     // ... We should receive a Jump action!
-    let mut action_state = app.world.resource_mut::<ActionState<MyAction>>();
+    let mut action_state = app.world_mut().resource_mut::<ActionState<MyAction>>();
     assert!(action_state.pressed(&MyAction::Jump));
 
     action_state.release(&MyAction::Jump);
     app.update();
 
     // This is maintained for any gamepad.
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     events.send(jump_button_press_event(SECOND_GAMEPAD));
     app.update();
 
-    let action_state = app.world.resource_mut::<ActionState<MyAction>>();
+    let action_state = app.world_mut().resource_mut::<ActionState<MyAction>>();
     assert!(action_state.pressed(&MyAction::Jump));
 }
 
@@ -91,12 +91,12 @@ fn accepts_preferred_gamepad() {
     app.init_resource::<ActionState<MyAction>>();
 
     // When we press the Jump button...
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     events.send(jump_button_press_event(PREFERRED_GAMEPAD));
     app.update();
 
     // ... We should receive a Jump action!
-    let action_state = app.world.resource_mut::<ActionState<MyAction>>();
+    let action_state = app.world_mut().resource_mut::<ActionState<MyAction>>();
     assert!(action_state.pressed(&MyAction::Jump));
 }
 
@@ -113,11 +113,11 @@ fn filters_out_other_gamepads() {
     app.init_resource::<ActionState<MyAction>>();
 
     // When we press the Jump button...
-    let mut events = app.world.resource_mut::<Events<GamepadEvent>>();
+    let mut events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
     events.send(jump_button_press_event(OTHER_GAMEPAD));
     app.update();
 
     // ... We should receive a Jump action!
-    let action_state = app.world.resource_mut::<ActionState<MyAction>>();
+    let action_state = app.world_mut().resource_mut::<ActionState<MyAction>>();
     assert!(action_state.released(&MyAction::Jump));
 }


### PR DESCRIPTION
A PR to match the Bevy 0.14.0-rc.2 release. Most of the change seem straightforward, although I'm not as familiar with the internals here as I'd like. The vast majority of the PR is app.world refactors to use function access.

Most notably:

* bevy_egui has a [pr](https://github.com/mvlabat/bevy_egui/pull/284) open for 0.14, so I'm using that as a dependency in this PR which will have to be switched out.
* Some features in the dev-dependency for bevy seem to be temporarily required: https://github.com/bevyengine/bevy/issues/13728
* Both `Reflect::try_apply` implementations for `CustomAxisProcessor` and `CustomDualAxisProcessor` are `todo!` because I'm not sure how to fill it out yet.

Additionally, there seems to be an issue on main with the `mouse_position` example, and that issue is still present here in this PR.

```
❯ cargo run --example mouse_position
warning: `leafwing-input-manager` (lib) generated 2 warnings
   Compiling leafwing-input-manager v0.14.0 (/Users/chris/github/leafwing-studios/leafwing_input_manager)
error[E0432]: unresolved import `leafwing_input_manager::systems::run_if_enabled`
 --> examples/mouse_position.rs:3:69
  |
3 |     axislike::DualAxisData, plugin::InputManagerSystem, prelude::*, systems::run_if_enabled,
  |                                                                     ^^^^^^^^^^^^^^^^^^^^^^^ no `run_if_enabled` in `systems`

error[E0599]: no variant or associated item named `ReleaseOnDisable` found for enum `InputManagerSystem` in the current scope
  --> examples/mouse_position.rs:16:45
   |
16 |                 .before(InputManagerSystem::ReleaseOnDisable)
   |                                             ^^^^^^^^^^^^^^^^ variant or associated item not found in `InputManagerSystem`

Some errors have detailed explanations: E0432, E0599.
For more information about an error, try `rustc --explain E0432`.
error: could not compile `leafwing-input-manager` (example "mouse_position") due to 2 previous errors
``` 