### PR TITLE
Fix `InputMap::merge`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -9,7 +9,7 @@
   - added `TripleAxislikeChord` that groups a `Buttonlike` and a `TripleAxislike` together.
   - added related variants such as:
     - `InputControlType::TripleAxis`
-    - `ActionDiff::TripleAxisChanged` 
+    - `ActionDiff::TripleAxisChanged`
 
 ### Usability (0.15.1)
 
@@ -32,6 +32,7 @@
 ### Bugs (0.15.1)
 
 - `InputMap::get_pressed` and siblings now check if the action kind is buttonlike before checking if they are pressed or released, avoiding a debug-mode panic
+- `InputMap::merge` is now compatible with all input kinds, previously limited to buttons
 
 ## Version 0.15.0
 

--- a/examples/twin_stick_controller.rs
+++ b/examples/twin_stick_controller.rs
@@ -160,14 +160,13 @@ fn control_player(
     if action_state.axis_pair(&PlayerAction::Move) != Vec2::ZERO {
         // Note: In a real game we'd feed this into an actual player controller
         // and respects the camera extrinsics to ensure the direction is correct
-        let move_delta =
-            time.delta_seconds() * action_state.clamped_axis_pair(&PlayerAction::Move).xy();
+        let move_delta = time.delta_seconds() * action_state.clamped_axis_pair(&PlayerAction::Move);
         player_transform.translation += Vec3::new(move_delta.x, 0.0, move_delta.y);
         println!("Player moved to: {}", player_transform.translation.xz());
     }
 
     if action_state.axis_pair(&PlayerAction::Look) != Vec2::ZERO {
-        let look = action_state.axis_pair(&PlayerAction::Look).xy().normalize();
+        let look = action_state.axis_pair(&PlayerAction::Look).normalize();
         println!("Player looking in direction: {}", look);
     }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -224,13 +224,17 @@ impl<A: Actionlike> InputMap<A> {
 }
 
 #[inline(always)]
-fn insert_unique<K: Eq + Hash, V: PartialEq>(map: &mut HashMap<K, Vec<V>>, key: K, value: V) {
-    if let Some(list) = map.get_mut(&key) {
+fn insert_unique<K, V>(map: &mut HashMap<K, Vec<V>>, key: &K, value: V)
+where
+    K: Clone + Eq + Hash,
+    V: PartialEq,
+{
+    if let Some(list) = map.get_mut(key) {
         if !list.contains(&value) {
             list.push(value);
         }
     } else {
-        map.insert(key, vec![value]);
+        map.insert(key.clone(), vec![value]);
     }
 }
 
@@ -261,7 +265,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.buttonlike_map, action, Box::new(button));
+        insert_unique(&mut self.buttonlike_map, &action, Box::new(button));
         self
     }
 
@@ -290,7 +294,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.axislike_map, action, Box::new(axis));
+        insert_unique(&mut self.axislike_map, &action, Box::new(axis));
         self
     }
 
@@ -319,7 +323,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.dual_axislike_map, action, Box::new(dual_axis));
+        insert_unique(&mut self.dual_axislike_map, &action, Box::new(dual_axis));
         self
     }
 
@@ -348,7 +352,8 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.triple_axislike_map, action, Box::new(triple_axis));
+        let boxed = Box::new(triple_axis);
+        insert_unique(&mut self.triple_axislike_map, &action, boxed);
         self
     }
 
@@ -408,33 +413,25 @@ impl<A: Actionlike> InputMap<A> {
 
         for (other_action, other_inputs) in other.iter_buttonlike() {
             for other_input in other_inputs.iter().cloned() {
-                insert_unique(&mut self.buttonlike_map, other_action.clone(), other_input);
+                insert_unique(&mut self.buttonlike_map, other_action, other_input);
             }
         }
 
         for (other_action, other_inputs) in other.iter_axislike() {
             for other_input in other_inputs.iter().cloned() {
-                insert_unique(&mut self.axislike_map, other_action.clone(), other_input);
+                insert_unique(&mut self.axislike_map, other_action, other_input);
             }
         }
 
         for (other_action, other_inputs) in other.iter_dual_axislike() {
             for other_input in other_inputs.iter().cloned() {
-                insert_unique(
-                    &mut self.dual_axislike_map,
-                    other_action.clone(),
-                    other_input,
-                );
+                insert_unique(&mut self.dual_axislike_map, other_action, other_input);
             }
         }
 
         for (other_action, other_inputs) in other.iter_triple_axislike() {
             for other_input in other_inputs.iter().cloned() {
-                insert_unique(
-                    &mut self.triple_axislike_map,
-                    other_action.clone(),
-                    other_input,
-                );
+                insert_unique(&mut self.triple_axislike_map, other_action, other_input);
             }
         }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1,6 +1,7 @@
 //! This module contains [`InputMap`] and its supporting methods and impls.
 
 use std::fmt::Debug;
+use std::hash::Hash;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
@@ -222,26 +223,19 @@ impl<A: Actionlike> InputMap<A> {
     }
 }
 
+#[inline(always)]
+fn insert_unique<K: Eq + Hash, V: PartialEq>(map: &mut HashMap<K, Vec<V>>, key: K, value: V) {
+    if let Some(list) = map.get_mut(&key) {
+        if !list.contains(&value) {
+            list.push(value);
+        }
+    } else {
+        map.insert(key, vec![value]);
+    }
+}
+
 // Insertion
 impl<A: Actionlike> InputMap<A> {
-    /// Inserts a binding between an `action` and a specific boxed dyn [`Buttonlike`].
-    /// Multiple inputs can be bound to the same action.
-    ///
-    /// This method ensures idempotence, meaning that adding the same input
-    /// for the same action multiple times will only result in a single binding being created.
-    #[inline(always)]
-    fn insert_boxed(&mut self, action: A, button: Box<dyn Buttonlike>) -> &mut Self {
-        if let Some(bindings) = self.buttonlike_map.get_mut(&action) {
-            if !bindings.contains(&button) {
-                bindings.push(button);
-            }
-        } else {
-            self.buttonlike_map.insert(action, vec![button]);
-        }
-
-        self
-    }
-
     /// Inserts a binding between an `action` and a specific [`Buttonlike`] `input`.
     /// Multiple inputs can be bound to the same action.
     ///
@@ -267,7 +261,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        self.insert_boxed(action, Box::new(button));
+        insert_unique(&mut self.buttonlike_map, action, Box::new(button));
         self
     }
 
@@ -296,14 +290,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        let axis = Box::new(axis) as Box<dyn Axislike>;
-        if let Some(bindings) = self.axislike_map.get_mut(&action) {
-            if !bindings.contains(&axis) {
-                bindings.push(axis);
-            }
-        } else {
-            self.axislike_map.insert(action, vec![axis]);
-        }
+        insert_unique(&mut self.axislike_map, action, Box::new(axis));
         self
     }
 
@@ -332,14 +319,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        let dual_axis = Box::new(dual_axis) as Box<dyn DualAxislike>;
-        if let Some(bindings) = self.dual_axislike_map.get_mut(&action) {
-            if !bindings.contains(&dual_axis) {
-                bindings.push(dual_axis);
-            }
-        } else {
-            self.dual_axislike_map.insert(action, vec![dual_axis]);
-        }
+        insert_unique(&mut self.dual_axislike_map, action, Box::new(dual_axis));
         self
     }
 
@@ -368,14 +348,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        let triple_axis = Box::new(triple_axis) as Box<dyn TripleAxislike>;
-        if let Some(bindings) = self.triple_axislike_map.get_mut(&action) {
-            if !bindings.contains(&triple_axis) {
-                bindings.push(triple_axis);
-            }
-        } else {
-            self.triple_axislike_map.insert(action, vec![triple_axis]);
-        }
+        insert_unique(&mut self.triple_axislike_map, action, Box::new(triple_axis));
         self
     }
 
@@ -435,7 +408,33 @@ impl<A: Actionlike> InputMap<A> {
 
         for (other_action, other_inputs) in other.buttonlike_map.iter() {
             for other_input in other_inputs.iter().cloned() {
-                self.insert_boxed(other_action.clone(), other_input);
+                insert_unique(&mut self.buttonlike_map, other_action.clone(), other_input);
+            }
+        }
+
+        for (other_action, other_inputs) in other.axislike_map.iter() {
+            for other_input in other_inputs.iter().cloned() {
+                insert_unique(&mut self.axislike_map, other_action.clone(), other_input);
+            }
+        }
+
+        for (other_action, other_inputs) in other.dual_axislike_map.iter() {
+            for other_input in other_inputs.iter().cloned() {
+                insert_unique(
+                    &mut self.dual_axislike_map,
+                    other_action.clone(),
+                    other_input,
+                );
+            }
+        }
+
+        for (other_action, other_inputs) in other.triple_axislike_map.iter() {
+            for other_input in other_inputs.iter().cloned() {
+                insert_unique(
+                    &mut self.triple_axislike_map,
+                    other_action.clone(),
+                    other_input,
+                );
             }
         }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -406,19 +406,19 @@ impl<A: Actionlike> InputMap<A> {
             self.clear_gamepad();
         }
 
-        for (other_action, other_inputs) in other.buttonlike_map.iter() {
+        for (other_action, other_inputs) in other.iter_buttonlike() {
             for other_input in other_inputs.iter().cloned() {
                 insert_unique(&mut self.buttonlike_map, other_action.clone(), other_input);
             }
         }
 
-        for (other_action, other_inputs) in other.axislike_map.iter() {
+        for (other_action, other_inputs) in other.iter_axislike() {
             for other_input in other_inputs.iter().cloned() {
                 insert_unique(&mut self.axislike_map, other_action.clone(), other_input);
             }
         }
 
-        for (other_action, other_inputs) in other.dual_axislike_map.iter() {
+        for (other_action, other_inputs) in other.iter_dual_axislike() {
             for other_input in other_inputs.iter().cloned() {
                 insert_unique(
                     &mut self.dual_axislike_map,
@@ -428,7 +428,7 @@ impl<A: Actionlike> InputMap<A> {
             }
         }
 
-        for (other_action, other_inputs) in other.triple_axislike_map.iter() {
+        for (other_action, other_inputs) in other.iter_triple_axislike() {
             for other_input in other_inputs.iter().cloned() {
                 insert_unique(
                     &mut self.triple_axislike_map,


### PR DESCRIPTION
`InputMap::merge` is now compatible with all input kinds, previously limited to buttons