### PR TITLE
Reflect InputMap and ActionState

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,17 @@
 # Release Notes
 
+## Version 0.15.1
+
+### Usability (0.15.1)
+
+#### InputMap
+
+- Reflect `Component` and `Resource`, which enables accessing the data in the type registry
+
+#### ActionState
+
+- Reflect `Component` and `Resource`, which enables accessing the data in the type registry
+
 ## Version 0.15.0
 
 ### Enhancements (0.15)
@@ -184,7 +196,7 @@ Input processors allow you to create custom logic for axis-like input manipulati
 - removed `MockInput::send_input` methods, in favor of new input mocking APIs (see 'Usability: MockInput' for details).
 - `DualAxisData` has been removed, and replaced with a simple `Vec2` throughout
   - a new type with the `DualAxisData` name has been added, as a parallel to `ButtonData` and `AxisData`
-- when no `associated_gamepad` is provided to an input map, `find_gamepad` will be called to attempt to search for a gamepad. Input from *any* gamepad will no longer work
+- when no `associated_gamepad` is provided to an input map, `find_gamepad` will be called to attempt to search for a gamepad. Input from _any_ gamepad will no longer work
 - `SummarizedActionState` is now found in the `action_diff` module
 - Axislike and DualAxislike inputs no longer send pressed / released `ActionDiff`s: only `AxisChanged` and `DualAxisChanged` events
 

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -4,13 +4,13 @@ use crate::input_map::UpdatedValue;
 use crate::{action_diff::ActionDiff, input_map::UpdatedActions};
 use crate::{Actionlike, InputControlKind};
 
-use bevy::math::Vec2;
 use bevy::prelude::Resource;
 use bevy::reflect::Reflect;
 #[cfg(feature = "timing")]
 use bevy::utils::Duration;
 use bevy::utils::{HashMap, Instant};
 use bevy::{ecs::component::Component, prelude::ReflectComponent};
+use bevy::{math::Vec2, prelude::ReflectResource};
 use serde::{Deserialize, Serialize};
 
 mod action_data;
@@ -80,7 +80,7 @@ pub use action_data::*;
 /// assert!(!action_state.just_released(&Action::Jump));
 /// ```
 #[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
-#[reflect(Component)]
+#[reflect(Resource, Component)]
 pub struct ActionState<A: Actionlike> {
     /// Whether or not all of the actions are disabled.
     disabled: bool,

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -4,13 +4,13 @@ use crate::input_map::UpdatedValue;
 use crate::{action_diff::ActionDiff, input_map::UpdatedActions};
 use crate::{Actionlike, InputControlKind};
 
-use bevy::ecs::component::Component;
 use bevy::math::Vec2;
 use bevy::prelude::Resource;
 use bevy::reflect::Reflect;
 #[cfg(feature = "timing")]
 use bevy::utils::Duration;
 use bevy::utils::{HashMap, Instant};
+use bevy::{ecs::component::Component, prelude::ReflectComponent};
 use serde::{Deserialize, Serialize};
 
 mod action_data;
@@ -80,6 +80,7 @@ pub use action_data::*;
 /// assert!(!action_state.just_released(&Action::Jump));
 /// ```
 #[derive(Resource, Component, Clone, Debug, PartialEq, Serialize, Deserialize, Reflect)]
+#[reflect(Component)]
 pub struct ActionState<A: Actionlike> {
     /// Whether or not all of the actions are disabled.
     disabled: bool,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -4,10 +4,10 @@ use std::fmt::Debug;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
-use bevy::log::error;
 use bevy::math::Vec2;
 use bevy::prelude::{Component, Deref, DerefMut, Gamepad, Gamepads, Reflect, Resource};
 use bevy::utils::HashMap;
+use bevy::{log::error, prelude::ReflectComponent};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -110,6 +110,7 @@ fn find_gamepad(_gamepads: &Gamepads) -> Gamepad {
 /// ```
 #[derive(Resource, Component, Debug, Clone, PartialEq, Eq, Reflect, Serialize, Deserialize)]
 #[cfg_attr(feature = "asset", derive(Asset))]
+#[reflect(Component)]
 pub struct InputMap<A: Actionlike> {
     /// The underlying map that stores action-input mappings for [`Buttonlike`] actions.
     buttonlike_map: HashMap<A, Vec<Box<dyn Buttonlike>>>,

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -4,10 +4,10 @@ use std::fmt::Debug;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
-use bevy::math::Vec2;
 use bevy::prelude::{Component, Deref, DerefMut, Gamepad, Gamepads, Reflect, Resource};
 use bevy::utils::HashMap;
 use bevy::{log::error, prelude::ReflectComponent};
+use bevy::{math::Vec2, prelude::ReflectResource};
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
@@ -110,7 +110,7 @@ fn find_gamepad(_gamepads: &Gamepads) -> Gamepad {
 /// ```
 #[derive(Resource, Component, Debug, Clone, PartialEq, Eq, Reflect, Serialize, Deserialize)]
 #[cfg_attr(feature = "asset", derive(Asset))]
-#[reflect(Component)]
+#[reflect(Resource, Component)]
 pub struct InputMap<A: Actionlike> {
     /// The underlying map that stores action-input mappings for [`Buttonlike`] actions.
     buttonlike_map: HashMap<A, Vec<Box<dyn Buttonlike>>>,


### PR DESCRIPTION
blenvy requires the ReflectComponent data when instantiating blueprints.