### PR TITLE
Fix buggy examples

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -19,7 +19,7 @@
 
 #### Actionlike
 
- - added `#[actionlike]` for actions to set their input kinds, either on an enum or on its individual variants.
+- added `#[actionlike]` for actions to set their input kinds, either on an enum or on its individual variants.
 
 #### ActionState
 
@@ -28,6 +28,10 @@
 #### ActionDiffEvent
 
 - Implement `MapEntities`, which lets networking crates translate owner entity IDs between ECS worlds
+
+### Bugs (0.15.1)
+
+- `InputMap::get_pressed` and siblings now check if the action kind is buttonlike before checking if they are pressed or released, avoiding a debug-mode panic
 
 ## Version 0.15.0
 

--- a/examples/action_state_resource.rs
+++ b/examples/action_state_resource.rs
@@ -21,6 +21,7 @@ fn main() {
 
 #[derive(Actionlike, PartialEq, Eq, Clone, Copy, Hash, Debug, Reflect)]
 pub enum PlayerAction {
+    #[actionlike(DualAxis)]
     Move,
     Jump,
 }
@@ -37,11 +38,8 @@ fn move_player(
     // action_state is stored as a resource
     action_state: Res<ActionState<PlayerAction>>,
 ) {
-    if action_state.pressed(&PlayerAction::Move) {
-        // We're working with gamepads, so we want to defensively ensure that we're using the clamped values
-        let axis_pair = action_state.clamped_axis_pair(&PlayerAction::Move);
-        println!("Move: ({}, {})", axis_pair.x, axis_pair.y);
-    }
+    let axis_pair = action_state.clamped_axis_pair(&PlayerAction::Move);
+    println!("Move: ({}, {})", axis_pair.x, axis_pair.y);
 
     if action_state.pressed(&PlayerAction::Jump) {
         println!("Jumping!");

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -49,15 +49,11 @@ fn spawn_player(mut commands: Commands) {
 fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
 
-    // Each action has a button-like state of its own that you can check
-    if action_state.pressed(&Action::Move) {
-        // We're working with gamepads, so we want to defensively ensure that we're using the clamped values
-        let axis_pair = action_state.clamped_axis_pair(&Action::Move);
-        println!("Move:");
-        println!("   distance: {}", axis_pair.length());
-        println!("          x: {}", axis_pair.x);
-        println!("          y: {}", axis_pair.y);
-    }
+    let axis_pair = action_state.clamped_axis_pair(&Action::Move);
+    println!("Move:");
+    println!("   distance: {}", axis_pair.length());
+    println!("          x: {}", axis_pair.x);
+    println!("          y: {}", axis_pair.y);
 
     if action_state.pressed(&Action::Throttle) {
         // Note that some gamepad buttons are also tied to axes, so even though we used a
@@ -70,8 +66,6 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
         println!("Throttle: {value}");
     }
 
-    if action_state.pressed(&Action::Rudder) {
-        let value = action_state.clamped_value(&Action::Rudder);
-        println!("Rudder: {value}");
-    }
+    let value = action_state.clamped_value(&Action::Rudder);
+    println!("Rudder: {value}");
 }

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -54,20 +54,17 @@ fn spawn_player(mut commands: Commands) {
 fn use_actions(query: Query<&ActionState<PlayerAction>, With<Player>>) {
     let action_state = query.single();
 
-    // When the default input for `PlayerAction::Run` is pressed, print the clamped direction of the axis
-    if action_state.pressed(&PlayerAction::Run) {
+    if action_state.axis_pair(&PlayerAction::Run) != Vec2::ZERO {
         println!(
             "Moving in direction {}",
             action_state.clamped_axis_pair(&PlayerAction::Run).xy()
         );
     }
 
-    // When the default input for `PlayerAction::Jump` is pressed, print "Jump!"
     if action_state.just_pressed(&PlayerAction::Jump) {
         println!("Jumped!");
     }
 
-    // When the default input for `PlayerAction::UseItem` is pressed, print "Used an Item!"
     if action_state.just_pressed(&PlayerAction::UseItem) {
         println!("Used an Item!");
     }

--- a/examples/twin_stick_controller.rs
+++ b/examples/twin_stick_controller.rs
@@ -113,8 +113,6 @@ fn activate_mkb(
 
 // ----------------------------- Mouse input handling-----------------------------
 
-/// Note that we handle the action state mutation differently here than in the `mouse_position` example.
-/// Here we don't use an `ActionStateDriver`, but change the action data directly.
 fn player_mouse_look(
     camera_query: Query<(&GlobalTransform, &Camera)>,
     player_query: Query<&Transform, With<Player>>,
@@ -148,9 +146,6 @@ fn player_mouse_look(
             // Flipping y sign here to be consistent with gamepad input.
             // We could also invert the gamepad y-axis
             action_data.pair = Vec2::new(diff.x, -diff.y);
-
-            // Press the look action, so we can check that it is active
-            action_state.press(&PlayerAction::Look);
         }
     }
 }
@@ -162,7 +157,7 @@ fn control_player(
     mut query: Query<&mut Transform, With<Player>>,
 ) {
     let mut player_transform = query.single_mut();
-    if action_state.pressed(&PlayerAction::Move) {
+    if action_state.axis_pair(&PlayerAction::Move) != Vec2::ZERO {
         // Note: In a real game we'd feed this into an actual player controller
         // and respects the camera extrinsics to ensure the direction is correct
         let move_delta =
@@ -171,7 +166,7 @@ fn control_player(
         println!("Player moved to: {}", player_transform.translation.xz());
     }
 
-    if action_state.pressed(&PlayerAction::Look) {
+    if action_state.axis_pair(&PlayerAction::Look) != Vec2::ZERO {
         let look = action_state.axis_pair(&PlayerAction::Look).xy().normalize();
         println!("Player looking in direction: {}", look);
     }
@@ -196,6 +191,4 @@ fn setup_scene(mut commands: Commands) {
 
     // And a player
     commands.spawn(Player).insert(Transform::default());
-
-    // But note that there is no visibility in this example
 }

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -39,8 +39,7 @@ fn spawn_player(mut commands: Commands) {
 // Query for the `ActionState` component in your game logic systems!
 fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
-    // If any button in a virtual direction pad is pressed, then the action state is "pressed"
-    if action_state.pressed(&Action::Move) {
+    if action_state.axis_pair(&Action::Move) != Vec2::ZERO {
         // Virtual direction pads are one of the types which return a DualAxis. The values will be
         // represented as `-1.0`, `0.0`, or `1.0` depending on the combination of buttons pressed.
         let axis_pair = action_state.axis_pair(&Action::Move);

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -970,6 +970,7 @@ impl<A: Actionlike> ActionState<A> {
 
         all_actions
             .into_iter()
+            .filter(|action| action.input_control_kind() == InputControlKind::Button)
             .filter(|action| self.pressed(action))
             .collect()
     }
@@ -981,6 +982,7 @@ impl<A: Actionlike> ActionState<A> {
 
         all_actions
             .into_iter()
+            .filter(|action| action.input_control_kind() == InputControlKind::Button)
             .filter(|action| self.just_pressed(action))
             .collect()
     }
@@ -992,6 +994,7 @@ impl<A: Actionlike> ActionState<A> {
 
         all_actions
             .into_iter()
+            .filter(|action| action.input_control_kind() == InputControlKind::Button)
             .filter(|action| self.released(action))
             .collect()
     }
@@ -1003,6 +1006,7 @@ impl<A: Actionlike> ActionState<A> {
 
         all_actions
             .into_iter()
+            .filter(|action| action.input_control_kind() == InputControlKind::Button)
             .filter(|action| self.just_released(action))
             .collect()
     }

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -311,6 +311,7 @@ impl<A: Actionlike> ActionState<A> {
     /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn button_data_mut_or_default(&mut self, action: &A) -> &mut ButtonData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -334,6 +335,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn axis_data(&self, action: &A) -> Option<&AxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
@@ -379,6 +381,7 @@ impl<A: Actionlike> ActionState<A> {
     /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn axis_data_mut_or_default(&mut self, action: &A) -> &mut AxisData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
@@ -402,6 +405,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn dual_axis_data(&self, action: &A) -> Option<&DualAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
@@ -427,6 +431,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn dual_axis_data_mut(&mut self, action: &A) -> Option<&mut DualAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
@@ -449,6 +454,7 @@ impl<A: Actionlike> ActionState<A> {
     /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn dual_axis_data_mut_or_default(&mut self, action: &A) -> &mut DualAxisData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
@@ -472,6 +478,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn triple_axis_data(&self, action: &A) -> Option<&TripleAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
 
@@ -497,6 +504,7 @@ impl<A: Actionlike> ActionState<A> {
     /// - `None` if the `action` has never been triggered (pressed, clicked, etc.).
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn triple_axis_data_mut(&mut self, action: &A) -> Option<&mut TripleAxisData> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
 
@@ -519,6 +527,7 @@ impl<A: Actionlike> ActionState<A> {
     /// However, accessing the raw data directly allows you to examine detailed metadata holistically.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn triple_axis_data_mut_or_default(&mut self, action: &A) -> &mut TripleAxisData {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
 
@@ -550,6 +559,9 @@ impl<A: Actionlike> ActionState<A> {
     /// This value may not be bounded as you might expect.
     /// Consider clamping this to account for multiple triggering inputs,
     /// typically using the [`clamped_value`](Self::clamped_value) method instead.
+    #[inline]
+    #[must_use]
+    #[track_caller]
     pub fn value(&self, action: &A) -> f32 {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
@@ -564,6 +576,7 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     /// Sets the value of the `action` to the provided `value`.
+    #[track_caller]
     pub fn set_value(&mut self, action: &A, value: f32) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Axis);
 
@@ -597,6 +610,8 @@ impl<A: Actionlike> ActionState<A> {
     /// These values may not be bounded as you might expect.
     /// Consider clamping this to account for multiple triggering inputs,
     /// typically using the [`clamped_axis_pair`](Self::clamped_axis_pair) method instead.
+    #[must_use]
+    #[track_caller]
     pub fn axis_pair(&self, action: &A) -> Vec2 {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
@@ -609,6 +624,7 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     /// Sets the [`Vec2`] of the `action` to the provided `pair`.
+    #[track_caller]
     pub fn set_axis_pair(&mut self, action: &A, pair: Vec2) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::DualAxis);
 
@@ -643,6 +659,8 @@ impl<A: Actionlike> ActionState<A> {
     /// These values may not be bounded as you might expect.
     /// Consider clamping this to account for multiple triggering inputs,
     /// typically using the [`clamped_axis_triple`](Self::clamped_axis_triple) method instead.
+    #[must_use]
+    #[track_caller]
     pub fn axis_triple(&self, action: &A) -> Vec3 {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
 
@@ -655,6 +673,7 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     /// Sets the [`Vec2`] of the `action` to the provided `pair`.
+    #[track_caller]
     pub fn set_axis_triple(&mut self, action: &A, triple: Vec3) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::TripleAxis);
 
@@ -710,6 +729,7 @@ impl<A: Actionlike> ActionState<A> {
     /// }
     /// ```
     #[inline]
+    #[track_caller]
     pub fn set_button_data(&mut self, action: A, data: ButtonData) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -722,6 +742,7 @@ impl<A: Actionlike> ActionState<A> {
     /// No initial instant or reasons why the button was pressed will be recorded.
     /// Instead, this is set through [`ActionState::tick()`]
     #[inline]
+    #[track_caller]
     pub fn press(&mut self, action: &A) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -860,6 +881,7 @@ impl<A: Actionlike> ActionState<A> {
     /// even if the action is not a buttonlike action.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn pressed(&self, action: &A) -> bool {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -881,6 +903,7 @@ impl<A: Actionlike> ActionState<A> {
     /// even if the action is not a buttonlike action.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn just_pressed(&self, action: &A) -> bool {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -904,6 +927,7 @@ impl<A: Actionlike> ActionState<A> {
     /// even if the action is not a buttonlike action.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn released(&self, action: &A) -> bool {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -925,6 +949,7 @@ impl<A: Actionlike> ActionState<A> {
     /// even if the action is not a buttonlike action.
     #[inline]
     #[must_use]
+    #[track_caller]
     pub fn just_released(&self, action: &A) -> bool {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -993,6 +1018,8 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// This will also be [`None`] if the action was never pressed or released.
     #[cfg(feature = "timing")]
+    #[must_use]
+    #[track_caller]
     pub fn instant_started(&self, action: &A) -> Option<Instant> {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -1004,6 +1031,8 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// This will be [`Duration::ZERO`] if the action was never pressed or released.
     #[cfg(feature = "timing")]
+    #[must_use]
+    #[track_caller]
     pub fn current_duration(&self, action: &A) -> Duration {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 
@@ -1019,6 +1048,8 @@ impl<A: Actionlike> ActionState<A> {
     ///
     /// This will be [`Duration::ZERO`] if the action was never pressed or released.
     #[cfg(feature = "timing")]
+    #[must_use]
+    #[track_caller]
     pub fn previous_duration(&self, action: &A) -> Duration {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -248,6 +248,7 @@ impl<A: Actionlike> InputMap<A> {
     /// This method ensures idempotence, meaning that adding the same input
     /// for the same action multiple times will only result in a single binding being created.
     #[inline(always)]
+    #[track_caller]
     pub fn insert(&mut self, action: A, button: impl Buttonlike) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::Button,
@@ -276,6 +277,7 @@ impl<A: Actionlike> InputMap<A> {
     /// This method ensures idempotence, meaning that adding the same input
     /// for the same action multiple times will only result in a single binding being created.
     #[inline(always)]
+    #[track_caller]
     pub fn insert_axis(&mut self, action: A, axis: impl Axislike) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::Axis,
@@ -311,6 +313,7 @@ impl<A: Actionlike> InputMap<A> {
     /// This method ensures idempotence, meaning that adding the same input
     /// for the same action multiple times will only result in a single binding being created.
     #[inline(always)]
+    #[track_caller]
     pub fn insert_dual_axis(&mut self, action: A, dual_axis: impl DualAxislike) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::DualAxis,
@@ -346,6 +349,7 @@ impl<A: Actionlike> InputMap<A> {
     /// This method ensures idempotence, meaning that adding the same input
     /// for the same action multiple times will only result in a single binding being created.
     #[inline(always)]
+    #[track_caller]
     pub fn insert_triple_axis(&mut self, action: A, triple_axis: impl TripleAxislike) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::TripleAxis,

--- a/src/user_input/mod.rs
+++ b/src/user_input/mod.rs
@@ -312,6 +312,7 @@ pub enum UserInputWrapper {
 }
 
 impl UserInput for UserInputWrapper {
+    #[track_caller]
     fn kind(&self) -> InputControlKind {
         match self {
             UserInputWrapper::Button(input) => {


### PR DESCRIPTION
Fixes #591. The press_duration example looks more involved, so that's been spun out into #612.