### PR TITLE
Fixes #589: compilation for target wasm32-unknown-unknown

### DIFF
--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -1,8 +1,6 @@
 //! Contains types used to store the state of the actions held in an [`ActionState`](super::ActionState).
 
-use std::time::Instant;
-
-use bevy::{math::Vec2, reflect::Reflect};
+use bevy::{math::Vec2, reflect::Reflect, utils::Instant};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "timing")]


### PR DESCRIPTION
The fix is simply to use bevy_utils::Instant instead of std::time::Instant in action_data.

Fixes #589.