### PR TITLE
Share metadata across action types and only store a single Hashmap in ActionState

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,7 @@
   - if you are storing non-buttonlike actions (e.g. movement) inside of your Actionlike enum, you must manually implement the trait
   - pressed / released state can only be accessed for buttonlike data: invalid requests will always return released
   - `f32` values can only be accessed for axislike data: invalid requests will always return 0.0
-  - `ActionData` has been renamed to `ButtonData`, and no longer holds a `value` or `DualAxisData`
+  - `ActionData` has been refactored, and now stores common data and input-kind specific data separately
   - 2-dimensional `DualAxisData` can only be accessed for dualaxislike data: invalid requests will always return (0.0, 0.0)
   - `Axislike` inputs can no longer be inserted directly into an `InputMap`: instead, use the `insert_axis` method
   - `Axislike` inputs can no longer be inserted directly into an `InputMap`: instead, use the `insert_dual_axis` method

--- a/benches/action_state.rs
+++ b/benches/action_state.rs
@@ -1,6 +1,10 @@
 use bevy::{prelude::Reflect, utils::HashMap};
 use criterion::{criterion_group, criterion_main, Criterion};
-use leafwing_input_manager::{input_map::UpdatedActions, prelude::ActionState, Actionlike};
+use leafwing_input_manager::{
+    input_map::{UpdatedActions, UpdatedValue},
+    prelude::ActionState,
+    Actionlike,
+};
 
 #[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]
 enum TestAction {
@@ -54,14 +58,11 @@ fn criterion_benchmark(c: &mut Criterion) {
     c.bench_function("released", |b| b.iter(|| released(&action_state)));
     c.bench_function("just_released", |b| b.iter(|| just_released(&action_state)));
 
-    let button_actions: HashMap<TestAction, bool> = TestAction::variants()
-        .map(|action| (action, true))
+    let button_actions: HashMap<TestAction, UpdatedValue> = TestAction::variants()
+        .map(|action| (action, UpdatedValue::Button(true)))
         .collect();
 
-    let updated_actions = UpdatedActions {
-        button_actions,
-        ..Default::default()
-    };
+    let updated_actions = UpdatedActions(button_actions);
 
     c.bench_function("update", |b| {
         b.iter(|| update(action_state.clone(), updated_actions.clone()))

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -3,9 +3,9 @@
 use bevy::{math::Vec2, reflect::Reflect};
 use serde::{Deserialize, Serialize};
 
-use crate::buttonlike::ButtonState;
 #[cfg(feature = "timing")]
 use crate::timing::Timing;
+use crate::{buttonlike::ButtonState, InputControlKind};
 
 /// Data about the state of an action.
 ///
@@ -19,6 +19,20 @@ pub struct ActionData {
     pub disabled: bool,
     /// The data for the action.
     pub kind_data: ActionKindData,
+}
+
+impl ActionData {
+    /// Constructs a new `ActionData` with default values corresponding to the given `kind_data`.
+    pub fn from_kind(input_control_kind: InputControlKind) -> Self {
+        Self {
+            disabled: false,
+            kind_data: match input_control_kind {
+                InputControlKind::Button => ActionKindData::Button(ButtonData::default()),
+                InputControlKind::Axis => ActionKindData::Axis(AxisData::default()),
+                InputControlKind::DualAxis => ActionKindData::DualAxis(DualAxisData::default()),
+            },
+        }
+    }
 }
 
 /// A wrapper over the various forms of data that an action can take.
@@ -51,10 +65,6 @@ pub struct ButtonData {
     /// Actions that are consumed cannot be pressed again until they are explicitly released.
     /// This ensures that consumed actions are not immediately re-pressed by continued inputs.
     pub consumed: bool,
-    /// Is the action disabled?
-    ///
-    /// While disabled, an action will always report as released, regardless of its actual state.
-    pub disabled: bool,
 }
 
 impl ButtonData {
@@ -66,7 +76,6 @@ impl ButtonData {
         #[cfg(feature = "timing")]
         timing: Timing::NEW,
         consumed: false,
-        disabled: false,
     };
 
     /// The default data for a button that was just released.
@@ -77,7 +86,6 @@ impl ButtonData {
         #[cfg(feature = "timing")]
         timing: Timing::NEW,
         consumed: false,
-        disabled: false,
     };
 
     /// The default data for a button that is released,
@@ -92,35 +100,34 @@ impl ButtonData {
         #[cfg(feature = "timing")]
         timing: Timing::NEW,
         consumed: false,
-        disabled: false,
     };
 
     /// Is the action currently pressed?
     #[inline]
     #[must_use]
     pub fn pressed(&self) -> bool {
-        !self.disabled && self.state.pressed()
+        self.state.pressed()
     }
 
     /// Was the action pressed since the last time it was ticked?
     #[inline]
     #[must_use]
     pub fn just_pressed(&self) -> bool {
-        !self.disabled && self.state.just_pressed()
+        self.state.just_pressed()
     }
 
     /// Is the action currently released?
     #[inline]
     #[must_use]
     pub fn released(&self) -> bool {
-        self.disabled || self.state.released()
+        self.state.released()
     }
 
     /// Was the action released since the last time it was ticked?
     #[inline]
     #[must_use]
     pub fn just_released(&self) -> bool {
-        !self.disabled && self.state.just_released()
+        self.state.just_released()
     }
 }
 
@@ -133,10 +140,6 @@ pub struct AxisData {
     pub update_value: f32,
     /// The `value` of the action in the `FixedMain` schedule
     pub fixed_update_value: f32,
-    /// Is the action disabled?
-    ///
-    /// While disabled, an action will always return 0, regardless of its actual state.
-    pub disabled: bool,
 }
 
 /// The raw data for an [`ActionState`](super::ActionState)  corresponding to a pair of virtual axes.
@@ -148,8 +151,4 @@ pub struct DualAxisData {
     pub update_pair: Vec2,
     /// The `value` of the action in the `FixedMain` schedule
     pub fixed_update_pair: Vec2,
-    /// Is the action disabled?
-    ///
-    /// While disabled, an action will always return 0, regardless of its actual state.
-    pub disabled: bool,
 }

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -7,13 +7,29 @@ use crate::buttonlike::ButtonState;
 #[cfg(feature = "timing")]
 use crate::timing::Timing;
 
-/// The shared data about the state of an action.
-#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Reflect)]
+/// Data about the state of an action.
+///
+/// Universal data about the state of the data is stored directly in this struct,
+/// while data for each kind of action (buttonlike, axislike...) is stored in the `kind_data` field.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Reflect)]
 pub struct ActionData {
     /// Whether or not the action is disabled.
     ///
     /// While disabled, buttons will always report as released, and axes will always report as 0.
     pub disabled: bool,
+    /// The data for the action.
+    pub kind_data: ActionKindData,
+}
+
+/// A wrapper over the various forms of data that an action can take.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, Reflect)]
+pub enum ActionKindData {
+    /// The data for a button-like action.
+    Button(ButtonData),
+    /// The data for an axis-like action.
+    Axis(AxisData),
+    /// The data for a dual-axis-like action.
+    DualAxis(DualAxisData),
 }
 
 /// Metadata about an [`Buttonlike`](crate::user_input::Buttonlike) action

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -7,6 +7,15 @@ use crate::buttonlike::ButtonState;
 #[cfg(feature = "timing")]
 use crate::timing::Timing;
 
+/// The shared data about the state of an action.
+#[derive(Debug, Default, Clone, PartialEq, Serialize, Deserialize, Reflect)]
+pub struct ActionData {
+    /// Whether or not the action is disabled.
+    ///
+    /// While disabled, buttons will always report as released, and axes will always report as 0.
+    pub disabled: bool,
+}
+
 /// Metadata about an [`Buttonlike`](crate::user_input::Buttonlike) action
 ///
 /// If a button is released, its `reasons_pressed` should be empty.

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -1,5 +1,6 @@
 //! This module contains [`ActionState`] and its supporting methods and impls.
 
+use crate::input_map::UpdatedValue;
 use crate::{action_diff::ActionDiff, input_map::UpdatedActions};
 use crate::{Actionlike, InputControlKind};
 
@@ -64,12 +65,6 @@ pub use action_data::*;
 pub struct ActionState<A: Actionlike> {
     /// The shared action data for each action
     action_data: HashMap<A, ActionData>,
-    /// The [`ButtonData`] of each action
-    button_data: HashMap<A, ButtonData>,
-    /// The [`AxisData`] of each action
-    axis_data: HashMap<A, AxisData>,
-    /// The [`Vec2`] of each action
-    dual_axis_data: HashMap<A, DualAxisData>,
 }
 
 // The derive does not work unless A: Default,
@@ -78,58 +73,24 @@ impl<A: Actionlike> Default for ActionState<A> {
     fn default() -> Self {
         Self {
             action_data: HashMap::default(),
-            button_data: HashMap::default(),
-            axis_data: HashMap::default(),
-            dual_axis_data: HashMap::default(),
         }
     }
 }
 
 impl<A: Actionlike> ActionState<A> {
-    /// Returns a reference to the complete [`ButtonData`] for all actions.
+    /// Returns a reference to the complete [`ActionData`] for all actions.
     #[inline]
     #[must_use]
-    pub fn all_button_data(&self) -> &HashMap<A, ButtonData> {
-        &self.button_data
-    }
-
-    /// Returns a reference to the complete [`AxisData`] for all actions.
-    #[inline]
-    #[must_use]
-    pub fn all_axis_data(&self) -> &HashMap<A, AxisData> {
-        &self.axis_data
-    }
-
-    /// Returns a reference to the complete [`DualAxisData`] for all actions.
-    #[inline]
-    #[must_use]
-    pub fn all_dual_axis_data(&self) -> &HashMap<A, DualAxisData> {
-        &self.dual_axis_data
+    pub fn all_action_data(&self) -> &HashMap<A, ActionData> {
+        &self.action_data
     }
 
     /// We are about to enter the `Main` schedule, so we:
     /// - save all the changes applied to `state` into the `fixed_update_state`
     /// - switch to loading the `update_state`
     pub(crate) fn swap_to_update_state(&mut self) {
-        for (_action, action_datum) in self.button_data.iter_mut() {
-            // save the changes applied to `state` into `fixed_update_state`
-            action_datum.fixed_update_state = action_datum.state;
-            // switch to loading the `update_state` into `state`
-            action_datum.state = action_datum.update_state;
-        }
-
-        for (_action, action_datum) in self.axis_data.iter_mut() {
-            // save the changes applied to `state` into `fixed_update_state`
-            action_datum.fixed_update_value = action_datum.value;
-            // switch to loading the `update_state` into `state`
-            action_datum.value = action_datum.update_value;
-        }
-
-        for (_action, action_datum) in self.dual_axis_data.iter_mut() {
-            // save the changes applied to `state` into `fixed_update_state`
-            action_datum.fixed_update_pair = action_datum.pair;
-            // switch to loading the `update_state` into `state`
-            action_datum.pair = action_datum.update_pair;
+        for action_datum in self.action_data.values_mut() {
+            action_datum.kind_data.swap_to_update_state();
         }
     }
 
@@ -137,25 +98,8 @@ impl<A: Actionlike> ActionState<A> {
     /// - save all the changes applied to `state` into the `update_state`
     /// - switch to loading the `fixed_update_state`
     pub(crate) fn swap_to_fixed_update_state(&mut self) {
-        for (_action, action_datum) in self.button_data.iter_mut() {
-            // save the changes applied to `state` into `update_state`
-            action_datum.update_state = action_datum.state;
-            // switch to loading the `fixed_update_state` into `state`
-            action_datum.state = action_datum.fixed_update_state;
-        }
-
-        for (_action, action_datum) in self.axis_data.iter_mut() {
-            // save the changes applied to `state` into `update_state`
-            action_datum.update_value = action_datum.value;
-            // switch to loading the `fixed_update_state` into `state`
-            action_datum.value = action_datum.fixed_update_value;
-        }
-
-        for (_action, action_datum) in self.dual_axis_data.iter_mut() {
-            // save the changes applied to `state` into `update_state`
-            action_datum.update_pair = action_datum.pair;
-            // switch to loading the `fixed_update_state` into `state`
-            action_datum.pair = action_datum.fixed_update_pair;
+        for action_datum in self.action_data.values_mut() {
+            action_datum.kind_data.swap_to_fixed_update_state();
         }
     }
 
@@ -164,49 +108,21 @@ impl<A: Actionlike> ActionState<A> {
     /// The `action_data` is typically constructed from [`InputMap::process_actions`](crate::input_map::InputMap::process_actions),
     /// which reads from the assorted [`ButtonInput`](bevy::input::ButtonInput) resources.
     pub fn update(&mut self, updated_actions: UpdatedActions<A>) {
-        for (action, button_datum) in updated_actions.button_actions {
-            if self.button_data.contains_key(&action) {
-                match button_datum {
-                    true => self.press(&action),
-                    false => self.release(&action),
+        for (action, updated_value) in updated_actions.iter() {
+            match updated_value {
+                UpdatedValue::Button(pressed) => {
+                    if *pressed {
+                        self.press(action);
+                    } else {
+                        self.release(action);
+                    }
                 }
-            } else {
-                match button_datum {
-                    true => self.button_data.insert(action, ButtonData::JUST_PRESSED),
-                    // Buttons should start in a released state,
-                    // and should not be just pressed or just released.
-                    // This behavior helps avoid unexpected behavior with on-key-release actions
-                    // at the start of the game.
-                    false => self.button_data.insert(action, ButtonData::RELEASED),
-                };
-            }
-        }
-
-        for (action, axis_datum) in updated_actions.axis_actions.into_iter() {
-            if self.axis_data.contains_key(&action) {
-                self.axis_data.get_mut(&action).unwrap().value = axis_datum;
-            } else {
-                self.axis_data.insert(
-                    action,
-                    AxisData {
-                        value: axis_datum,
-                        ..Default::default()
-                    },
-                );
-            }
-        }
-
-        for (action, dual_axis_datum) in updated_actions.dual_axis_actions.into_iter() {
-            if self.dual_axis_data.contains_key(&action) {
-                self.dual_axis_data.get_mut(&action).unwrap().pair = dual_axis_datum;
-            } else {
-                self.dual_axis_data.insert(
-                    action,
-                    DualAxisData {
-                        pair: dual_axis_datum,
-                        ..Default::default()
-                    },
-                );
+                UpdatedValue::Axis(value) => {
+                    self.axis_data_mut_or_default(action).value = *value;
+                }
+                UpdatedValue::DualAxis(pair) => {
+                    self.dual_axis_data_mut_or_default(action).pair = *pair;
+                }
             }
         }
     }
@@ -257,17 +173,10 @@ impl<A: Actionlike> ActionState<A> {
     /// assert!(!action_state.just_pressed(&Action::Jump));
     /// ```
     pub fn tick(&mut self, _current_instant: Instant, _previous_instant: Instant) {
-        // Advanced the ButtonState
-        self.button_data.values_mut().for_each(|ad| ad.state.tick());
-
-        // Advance the Timings if the feature is enabled
-        #[cfg(feature = "timing")]
-        self.button_data.values_mut().for_each(|ad| {
-            // Durations should not advance while actions are consumed
-            if !ad.consumed {
-                ad.timing.tick(_current_instant, _previous_instant);
-            }
-        });
+        // Advanced the action states
+        self.action_data
+            .values_mut()
+            .for_each(|action_datum| action_datum.tick(_current_instant, _previous_instant));
     }
 
     /// A reference to the [`ActionData`] corresponding to the `action`.
@@ -323,7 +232,13 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn button_data(&self, action: &A) -> Option<&ButtonData> {
-        self.button_data.get(action)
+        match self.action_data(action) {
+            Some(action_data) => match action_data.kind_data {
+                ActionKindData::Button(ref button_data) => Some(button_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`ButtonData`] corresponding to the `action`.
@@ -346,7 +261,13 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn button_data_mut(&mut self, action: &A) -> Option<&mut ButtonData> {
-        self.button_data.get_mut(action)
+        match self.action_data_mut(action) {
+            Some(action_data) => match &mut action_data.kind_data {
+                ActionKindData::Button(ref mut button_data) => Some(button_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`ButtonData`] corresponding to the `action`, initializing it if needed.
@@ -360,11 +281,13 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn button_data_mut_or_default(&mut self, action: &A) -> &mut ButtonData {
-        self.button_data
-            .raw_entry_mut()
-            .from_key(action)
-            .or_insert_with(|| (action.clone(), ButtonData::default()))
-            .1
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
+
+        let action_data = self.action_data_mut_or_default(action);
+        let ActionKindData::Button(ref mut button_data) = action_data.kind_data else {
+            panic!("{action:?} is not a Button");
+        };
+        button_data
     }
 
     /// A reference of the [`AxisData`] corresponding to the `action`.
@@ -383,7 +306,13 @@ impl<A: Actionlike> ActionState<A> {
     pub fn axis_data(&self, action: &A) -> Option<&AxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
-        self.axis_data.get(action)
+        match self.action_data(action) {
+            Some(action_data) => match action_data.kind_data {
+                ActionKindData::Axis(ref axis_data) => Some(axis_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`AxisData`] corresponding to the `action`.
@@ -400,9 +329,13 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn axis_data_mut(&mut self, action: &A) -> Option<&mut AxisData> {
-        debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
-
-        self.axis_data.get_mut(action)
+        match self.action_data_mut(action) {
+            Some(action_data) => match &mut action_data.kind_data {
+                ActionKindData::Axis(ref mut axis_data) => Some(axis_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`AxisData`] corresponding to the `action`, initializing it if needed..
@@ -418,11 +351,11 @@ impl<A: Actionlike> ActionState<A> {
     pub fn axis_data_mut_or_default(&mut self, action: &A) -> &mut AxisData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
-        self.axis_data
-            .raw_entry_mut()
-            .from_key(action)
-            .or_insert_with(|| (action.clone(), AxisData::default()))
-            .1
+        let action_data = self.action_data_mut_or_default(action);
+        let ActionKindData::Axis(ref mut axis_data) = action_data.kind_data else {
+            panic!("{action:?} is not an Axis");
+        };
+        axis_data
     }
 
     /// A reference of the [`DualAxisData`] corresponding to the `action`.
@@ -441,7 +374,13 @@ impl<A: Actionlike> ActionState<A> {
     pub fn dual_axis_data(&self, action: &A) -> Option<&DualAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
-        self.dual_axis_data.get(action)
+        match self.action_data(action) {
+            Some(action_data) => match action_data.kind_data {
+                ActionKindData::DualAxis(ref axis_data) => Some(axis_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`DualAxisData`] corresponding to the `action`.
@@ -460,7 +399,13 @@ impl<A: Actionlike> ActionState<A> {
     pub fn dual_axis_data_mut(&mut self, action: &A) -> Option<&mut DualAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
-        self.dual_axis_data.get_mut(action)
+        match self.action_data_mut(action) {
+            Some(action_data) => match &mut action_data.kind_data {
+                ActionKindData::DualAxis(ref mut dual_axis_data) => Some(dual_axis_data),
+                _ => None,
+            },
+            None => None,
+        }
     }
 
     /// A mutable reference of the [`ButtonData`] corresponding to the `action` initializing it if needed.
@@ -476,11 +421,11 @@ impl<A: Actionlike> ActionState<A> {
     pub fn dual_axis_data_mut_or_default(&mut self, action: &A) -> &mut DualAxisData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
-        self.dual_axis_data
-            .raw_entry_mut()
-            .from_key(action)
-            .or_insert_with(|| (action.clone(), DualAxisData::default()))
-            .1
+        let action_data = self.action_data_mut_or_default(action);
+        let ActionKindData::DualAxis(ref mut dual_axis_data) = action_data.kind_data else {
+            panic!("{action:?} is not a Dual Axis");
+        };
+        dual_axis_data
     }
 
     /// Get the value associated with the corresponding `action` if present.
@@ -597,12 +542,13 @@ impl<A: Actionlike> ActionState<A> {
     pub fn set_button_data(&mut self, action: A, data: ButtonData) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
-        self.button_data.insert(action, data);
+        let button_data = self.button_data_mut_or_default(&action);
+        *button_data = data;
     }
 
     /// Press the `action`
     ///
-    /// No initial instant or reasons why the button was pressed will be recorded
+    /// No initial instant or reasons why the button was pressed will be recorded.
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn press(&mut self, action: &A) {
@@ -625,7 +571,7 @@ impl<A: Actionlike> ActionState<A> {
 
     /// Release the `action`
     ///
-    /// No initial instant will be recorded
+    /// No initial instant will be recorded.
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
     pub fn release(&mut self, action: &A) {
@@ -644,11 +590,14 @@ impl<A: Actionlike> ActionState<A> {
         action_data.state.release();
     }
 
-    /// Releases all [`Buttonlike`](crate::user_input::Buttonlike) actions
+    /// Releases all [`Buttonlike`](crate::user_input::Buttonlike) actions.
     pub fn release_all(&mut self) {
         // Collect out to avoid angering the borrow checker
-        let buttonlike_actions = self.button_data.keys().cloned().collect::<Vec<A>>();
-        for action in buttonlike_actions {
+        let all_actions = self.action_data.keys().cloned().collect::<Vec<A>>();
+        for action in all_actions
+            .into_iter()
+            .filter(|action| action.input_control_kind() == InputControlKind::Button)
+        {
             self.release(&action);
         }
     }
@@ -861,40 +810,44 @@ impl<A: Actionlike> ActionState<A> {
     #[must_use]
     /// Which actions are currently pressed?
     pub fn get_pressed(&self) -> Vec<A> {
-        self.button_data
-            .iter()
-            .filter(|(_action, data)| data.pressed())
-            .map(|(action, _data)| action.clone())
+        let all_actions = self.action_data.keys().cloned();
+
+        all_actions
+            .into_iter()
+            .filter(|action| self.pressed(action))
             .collect()
     }
 
     #[must_use]
     /// Which actions were just pressed?
     pub fn get_just_pressed(&self) -> Vec<A> {
-        self.button_data
-            .iter()
-            .filter(|(_action, data)| data.just_pressed())
-            .map(|(action, _data)| action.clone())
+        let all_actions = self.action_data.keys().cloned();
+
+        all_actions
+            .into_iter()
+            .filter(|action| self.just_pressed(action))
             .collect()
     }
 
     #[must_use]
     /// Which actions are currently released?
     pub fn get_released(&self) -> Vec<A> {
-        self.button_data
-            .iter()
-            .filter(|(_action, data)| data.released())
-            .map(|(action, _data)| action.clone())
+        let all_actions = self.action_data.keys().cloned();
+
+        all_actions
+            .into_iter()
+            .filter(|action| self.released(action))
             .collect()
     }
 
     #[must_use]
     /// Which actions were just released?
     pub fn get_just_released(&self) -> Vec<A> {
-        self.button_data
-            .iter()
-            .filter(|(_action, data)| data.just_released())
-            .map(|(action, _data)| action.clone())
+        let all_actions = self.action_data.keys().cloned();
+
+        all_actions
+            .into_iter()
+            .filter(|action| self.just_released(action))
             .collect()
     }
 
@@ -971,7 +924,7 @@ impl<A: Actionlike> ActionState<A> {
     #[inline]
     #[must_use]
     pub fn keys(&self) -> Vec<A> {
-        self.button_data.keys().cloned().collect()
+        self.action_data.keys().cloned().collect()
     }
 }
 

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -62,6 +62,8 @@ pub use action_data::*;
 /// ```
 #[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
 pub struct ActionState<A: Actionlike> {
+    /// The shared action data for each action
+    action_data: HashMap<A, ActionData>,
     /// The [`ButtonData`] of each action
     button_data: HashMap<A, ButtonData>,
     /// The [`AxisData`] of each action
@@ -75,6 +77,7 @@ pub struct ActionState<A: Actionlike> {
 impl<A: Actionlike> Default for ActionState<A> {
     fn default() -> Self {
         Self {
+            action_data: HashMap::default(),
             button_data: HashMap::default(),
             axis_data: HashMap::default(),
             dual_axis_data: HashMap::default(),

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -465,7 +465,7 @@ mod tests {
             input_map::UpdatedValue,
             prelude::{AccumulatedMouseMovement, AccumulatedMouseScroll, ModifierKey},
         };
-        use bevy::input::InputPlugin;
+        use bevy::{input::InputPlugin, math::Vec2};
         use Action::*;
 
         use super::*;
@@ -720,7 +720,11 @@ mod tests {
                 if *action == CtrlOne || *action == OneAndTwo {
                     assert_eq!(updated_value, UpdatedValue::Button(true));
                 } else {
-                    assert_eq!(updated_value, UpdatedValue::Button(false));
+                    match updated_value {
+                        UpdatedValue::Button(pressed) => assert_eq!(pressed, false),
+                        UpdatedValue::Axis(value) => assert_eq!(value, 0.0),
+                        UpdatedValue::DualAxis(pair) => assert_eq!(pair, Vec2::ZERO),
+                    }
                 }
             }
         }

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,5 +1,6 @@
 //! The systems that power each [`InputManagerPlugin`](crate::plugin::InputManagerPlugin).
 
+use crate::action_state::ActionKindData;
 use crate::user_input::{AccumulatedMouseMovement, AccumulatedMouseScroll};
 use crate::{
     action_state::ActionState, clashing_inputs::ClashStrategy, input_map::InputMap,
@@ -250,16 +251,18 @@ impl<A: Actionlike> SummarizedActionState<A> {
             let mut per_entity_axis_state = HashMap::default();
             let mut per_entity_dual_axis_state = HashMap::default();
 
-            for (action, button_data) in global_action_state.all_button_data() {
-                per_entity_button_state.insert(action.clone(), button_data.pressed());
-            }
-
-            for (action, axis_data) in global_action_state.all_axis_data() {
-                per_entity_axis_state.insert(action.clone(), axis_data.value);
-            }
-
-            for (action, dual_axis_data) in global_action_state.all_dual_axis_data() {
-                per_entity_dual_axis_state.insert(action.clone(), dual_axis_data.pair);
+            for (action, action_data) in global_action_state.all_action_data() {
+                match &action_data.kind_data {
+                    ActionKindData::Button(button_data) => {
+                        per_entity_button_state.insert(action.clone(), button_data.pressed());
+                    }
+                    ActionKindData::Axis(axis_data) => {
+                        per_entity_axis_state.insert(action.clone(), axis_data.value);
+                    }
+                    ActionKindData::DualAxis(dual_axis_data) => {
+                        per_entity_dual_axis_state.insert(action.clone(), dual_axis_data.pair);
+                    }
+                }
             }
 
             button_state_map.insert(Entity::PLACEHOLDER, per_entity_button_state);
@@ -272,16 +275,18 @@ impl<A: Actionlike> SummarizedActionState<A> {
             let mut per_entity_axis_state = HashMap::default();
             let mut per_entity_dual_axis_state = HashMap::default();
 
-            for (action, button_data) in action_state.all_button_data() {
-                per_entity_button_state.insert(action.clone(), button_data.pressed());
-            }
-
-            for (action, axis_data) in action_state.all_axis_data() {
-                per_entity_axis_state.insert(action.clone(), axis_data.value);
-            }
-
-            for (action, dual_axis_data) in action_state.all_dual_axis_data() {
-                per_entity_dual_axis_state.insert(action.clone(), dual_axis_data.pair);
+            for (action, action_data) in action_state.all_action_data() {
+                match &action_data.kind_data {
+                    ActionKindData::Button(button_data) => {
+                        per_entity_button_state.insert(action.clone(), button_data.pressed());
+                    }
+                    ActionKindData::Axis(axis_data) => {
+                        per_entity_axis_state.insert(action.clone(), axis_data.value);
+                    }
+                    ActionKindData::DualAxis(dual_axis_data) => {
+                        per_entity_dual_axis_state.insert(action.clone(), dual_axis_data.pair);
+                    }
+                }
             }
 
             button_state_map.insert(entity, per_entity_button_state);


### PR DESCRIPTION
Fixes #553.

Prompted by @cBournhonesque, this PR refactors the internals of `ActionState`: restoring the `ActionData` type, and moving shared data into that struct.