### PR TITLE
Add `threshold` value for `GamepadControlDirection`, `MouseMoveDirection`, and `MouseScrollDirection`

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 0.16.0 (Unreleased)
+
+### Usability (0.16.0)
+
+- added `threshold` value for `GamepadControlDirection`, `MouseMoveDirection`, and `MouseScrollDirection` to be considered pressed.
+
 ## Version 0.15.1
 
 ### Enhancements (0.15.1)
@@ -24,10 +30,6 @@
 #### ActionState
 
 - Reflect `Component` and `Resource`, which enables accessing the data in the type registry
-
-#### Inputs
-
-- added `threshold` value for `GamepadControlDirection`, `MouseMoveDirection`, and `MouseScrollDirection` to be considered pressed.
 
 #### ActionDiffEvent
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,10 @@
 
 - Reflect `Component` and `Resource`, which enables accessing the data in the type registry
 
+#### Inputs
+
+- added `threshold` value for `GamepadControlDirection`, `MouseMoveDirection`, and `MouseScrollDirection` to be considered pressed.
+
 #### ActionDiffEvent
 
 - Implement `MapEntities`, which lets networking crates translate owner entity IDs between ECS worlds

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -26,7 +26,15 @@ impl AxisDirection {
     }
 
     /// Checks if the given `value` represents an active input in this direction,
-    /// considering the specified `threshold` (Must be non-negative).
+    /// considering the specified `threshold`.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement isn't met.
     #[must_use]
     #[inline]
     pub fn is_active(&self, value: f32, threshold: f32) -> bool {
@@ -154,7 +162,15 @@ impl DualAxisDirection {
     }
 
     /// Checks if the given `value` represents an active input in this direction,
-    /// considering the specified `threshold` (Must be non-negative).
+    /// considering the specified `threshold`.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement isn't met.
     #[must_use]
     #[inline]
     pub fn is_active(&self, value: Vec2, threshold: f32) -> bool {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -26,10 +26,11 @@ impl AxisDirection {
     }
 
     /// Checks if the given `value` represents an active input in this direction,
-    /// considering the specified `threshold`.
+    /// considering the specified `threshold` (Must be non-negative).
     #[must_use]
     #[inline]
     pub fn is_active(&self, value: f32, threshold: f32) -> bool {
+        assert!(threshold >= 0.0);
         match self {
             Self::Negative => value < -threshold,
             Self::Positive => value > threshold,
@@ -153,7 +154,7 @@ impl DualAxisDirection {
     }
 
     /// Checks if the given `value` represents an active input in this direction,
-    /// considering the specified `threshold`.
+    /// considering the specified `threshold` (Must be non-negative).
     #[must_use]
     #[inline]
     pub fn is_active(&self, value: Vec2, threshold: f32) -> bool {

--- a/src/axislike.rs
+++ b/src/axislike.rs
@@ -25,13 +25,14 @@ impl AxisDirection {
         }
     }
 
-    /// Checks if the given `value` represents an active input in this direction.
+    /// Checks if the given `value` represents an active input in this direction,
+    /// considering the specified `threshold`.
     #[must_use]
     #[inline]
-    pub fn is_active(&self, value: f32) -> bool {
+    pub fn is_active(&self, value: f32, threshold: f32) -> bool {
         match self {
-            Self::Negative => value < 0.0,
-            Self::Positive => value > 0.0,
+            Self::Negative => value < -threshold,
+            Self::Positive => value > threshold,
         }
     }
 }
@@ -151,11 +152,12 @@ impl DualAxisDirection {
         }
     }
 
-    /// Checks if the given `value` represents an active input in this direction.
+    /// Checks if the given `value` represents an active input in this direction,
+    /// considering the specified `threshold`.
     #[must_use]
     #[inline]
-    pub fn is_active(&self, value: Vec2) -> bool {
-        let component_along_axis = self.axis().get_value(value);
-        self.axis_direction().is_active(component_along_axis)
+    pub fn is_active(&self, value: Vec2, threshold: f32) -> bool {
+        let axis_value = self.axis().get_value(value);
+        self.axis_direction().is_active(axis_value, threshold)
     }
 }

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -1,14 +1,7 @@
 //! Gamepad inputs
 
-use crate as leafwing_input_manager;
-use crate::axislike::AxisDirection;
-use crate::clashing_inputs::BasicInputs;
-use crate::input_processing::{
-    AxisProcessor, DualAxisProcessor, WithAxisProcessingPipelineExt,
-    WithDualAxisProcessingPipelineExt,
-};
-use crate::user_input::UserInput;
-use crate::InputControlKind;
+use std::hash::{Hash, Hasher};
+
 use bevy::input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadEvent};
 use bevy::input::{Axis, ButtonInput};
 use bevy::math::FloatOrd;
@@ -18,7 +11,16 @@ use bevy::prelude::{
 };
 use leafwing_input_manager_macros::serde_typetag;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
+
+use crate as leafwing_input_manager;
+use crate::axislike::AxisDirection;
+use crate::clashing_inputs::BasicInputs;
+use crate::input_processing::{
+    AxisProcessor, DualAxisProcessor, WithAxisProcessingPipelineExt,
+    WithDualAxisProcessingPipelineExt,
+};
+use crate::user_input::UserInput;
+use crate::InputControlKind;
 
 use super::updating::{CentralInputStore, UpdatableInput};
 use super::{Axislike, Buttonlike, DualAxislike};

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -82,6 +82,7 @@ pub struct GamepadControlDirection {
     pub direction: AxisDirection,
 
     /// The threshold value for the direction to be considered pressed.
+    /// Must be non-negative.
     pub threshold: f32,
 }
 
@@ -106,9 +107,10 @@ impl GamepadControlDirection {
         }
     }
 
-    /// Sets the `threshold` value.
+    /// Sets the `threshold` value. Must be non-negative.
     #[inline]
     pub const fn threshold(mut self, threshold: f32) -> Self {
+        assert!(threshold >= 0.0);
         self.threshold = threshold;
         self
     }

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -1,14 +1,5 @@
 //! Gamepad inputs
 
-use bevy::input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadEvent};
-use bevy::input::{Axis, ButtonInput};
-use bevy::prelude::{
-    Events, Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType, Gamepads,
-    Reflect, Res, ResMut, Vec2, World,
-};
-use leafwing_input_manager_macros::serde_typetag;
-use serde::{Deserialize, Serialize};
-
 use crate as leafwing_input_manager;
 use crate::axislike::AxisDirection;
 use crate::clashing_inputs::BasicInputs;
@@ -18,6 +9,16 @@ use crate::input_processing::{
 };
 use crate::user_input::UserInput;
 use crate::InputControlKind;
+use bevy::input::gamepad::{GamepadAxisChangedEvent, GamepadButtonChangedEvent, GamepadEvent};
+use bevy::input::{Axis, ButtonInput};
+use bevy::math::FloatOrd;
+use bevy::prelude::{
+    Events, Gamepad, GamepadAxis, GamepadAxisType, GamepadButton, GamepadButtonType, Gamepads,
+    Reflect, Res, ResMut, Vec2, World,
+};
+use leafwing_input_manager_macros::serde_typetag;
+use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 use super::updating::{CentralInputStore, UpdatableInput};
 use super::{Axislike, Buttonlike, DualAxislike};
@@ -69,29 +70,45 @@ fn read_axis_value(
 /// app.update();
 /// assert!(app.read_pressed(input));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
 #[must_use]
 pub struct GamepadControlDirection {
     /// The axis that this input tracks.
     pub axis: GamepadAxisType,
 
     /// The direction of the axis to monitor (positive or negative).
-    pub side: AxisDirection,
+    pub direction: AxisDirection,
+
+    /// The threshold value for the direction to be considered pressed.
+    pub threshold: f32,
 }
 
 impl GamepadControlDirection {
     /// Creates a [`GamepadControlDirection`] triggered by a negative value on the specified `axis`.
     #[inline]
     pub const fn negative(axis: GamepadAxisType) -> Self {
-        let side = AxisDirection::Negative;
-        Self { axis, side }
+        Self {
+            axis,
+            direction: AxisDirection::Negative,
+            threshold: 0.0,
+        }
     }
 
     /// Creates a [`GamepadControlDirection`] triggered by a positive value on the specified `axis`.
     #[inline]
     pub const fn positive(axis: GamepadAxisType) -> Self {
-        let side = AxisDirection::Positive;
-        Self { axis, side }
+        Self {
+            axis,
+            direction: AxisDirection::Positive,
+            threshold: 0.0,
+        }
+    }
+
+    /// Sets the `threshold` value.
+    #[inline]
+    pub const fn threshold(mut self, threshold: f32) -> Self {
+        self.threshold = threshold;
+        self
     }
 
     /// "Up" on the left analog stick (positive Y-axis movement).
@@ -129,7 +146,7 @@ impl UserInput for GamepadControlDirection {
     /// [`GamepadControlDirection`] represents a simple virtual button.
     #[inline]
     fn decompose(&self) -> BasicInputs {
-        BasicInputs::Simple(Box::new(*self))
+        BasicInputs::Simple(Box::new((*self).threshold(0.0)))
     }
 }
 
@@ -140,7 +157,7 @@ impl Buttonlike for GamepadControlDirection {
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> bool {
         let value = read_axis_value(input_store, gamepad, self.axis);
-        self.side.is_active(value)
+        self.direction.is_active(value, self.threshold)
     }
 
     /// Sends a [`GamepadEvent::Axis`] event with a magnitude of 1.0 for the specified direction on the provided [`Gamepad`].
@@ -150,7 +167,7 @@ impl Buttonlike for GamepadControlDirection {
         let event = GamepadEvent::Axis(GamepadAxisChangedEvent {
             gamepad,
             axis_type: self.axis,
-            value: self.side.full_active_value(),
+            value: self.direction.full_active_value(),
         });
         world.resource_mut::<Events<GamepadEvent>>().send(event);
     }
@@ -165,6 +182,16 @@ impl Buttonlike for GamepadControlDirection {
             value: 0.0,
         });
         world.resource_mut::<Events<GamepadEvent>>().send(event);
+    }
+}
+
+impl Eq for GamepadControlDirection {}
+
+impl Hash for GamepadControlDirection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.axis.hash(state);
+        self.direction.hash(state);
+        FloatOrd(self.threshold).hash(state);
     }
 }
 

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -109,7 +109,7 @@ impl GamepadControlDirection {
 
     /// Sets the `threshold` value. Must be non-negative.
     #[inline]
-    pub const fn threshold(mut self, threshold: f32) -> Self {
+    pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);
         self.threshold = threshold;
         self

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -107,7 +107,15 @@ impl GamepadControlDirection {
         }
     }
 
-    /// Sets the `threshold` value. Must be non-negative.
+    /// Sets the `threshold` value.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement isn't met.
     #[inline]
     pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -1,12 +1,12 @@
 //! Mouse inputs
 
-use bevy::input::mouse::{MouseButtonInput, MouseMotion, MouseWheel};
+use bevy::input::mouse::{MouseButton, MouseButtonInput, MouseMotion, MouseWheel};
 use bevy::input::{ButtonInput, ButtonState};
-use bevy::prelude::{
-    Entity, Events, Gamepad, MouseButton, Reflect, Res, ResMut, Resource, Vec2, World,
-};
+use bevy::math::FloatOrd;
+use bevy::prelude::{Entity, Events, Gamepad, Reflect, Res, ResMut, Resource, Vec2, World};
 use leafwing_input_manager_macros::serde_typetag;
 use serde::{Deserialize, Serialize};
+use std::hash::{Hash, Hasher};
 
 use crate as leafwing_input_manager;
 use crate::axislike::{DualAxisDirection, DualAxisType};
@@ -112,22 +112,47 @@ impl Buttonlike for MouseButton {
 /// app.update();
 /// assert!(app.read_pressed(input));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
 #[must_use]
-pub struct MouseMoveDirection(pub DualAxisDirection);
+pub struct MouseMoveDirection {
+    /// The direction to monitor (up, down, left, or right).
+    pub direction: DualAxisDirection,
+
+    /// The threshold value for the direction to be considered pressed.
+    pub threshold: f32,
+}
 
 impl MouseMoveDirection {
+    /// Sets the `threshold` value.
+    #[inline]
+    pub const fn threshold(mut self, threshold: f32) -> Self {
+        self.threshold = threshold;
+        self
+    }
+
     /// Movement in the upward direction.
-    pub const UP: Self = Self(DualAxisDirection::Up);
+    pub const UP: Self = Self {
+        direction: DualAxisDirection::Up,
+        threshold: 0.0,
+    };
 
     /// Movement in the downward direction.
-    pub const DOWN: Self = Self(DualAxisDirection::Down);
+    pub const DOWN: Self = Self {
+        direction: DualAxisDirection::Down,
+        threshold: 0.0,
+    };
 
     /// Movement in the leftward direction.
-    pub const LEFT: Self = Self(DualAxisDirection::Left);
+    pub const LEFT: Self = Self {
+        direction: DualAxisDirection::Left,
+        threshold: 0.0,
+    };
 
     /// Movement in the rightward direction.
-    pub const RIGHT: Self = Self(DualAxisDirection::Right);
+    pub const RIGHT: Self = Self {
+        direction: DualAxisDirection::Right,
+        threshold: 0.0,
+    };
 }
 
 impl UserInput for MouseMoveDirection {
@@ -140,7 +165,7 @@ impl UserInput for MouseMoveDirection {
     /// [`MouseMoveDirection`] represents a simple virtual button.
     #[inline]
     fn decompose(&self) -> BasicInputs {
-        BasicInputs::Simple(Box::new(*self))
+        BasicInputs::Simple(Box::new((*self).threshold(0.0)))
     }
 }
 
@@ -151,7 +176,7 @@ impl Buttonlike for MouseMoveDirection {
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Gamepad) -> bool {
         let mouse_movement = input_store.pair(&MouseMove::default());
-        self.0.is_active(mouse_movement)
+        self.direction.is_active(mouse_movement, self.threshold)
     }
 
     /// Sends a [`MouseMotion`] event with a magnitude of 1.0 in the direction defined by `self`.
@@ -159,7 +184,7 @@ impl Buttonlike for MouseMoveDirection {
         world
             .resource_mut::<Events<MouseMotion>>()
             .send(MouseMotion {
-                delta: self.0.full_active_value(),
+                delta: self.direction.full_active_value(),
             });
     }
 
@@ -168,6 +193,15 @@ impl Buttonlike for MouseMoveDirection {
     /// As mouse movement directions are determined based on the recent change in mouse position,
     /// no action other than waiting for the next frame is necessary to release the input.
     fn release(&self, _world: &mut World) {}
+}
+
+impl Eq for MouseMoveDirection {}
+
+impl Hash for MouseMoveDirection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.direction.hash(state);
+        FloatOrd(self.threshold).hash(state);
+    }
 }
 
 /// Relative changes in position of mouse movement on a single axis (X or Y).
@@ -234,8 +268,14 @@ impl UserInput for MouseMoveAxis {
     #[inline]
     fn decompose(&self) -> BasicInputs {
         BasicInputs::Composite(vec![
-            Box::new(MouseMoveDirection(self.axis.negative())),
-            Box::new(MouseMoveDirection(self.axis.positive())),
+            Box::new(MouseMoveDirection {
+                direction: self.axis.negative(),
+                threshold: 0.0,
+            }),
+            Box::new(MouseMoveDirection {
+                direction: self.axis.positive(),
+                threshold: 0.0,
+            }),
         ])
     }
 }
@@ -422,22 +462,47 @@ impl WithDualAxisProcessingPipelineExt for MouseMove {
 /// app.update();
 /// assert!(app.read_pressed(input));
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Reflect, Serialize, Deserialize)]
 #[must_use]
-pub struct MouseScrollDirection(pub DualAxisDirection);
+pub struct MouseScrollDirection {
+    /// The direction to monitor (up, down, left, or right).
+    pub direction: DualAxisDirection,
+
+    /// The threshold value for the direction to be considered pressed.
+    pub threshold: f32,
+}
 
 impl MouseScrollDirection {
+    /// Sets the `threshold` value.
+    #[inline]
+    pub const fn threshold(mut self, threshold: f32) -> Self {
+        self.threshold = threshold;
+        self
+    }
+
     /// Movement in the upward direction.
-    pub const UP: Self = Self(DualAxisDirection::Up);
+    pub const UP: Self = Self {
+        direction: DualAxisDirection::Up,
+        threshold: 0.0,
+    };
 
     /// Movement in the downward direction.
-    pub const DOWN: Self = Self(DualAxisDirection::Down);
+    pub const DOWN: Self = Self {
+        direction: DualAxisDirection::Down,
+        threshold: 0.0,
+    };
 
     /// Movement in the leftward direction.
-    pub const LEFT: Self = Self(DualAxisDirection::Left);
+    pub const LEFT: Self = Self {
+        direction: DualAxisDirection::Left,
+        threshold: 0.0,
+    };
 
     /// Movement in the rightward direction.
-    pub const RIGHT: Self = Self(DualAxisDirection::Right);
+    pub const RIGHT: Self = Self {
+        direction: DualAxisDirection::Right,
+        threshold: 0.0,
+    };
 }
 
 impl UserInput for MouseScrollDirection {
@@ -450,7 +515,7 @@ impl UserInput for MouseScrollDirection {
     /// [`MouseScrollDirection`] represents a simple virtual button.
     #[inline]
     fn decompose(&self) -> BasicInputs {
-        BasicInputs::Simple(Box::new(*self))
+        BasicInputs::Simple(Box::new((*self).threshold(0.0)))
     }
 }
 
@@ -461,7 +526,7 @@ impl Buttonlike for MouseScrollDirection {
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Gamepad) -> bool {
         let movement = input_store.pair(&MouseScroll::default());
-        self.0.is_active(movement)
+        self.direction.is_active(movement, self.threshold)
     }
 
     /// Sends a [`MouseWheel`] event with a magnitude of 1.0 px in the direction defined by `self`.
@@ -470,7 +535,7 @@ impl Buttonlike for MouseScrollDirection {
     ///
     /// The `window` field will be filled with a placeholder value.
     fn press(&self, world: &mut World) {
-        let vec = self.0.full_active_value();
+        let vec = self.direction.full_active_value();
 
         world.resource_mut::<Events<MouseWheel>>().send(MouseWheel {
             unit: bevy::input::mouse::MouseScrollUnit::Pixel,
@@ -485,6 +550,15 @@ impl Buttonlike for MouseScrollDirection {
     /// As mouse scroll directions are determined based on the recent change in mouse scrolling,
     /// no action other than waiting for the next frame is necessary to release the input.
     fn release(&self, _world: &mut World) {}
+}
+
+impl Eq for MouseScrollDirection {}
+
+impl Hash for MouseScrollDirection {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.direction.hash(state);
+        FloatOrd(self.threshold).hash(state);
+    }
 }
 
 /// Amount of mouse wheel scrolling on a single axis (X or Y).
@@ -551,8 +625,14 @@ impl UserInput for MouseScrollAxis {
     #[inline]
     fn decompose(&self) -> BasicInputs {
         BasicInputs::Composite(vec![
-            Box::new(MouseScrollDirection(self.axis.negative())),
-            Box::new(MouseScrollDirection(self.axis.positive())),
+            Box::new(MouseScrollDirection {
+                direction: self.axis.negative(),
+                threshold: 0.0,
+            }),
+            Box::new(MouseScrollDirection {
+                direction: self.axis.positive(),
+                threshold: 0.0,
+            }),
         ])
     }
 }

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -119,13 +119,15 @@ pub struct MouseMoveDirection {
     pub direction: DualAxisDirection,
 
     /// The threshold value for the direction to be considered pressed.
+    /// Must be non-negative.
     pub threshold: f32,
 }
 
 impl MouseMoveDirection {
-    /// Sets the `threshold` value.
+    /// Sets the `threshold` value. Must be non-negative.
     #[inline]
     pub const fn threshold(mut self, threshold: f32) -> Self {
+        assert!(threshold >= 0.0);
         self.threshold = threshold;
         self
     }
@@ -469,13 +471,15 @@ pub struct MouseScrollDirection {
     pub direction: DualAxisDirection,
 
     /// The threshold value for the direction to be considered pressed.
+    /// Must be non-negative.
     pub threshold: f32,
 }
 
 impl MouseScrollDirection {
-    /// Sets the `threshold` value.
+    /// Sets the `threshold` value. Must be non-negative.
     #[inline]
     pub const fn threshold(mut self, threshold: f32) -> Self {
+        assert!(threshold >= 0.0);
         self.threshold = threshold;
         self
     }

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -124,7 +124,15 @@ pub struct MouseMoveDirection {
 }
 
 impl MouseMoveDirection {
-    /// Sets the `threshold` value. Must be non-negative.
+    /// Sets the `threshold` value.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement isn't met.
     #[inline]
     pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);
@@ -476,7 +484,15 @@ pub struct MouseScrollDirection {
 }
 
 impl MouseScrollDirection {
-    /// Sets the `threshold` value. Must be non-negative.
+    /// Sets the `threshold` value.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirement isn't met.
     #[inline]
     pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -126,7 +126,7 @@ pub struct MouseMoveDirection {
 impl MouseMoveDirection {
     /// Sets the `threshold` value. Must be non-negative.
     #[inline]
-    pub const fn threshold(mut self, threshold: f32) -> Self {
+    pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);
         self.threshold = threshold;
         self
@@ -478,7 +478,7 @@ pub struct MouseScrollDirection {
 impl MouseScrollDirection {
     /// Sets the `threshold` value. Must be non-negative.
     #[inline]
-    pub const fn threshold(mut self, threshold: f32) -> Self {
+    pub fn threshold(mut self, threshold: f32) -> Self {
         assert!(threshold >= 0.0);
         self.threshold = threshold;
         self


### PR DESCRIPTION
- Added a `threshold` field to `GamepadControlDirection`
- Renamed the `side` field of `GamepadControlDirection` to `direction` for clarity
- Changed the struct definitions of `MouseMoveDirection` and `MouseScrollDirection` from tuple structs to regular structs with `threshold` and `direction` fields