### PR TITLE
Add `TripleAxislike`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,6 +2,15 @@
 
 ## Version 0.15.1
 
+### Enhancements (0.15.1)
+
+- added `TripleAxislike` trait for inputs that track all X, Y, and Z axes.
+  - added `KeyboardVirtualDPad3D` that consists of six `KeyCode`s to represent a triple-axis-like input.
+  - added `TripleAxislikeChord` that groups a `Buttonlike` and a `TripleAxislike` together.
+  - added related variants such as:
+    - `InputControlType::TripleAxis`
+    - `ActionDiff::TripleAxisChanged` 
+
 ### Usability (0.15.1)
 
 #### InputMap

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -1,6 +1,10 @@
 //! Contains types used to store the state of the actions held in an [`ActionState`](super::ActionState).
 
-use bevy::{math::Vec2, reflect::Reflect, utils::Instant};
+use bevy::{
+    math::{Vec2, Vec3},
+    reflect::Reflect,
+    utils::Instant,
+};
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "timing")]
@@ -30,6 +34,9 @@ impl ActionData {
                 InputControlKind::Button => ActionKindData::Button(ButtonData::default()),
                 InputControlKind::Axis => ActionKindData::Axis(AxisData::default()),
                 InputControlKind::DualAxis => ActionKindData::DualAxis(DualAxisData::default()),
+                InputControlKind::TripleAxis => {
+                    ActionKindData::TripleAxis(TripleAxisData::default())
+                }
             },
         }
     }
@@ -45,6 +52,7 @@ impl ActionData {
             }
             ActionKindData::Axis(ref mut _data) => {}
             ActionKindData::DualAxis(ref mut _data) => {}
+            ActionKindData::TripleAxis(ref mut _data) => {}
         }
     }
 }
@@ -58,6 +66,8 @@ pub enum ActionKindData {
     Axis(AxisData),
     /// The data for a dual-axis-like action.
     DualAxis(DualAxisData),
+    /// The data for a triple-axis-like action.
+    TripleAxis(TripleAxisData),
 }
 
 impl ActionKindData {
@@ -77,6 +87,10 @@ impl ActionKindData {
                 data.fixed_update_pair = data.pair;
                 data.pair = data.update_pair;
             }
+            Self::TripleAxis(data) => {
+                data.fixed_update_triple = data.triple;
+                data.triple = data.update_triple;
+            }
         }
     }
 
@@ -95,6 +109,10 @@ impl ActionKindData {
             Self::DualAxis(data) => {
                 data.update_pair = data.pair;
                 data.pair = data.fixed_update_pair;
+            }
+            Self::TripleAxis(data) => {
+                data.update_triple = data.triple;
+                data.triple = data.fixed_update_triple;
             }
         }
     }
@@ -195,4 +213,15 @@ pub struct DualAxisData {
     pub update_pair: Vec2,
     /// The `pair` of the action in the `FixedMain` schedule
     pub fixed_update_pair: Vec2,
+}
+
+/// The raw data for an [`ActionState`](super::ActionState) corresponding to a triple of virtual axes.
+#[derive(Clone, Default, Debug, PartialEq, Serialize, Deserialize, Reflect)]
+pub struct TripleAxisData {
+    /// The XYZ coordinates of the axis
+    pub triple: Vec3,
+    /// The `triple` of the action in the `Main` schedule
+    pub update_triple: Vec3,
+    /// The `triple` of the action in the `FixedMain` schedule
+    pub fixed_update_triple: Vec3,
 }

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -662,7 +662,7 @@ impl<A: Actionlike> ActionState<A> {
         triple_axis_data.triple = triple;
     }
 
-    /// Get the [`Vec3`] associated with the corresponding `action`, clamped to `[-1.0, 1.0]`.
+    /// Get the [`Vec3`] associated with the corresponding `action`, clamped to the cube of values bounded by -1 and 1 on all axes.
     ///
     /// # Warning
     ///

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -10,7 +10,10 @@ use bevy::reflect::Reflect;
 use bevy::utils::Duration;
 use bevy::utils::{HashMap, Instant};
 use bevy::{ecs::component::Component, prelude::ReflectComponent};
-use bevy::{math::Vec2, prelude::ReflectResource};
+use bevy::{
+    math::{Vec2, Vec3},
+    prelude::ReflectResource,
+};
 use serde::{Deserialize, Serialize};
 
 mod action_data;
@@ -147,6 +150,9 @@ impl<A: Actionlike> ActionState<A> {
                 }
                 UpdatedValue::DualAxis(pair) => {
                     self.set_axis_pair(action, *pair);
+                }
+                UpdatedValue::TripleAxis(triple) => {
+                    self.set_axis_triple(action, *triple);
                 }
             }
         }
@@ -453,6 +459,76 @@ impl<A: Actionlike> ActionState<A> {
         dual_axis_data
     }
 
+    /// A reference of the [`TripleAxisData`] corresponding to the `action`.
+    ///
+    /// # Caution
+    ///
+    /// To access the [`TripleAxisData`] regardless of whether the `action` has been triggered,
+    /// use [`unwrap_or_default`](Option::unwrap_or_default) on the returned [`Option`].
+    ///
+    /// # Returns
+    ///
+    /// - `Some(TripleAxisData)` if it exists.
+    /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
+    #[inline]
+    #[must_use]
+    pub fn triple_axis_data(&self, action: &A) -> Option<&TripleAxisData> {
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
+
+        match self.action_data(action) {
+            Some(action_data) => match action_data.kind_data {
+                ActionKindData::TripleAxis(ref triple_axis_data) => Some(triple_axis_data),
+                _ => None,
+            },
+            None => None,
+        }
+    }
+
+    /// A mutable reference of the [`TripleAxisData`] corresponding to the `action`.
+    ///
+    /// # Caution
+    ///
+    /// To insert a default [`TripleAxisData`] if it doesn't exist,
+    /// use [`triple_axis_data_mut_or_default`](Self::dual_axis_data_mut_or_default) method.
+    ///
+    /// # Returns
+    ///
+    /// - `Some(ButtonData)` if it exists.
+    /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
+    #[inline]
+    #[must_use]
+    pub fn triple_axis_data_mut(&mut self, action: &A) -> Option<&mut TripleAxisData> {
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
+
+        match self.action_data_mut(action) {
+            Some(action_data) => match &mut action_data.kind_data {
+                ActionKindData::TripleAxis(ref mut triple_axis_data) => Some(triple_axis_data),
+                _ => None,
+            },
+            None => None,
+        }
+    }
+
+    /// A mutable reference of the [`TripleAxisData`] corresponding to the `action` initializing it if needed.
+    ///
+    /// If the `action` has no data yet (because the `action` has not been triggered),
+    /// this method will create and insert a default [`TripleAxisData`] for you,
+    /// avoiding potential errors from unwrapping [`None`].
+    ///
+    /// Generally, it'll be clearer to call `pressed` or so on directly on the [`ActionState`].
+    /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
+    #[inline]
+    #[must_use]
+    pub fn triple_axis_data_mut_or_default(&mut self, action: &A) -> &mut TripleAxisData {
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
+
+        let action_data = self.action_data_mut_or_default(action);
+        let ActionKindData::TripleAxis(ref mut triple_axis_data) = action_data.kind_data else {
+            panic!("{action:?} is not a TripleAxis");
+        };
+        triple_axis_data
+    }
+
     /// Get the value associated with the corresponding `action` if present.
     ///
     /// Different kinds of bindings have different ways of calculating the value:
@@ -551,6 +627,52 @@ impl<A: Actionlike> ActionState<A> {
         pair.clamp(Vec2::NEG_ONE, Vec2::ONE)
     }
 
+    /// Get the [`Vec3`] from the binding that triggered the corresponding `action`.
+    ///
+    /// Only events that represent triple-axis control provide a [`Vec3`],
+    /// and this will return [`None`] for other events.
+    ///
+    /// If multiple inputs with an axis triple trigger the same game action at the same time, the
+    /// value of each axis triple will be added together.
+    ///
+    /// # Warning
+    ///
+    /// This value will be [`Vec3::ZERO`] by default,
+    /// even if the action is not a triple-axislike action.
+    ///
+    /// These values may not be bounded as you might expect.
+    /// Consider clamping this to account for multiple triggering inputs,
+    /// typically using the [`clamped_axis_triple`](Self::clamped_axis_triple) method instead.
+    pub fn axis_triple(&self, action: &A) -> Vec3 {
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
+
+        if self.action_disabled(action) {
+            return Vec3::ZERO;
+        }
+
+        let action_data = self.triple_axis_data(action);
+        action_data.map_or(Vec3::ZERO, |action_data| action_data.triple)
+    }
+
+    /// Sets the [`Vec2`] of the `action` to the provided `pair`.
+    pub fn set_axis_triple(&mut self, action: &A, triple: Vec3) {
+        debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
+
+        let triple_axis_data = self.triple_axis_data_mut_or_default(action);
+        triple_axis_data.triple = triple;
+    }
+
+    /// Get the [`Vec3`] associated with the corresponding `action`, clamped to `[-1.0, 1.0]`.
+    ///
+    /// # Warning
+    ///
+    /// This value will be [`Vec3::ZERO`] by default,
+    /// even if the action is not a dual-axislike action.
+    pub fn clamped_axis_triple(&self, action: &A) -> Vec3 {
+        let triple = self.axis_triple(action);
+        triple.clamp(Vec3::NEG_ONE, Vec3::ONE)
+    }
+
     /// Manually sets the [`ButtonData`] of the corresponding `action`
     ///
     /// You should almost always use more direct methods, as they are simpler and less error-prone.
@@ -643,12 +765,16 @@ impl<A: Actionlike> ActionState<A> {
             InputControlKind::DualAxis => {
                 self.set_axis_pair(action, Vec2::ZERO);
             }
+            InputControlKind::TripleAxis => {
+                self.set_axis_triple(action, Vec3::ZERO);
+            }
         }
     }
 
     /// Releases all [`Buttonlike`](crate::user_input::Buttonlike) actions,
     /// sets all [`Axislike`](crate::user_input::Axislike) actions to 0,
-    /// and sets all [`DualAxislike`](crate::user_input::DualAxislike) actions to [`Vec2::ZERO`].
+    /// sets all [`DualAxislike`](crate::user_input::DualAxislike) actions to [`Vec2::ZERO`],
+    /// and sets all [`TripleAxislike`](crate::user_input::TripleAxislike) actions to [`Vec3::ZERO`].
     pub fn reset_all(&mut self) {
         // Collect out to avoid angering the borrow checker
         let all_actions = self.action_data.keys().cloned().collect::<Vec<A>>();
@@ -917,6 +1043,12 @@ impl<A: Actionlike> ActionState<A> {
             }
             ActionDiff::DualAxisChanged { action, axis_pair } => {
                 self.set_axis_pair(action, *axis_pair);
+            }
+            ActionDiff::TripleAxisChanged {
+                action,
+                axis_triple,
+            } => {
+                self.set_axis_triple(action, *axis_triple);
             }
         };
     }

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -258,6 +258,16 @@ impl<A: Actionlike> InputMap<A> {
                     .map(|input| input.decompose())
                     .collect()
             }
+            InputControlKind::TripleAxis => {
+                let Some(triple_axislike) = self.get_triple_axislike(action) else {
+                    return Vec::new();
+                };
+
+                triple_axislike
+                    .iter()
+                    .map(|input| input.decompose())
+                    .collect()
+            }
         }
     }
 
@@ -403,7 +413,6 @@ fn resolve_clash<A: Actionlike>(
 #[cfg(feature = "keyboard")]
 #[cfg(test)]
 mod tests {
-    use bevy::app::App;
     use bevy::input::keyboard::KeyCode::*;
     use bevy::prelude::Reflect;
 
@@ -469,7 +478,7 @@ mod tests {
             plugin::{AccumulatorPlugin, CentralInputStorePlugin},
             prelude::{AccumulatedMouseMovement, AccumulatedMouseScroll, ModifierKey},
         };
-        use bevy::{input::InputPlugin, math::Vec2, prelude::Gamepads};
+        use bevy::{input::InputPlugin, prelude::*};
         use Action::*;
 
         use super::*;
@@ -742,6 +751,7 @@ mod tests {
                         UpdatedValue::Button(pressed) => assert!(!pressed),
                         UpdatedValue::Axis(value) => assert_eq!(value, 0.0),
                         UpdatedValue::DualAxis(pair) => assert_eq!(pair, Vec2::ZERO),
+                        UpdatedValue::TripleAxis(triple) => assert_eq!(triple, Vec3::ZERO),
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -160,4 +160,9 @@ pub enum InputControlKind {
     ///
     /// Corresponds to [`DualAxislike`](crate::user_input::DualAxislike) inputs.
     DualAxis,
+
+    /// A combination of three axis-like inputs, providing separate values for the X, Y and Z axes.
+    ///
+    /// Corresponds to [`TripleAxislike`](crate::user_input::TripleAxislike) inputs.
+    TripleAxis,
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -212,7 +212,8 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
         app.register_user_input::<KeyCode>()
             .register_user_input::<ModifierKey>()
             .register_user_input::<KeyboardVirtualAxis>()
-            .register_user_input::<KeyboardVirtualDPad>();
+            .register_user_input::<KeyboardVirtualDPad>()
+            .register_user_input::<KeyboardVirtualDPad3D>();
 
         #[cfg(feature = "gamepad")]
         app.register_user_input::<GamepadControlDirection>()
@@ -225,7 +226,8 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
         // Chords
         app.register_user_input::<ButtonlikeChord>()
             .register_user_input::<AxislikeChord>()
-            .register_user_input::<DualAxislikeChord>();
+            .register_user_input::<DualAxislikeChord>()
+            .register_user_input::<TripleAxislikeChord>();
 
         // General-purpose reflection
         app.register_type::<ActionState<A>>()

--- a/src/user_input/trait_reflection.rs
+++ b/src/user_input/trait_reflection.rs
@@ -660,3 +660,164 @@ mod dualaxislike {
         }
     }
 }
+
+mod tripleaxislike {
+    use super::*;
+
+    use crate::user_input::TripleAxislike;
+
+    dyn_clone::clone_trait_object!(TripleAxislike);
+    dyn_eq::eq_trait_object!(TripleAxislike);
+    dyn_hash::hash_trait_object!(TripleAxislike);
+
+    impl Reflect for Box<dyn TripleAxislike> {
+        fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
+            Some(Self::type_info())
+        }
+
+        fn into_any(self: Box<Self>) -> Box<dyn Any> {
+            self
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+
+        fn as_any_mut(&mut self) -> &mut dyn Any {
+            self
+        }
+
+        fn into_reflect(self: Box<Self>) -> Box<dyn Reflect> {
+            self
+        }
+
+        fn as_reflect(&self) -> &dyn Reflect {
+            self
+        }
+
+        fn as_reflect_mut(&mut self) -> &mut dyn Reflect {
+            self
+        }
+
+        fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
+            let value = value.as_any();
+            if let Some(value) = value.downcast_ref::<Self>() {
+                *self = value.clone();
+                Ok(())
+            } else {
+                Err(bevy::reflect::ApplyError::MismatchedTypes {
+                    from_type: self
+                        .reflect_type_ident()
+                        .unwrap_or_default()
+                        .to_string()
+                        .into_boxed_str(),
+                    to_type: self
+                        .reflect_type_ident()
+                        .unwrap_or_default()
+                        .to_string()
+                        .into_boxed_str(),
+                })
+            }
+        }
+
+        fn apply(&mut self, value: &dyn Reflect) {
+            Self::try_apply(self, value).unwrap();
+        }
+
+        fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
+            *self = value.take()?;
+            Ok(())
+        }
+
+        fn reflect_kind(&self) -> ReflectKind {
+            ReflectKind::Value
+        }
+
+        fn reflect_ref(&self) -> ReflectRef {
+            ReflectRef::Value(self)
+        }
+
+        fn reflect_mut(&mut self) -> ReflectMut {
+            ReflectMut::Value(self)
+        }
+
+        fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+            ReflectOwned::Value(self)
+        }
+
+        fn clone_value(&self) -> Box<dyn Reflect> {
+            Box::new(self.clone())
+        }
+
+        fn reflect_hash(&self) -> Option<u64> {
+            let mut hasher = reflect_hasher();
+            let type_id = TypeId::of::<Self>();
+            Hash::hash(&type_id, &mut hasher);
+            Hash::hash(self, &mut hasher);
+            Some(hasher.finish())
+        }
+
+        fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
+            value
+                .as_any()
+                .downcast_ref::<Self>()
+                .map(|value| self.dyn_eq(value))
+                .or(Some(false))
+        }
+
+        fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+            Debug::fmt(self, f)
+        }
+    }
+
+    impl Typed for Box<dyn TripleAxislike> {
+        fn type_info() -> &'static TypeInfo {
+            static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
+            CELL.get_or_set(|| TypeInfo::Value(ValueInfo::new::<Self>()))
+        }
+    }
+
+    impl TypePath for Box<dyn TripleAxislike> {
+        fn type_path() -> &'static str {
+            static CELL: GenericTypePathCell = GenericTypePathCell::new();
+            CELL.get_or_insert::<Self, _>(|| {
+                {
+                    format!("std::boxed::Box<dyn {}::TripleAxislike>", module_path!())
+                }
+            })
+        }
+
+        fn short_type_path() -> &'static str {
+            static CELL: GenericTypePathCell = GenericTypePathCell::new();
+            CELL.get_or_insert::<Self, _>(|| "Box<dyn TripleAxislike>".to_string())
+        }
+
+        fn type_ident() -> Option<&'static str> {
+            Some("Box<dyn TripleAxislike>")
+        }
+
+        fn crate_name() -> Option<&'static str> {
+            module_path!().split(':').next()
+        }
+
+        fn module_path() -> Option<&'static str> {
+            Some(module_path!())
+        }
+    }
+
+    impl GetTypeRegistration for Box<dyn TripleAxislike> {
+        fn get_type_registration() -> TypeRegistration {
+            let mut registration = TypeRegistration::of::<Self>();
+            registration.insert::<ReflectDeserialize>(FromType::<Self>::from_type());
+            registration.insert::<ReflectFromPtr>(FromType::<Self>::from_type());
+            registration.insert::<ReflectSerialize>(FromType::<Self>::from_type());
+            registration
+        }
+    }
+
+    impl FromReflect for Box<dyn TripleAxislike> {
+        fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
+            Some(reflect.as_any().downcast_ref::<Self>()?.clone())
+        }
+    }
+}

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -100,6 +100,12 @@ fn assert_action_diff_received(app: &mut App, action_diff_event: ActionDiffEvent
         ActionDiff::DualAxisChanged { action, axis_pair } => {
             assert_eq!(action_state.axis_pair(&action), axis_pair);
         }
+        ActionDiff::TripleAxisChanged {
+            action,
+            axis_triple,
+        } => {
+            assert_eq!(action_state.axis_triple(&action), axis_triple);
+        }
     }
 }
 
@@ -137,6 +143,9 @@ fn generate_binary_action_diffs() {
             ActionDiff::DualAxisChanged { .. } => {
                 panic!("Expected a `Pressed` variant got a `DualAxisChanged` variant")
             }
+            ActionDiff::TripleAxisChanged { .. } => {
+                panic!("Expected a `Pressed` variant got a `TripleAxisChanged` variant")
+            }
         }
     });
 
@@ -168,6 +177,9 @@ fn generate_binary_action_diffs() {
             }
             ActionDiff::DualAxisChanged { .. } => {
                 panic!("Expected a `Released` variant got a `DualAxisChanged` variant")
+            }
+            ActionDiff::TripleAxisChanged { .. } => {
+                panic!("Expected a `Released` variant got a `TripleAxisChanged` variant")
             }
         }
     });
@@ -210,6 +222,9 @@ fn generate_axis_action_diffs() {
             ActionDiff::AxisChanged { .. } => {
                 panic!("Expected a `DualAxisChanged` variant got a `AxisChanged` variant")
             }
+            ActionDiff::TripleAxisChanged { .. } => {
+                panic!("Expected a `DualAxisChanged` variant got a `TripleAxisChanged` variant")
+            }
         }
     });
 
@@ -242,6 +257,9 @@ fn generate_axis_action_diffs() {
             }
             ActionDiff::AxisChanged { .. } => {
                 panic!("Expected a `DualAxisChanged` variant got a `AxisChanged` variant")
+            }
+            ActionDiff::TripleAxisChanged { .. } => {
+                panic!("Expected a `DualAxisChanged` variant got a `TripleAxisChanged` variant")
             }
         }
     });


### PR DESCRIPTION
- added `TripleAxislike` trait for inputs that track all X, Y, and Z axes.
  - added `KeyboardVirtualDPad3D` that consists of six `KeyCode`s to represent a triple-axis-like input.
  - added `TripleAxislikeChord` that groups a `Buttonlike` and a `TripleAxislike` together.
  - added related variants such as:
    - `InputControlType::TripleAxis`
    - `ActionDiff::TripleAxisChanged` 