### PR TITLE
Implement MapEntities for ActionDiffEvent

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -12,6 +12,10 @@
 
 - Reflect `Component` and `Resource`, which enables accessing the data in the type registry
 
+#### ActionDiffEvent
+
+- Implement `MapEntities`, which lets networking crates translate owner entity IDs between ECS worlds
+
 ## Version 0.15.0
 
 ### Enhancements (0.15)

--- a/src/action_diff.rs
+++ b/src/action_diff.rs
@@ -6,7 +6,10 @@
 //! about things like keybindings or input devices.
 
 use bevy::{
-    ecs::{entity::{Entity, MapEntities}, event::Event},
+    ecs::{
+        entity::{Entity, MapEntities},
+        event::Event,
+    },
     math::Vec2,
     prelude::{EntityMapper, EventWriter, Query, Res},
     utils::{HashMap, HashSet},

--- a/src/action_diff.rs
+++ b/src/action_diff.rs
@@ -65,7 +65,7 @@ pub struct ActionDiffEvent<A: Actionlike> {
 /// Implements entity mapping for `ActionDiffEvent`.
 ///
 /// This allows the owner entity to be remapped when transferring event diffs
-/// between different ECS contexts (e.g. client and server).
+/// between different ECS worlds (e.g. client and server).
 impl<A: Actionlike> MapEntities for ActionDiffEvent<A> {
     fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
         self.owner = self.owner.map(|entity| entity_mapper.map_entity(entity));

--- a/src/action_diff.rs
+++ b/src/action_diff.rs
@@ -6,9 +6,9 @@
 //! about things like keybindings or input devices.
 
 use bevy::{
-    ecs::{entity::Entity, event::Event},
+    ecs::{entity::{Entity, MapEntities}, event::Event},
     math::Vec2,
-    prelude::{EventWriter, Query, Res},
+    prelude::{EntityMapper, EventWriter, Query, Res},
     utils::{HashMap, HashSet},
 };
 use serde::{Deserialize, Serialize};
@@ -60,6 +60,16 @@ pub struct ActionDiffEvent<A: Actionlike> {
     pub owner: Option<Entity>,
     /// The `ActionDiff` that was generated
     pub action_diffs: Vec<ActionDiff<A>>,
+}
+
+/// Implements entity mapping for `ActionDiffEvent`.
+///
+/// This allows the owner entity to be remapped when transferring event diffs
+/// between different ECS contexts (e.g. client and server).
+impl<A: Actionlike> MapEntities for ActionDiffEvent<A> {
+    fn map_entities<M: EntityMapper>(&mut self, entity_mapper: &mut M) {
+        self.owner = self.owner.map(|entity| entity_mapper.map_entity(entity));
+    }
 }
 
 /// Stores the state of all actions in the current frame.


### PR DESCRIPTION
Implementing `MapEntities` for `ActionDiffEvent`s allows networking crates like replicon to automatically translate the ID of the "owner entity" for action diffs from the client's set of entity IDs to the server's (or vice versa).

------------------

I'm new to contributing to LWIM, should I open an issue first? Let me know if anything else is needed :)