### PR TITLE
Remove duplicate Hash bound for Actionlike

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub mod prelude {
 /// }
 /// ```
 pub trait Actionlike:
-    Eq + Hash + Send + Sync + Clone + Hash + Reflect + TypePath + FromReflect + 'static
+    Eq + Hash + Send + Sync + Clone + Reflect + TypePath + FromReflect + 'static
 {
 }
 


### PR DESCRIPTION
A trivial/harmless problem: `Hash` occurs twice in the trait bounds.