### PR TITLE
Add ActionState-level disabling

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -84,6 +84,12 @@ Input processors allow you to create custom logic for axis-like input manipulati
 - implemented `WithAxisProcessingPipelineExt` to manage processors for `SingleAxis` and `VirtualAxis`, integrating the common processing configuration.
 - implemented `WithDualAxisProcessingPipelineExt` to manage processors for `DualAxis` and `VirtualDpad`, integrating the common processing configuration.
 
+#### Better disabling
+
+- Actions can now be disabled at both the individual action and `ActionState` level
+- Disabling actions now resets their value, exposed via the `ActionState::reset` method
+- `ActionState::release_all` has been renamed to `ActionState::reset_all` and now resets the values of `Axislike` and `DualAxislike` actions
+
 ### Usability
 
 #### InputMap

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -641,7 +641,7 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// The action will be released, and will not be able to be pressed again
     /// until it would have otherwise been released by [`ActionState::release`],
-    /// [`ActionState::release_all`] or [`ActionState::update`].
+    /// [`ActionState::reset`], [`ActionState::reset_all`] or [`ActionState::update`].
     ///
     /// No initial instant will be recorded
     /// Instead, this is set through [`ActionState::tick()`]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -484,7 +484,7 @@ pub fn release_on_input_map_removed<A: Actionlike>(
 ) {
     let mut iter = action_state_query.iter_many_mut(removed_components.read());
     while let Some(mut action_state) = iter.fetch_next() {
-        action_state.release_all();
+        action_state.reset_all();
     }
 
     // Detect when an InputMap resource is removed.
@@ -496,7 +496,7 @@ pub fn release_on_input_map_removed<A: Actionlike>(
         // so we know the input map was removed.
 
         if let Some(mut action_state) = action_state_resource {
-            action_state.release_all();
+            action_state.reset_all();
         }
 
         // Reset our local so our removal detection is only triggered once.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -78,7 +78,7 @@ fn disable_input() {
 
     // Disable the global input
     let mut action_state = app.world_mut().resource_mut::<ActionState<Action>>();
-    action_state.disable_all();
+    action_state.disable_all_actions();
 
     // But the player is still paying respects
     app.update();
@@ -90,7 +90,7 @@ fn disable_input() {
         .world_mut()
         .query_filtered::<&mut ActionState<Action>, With<Player>>()
         .single_mut(app.world_mut());
-    action_state.disable_all();
+    action_state.disable_all_actions();
 
     // Now, all respect has faded
     app.update();
@@ -105,7 +105,7 @@ fn disable_input() {
 
     // Re-enable the global input
     let mut action_state = app.world_mut().resource_mut::<ActionState<Action>>();
-    action_state.enable_all();
+    action_state.enable_all_actions();
 
     // And it will start paying respects again
     app.update();


### PR DESCRIPTION
Fixes #563.

I've added `ActionState` level disabling in this PR, while documenting how to disable action updates via run conditions.

The other change that I've made is releasing / resetting all actions when they get disabled: actions started before a cutscene begins should not surprisingly resume upon its conclusion.