### PR TITLE
Add new builders for input processors and extensions for those implementing `WithInputProcessorExt` traits

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -25,6 +25,16 @@
 
 - Reflect `Component` and `Resource`, which enables accessing the data in the type registry
 
+#### Input Processors
+
+- allowed creating `AxisBounds`, `AxisExclusion`, `DualAxisBounds`, `DualAxisExclusion`, and `DualAxisDeadZone` from their struct definitions directly.
+- added `at_least` and `at_most` methods for those implementing `WithAxisProcessorExt` trait.
+- added `at_least`, `at_least_only_x`, `at_least_only_y`, `at_most`, `at_most_only_x`, and `at_most_only_y` methods for those implementing `WithDualAxisProcessorExt` trait.
+- added `only_positive` and `only_negative` builders for `AxisDeadZone` and `AxisExclusion`.
+  - added corresponding extension methods for those implementing `WithAxisProcessorExt` trait.
+- added `only_positive`, `only_positive_x`, `only_positive_y`, `only_negative`, `only_negative_x`, and `only_negative_y` builders for `DualAxisDeadZone` and `DualAxisExclusion`.
+  - added corresponding extension methods for those implementing `WithDualAxisProcessorExt` trait.
+
 #### ActionDiffEvent
 
 - Implement `MapEntities`, which lets networking crates translate owner entity IDs between ECS worlds

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -27,7 +27,7 @@
 
 #### Input Processors
 
-- allowed creating `AxisBounds`, `AxisExclusion`, `DualAxisBounds`, `DualAxisExclusion`, and `DualAxisDeadZone` from their struct definitions directly.
+- allowed creating `DualAxisBounds`, `DualAxisExclusion`, and `DualAxisDeadZone` from their struct definitions directly.
 - added `at_least` and `at_most` methods for those implementing `WithAxisProcessorExt` trait.
 - added `at_least`, `at_least_only_x`, `at_least_only_y`, `at_most`, `at_most_only_x`, and `at_most_only_y` methods for those implementing `WithDualAxisProcessorExt` trait.
 - added `only_positive` and `only_negative` builders for `AxisDeadZone` and `AxisExclusion`.

--- a/src/input_processing/dual_axis/circle.rs
+++ b/src/input_processing/dual_axis/circle.rs
@@ -48,7 +48,7 @@ impl CircleBounds {
     ///
     /// # Requirements
     ///
-    /// - `threshold` >= `0.0`.
+    /// - `max` >= `0.0`.
     ///
     /// # Panics
     ///
@@ -56,9 +56,9 @@ impl CircleBounds {
     #[doc(alias = "magnitude")]
     #[doc(alias = "from_radius")]
     #[inline]
-    pub fn new(threshold: f32) -> Self {
-        assert!(threshold >= 0.0);
-        Self { radius: threshold }
+    pub fn new(max: f32) -> Self {
+        assert!(max >= 0.0);
+        Self { radius: max }
     }
 
     /// Returns the radius of the bounds.

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -315,7 +315,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// only passing negative values that less than `negative_max` on both axes.
+    /// only passing negative values that less than `negative_max` on both axes
     /// and then normalizing them into the "live zone" range `[-1.0, negative_max]`.
     ///
     /// # Requirements
@@ -331,7 +331,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[negative_max, positive_min]` on the X-axis,
+    /// excluding values within the range `[negative_max, positive_min]` on the X-axis,
     /// treating them as zeros, then normalizing non-excluded X values into the "live zone",
     /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
@@ -349,7 +349,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[-threshold, threshold]` on the X-axis,
+    /// excluding values within the range `[-threshold, threshold]` on the X-axis,
     /// treating them as zeros, then normalizing non-excluded X values into the "live zone",
     /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
@@ -367,7 +367,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// only excluding X values that less than or equal to `positive_min`
+    /// only excluding X values that less than or equal to `positive_min`, treating them as zeros
     /// and then normalizing non-excluded X values into the "live zone" range `[positive_min, 1.0]`.
     ///
     /// # Requirements
@@ -383,7 +383,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// only excluding X values that greater than or equal to `negative_max`
+    /// only excluding X values that greater than or equal to `negative_max`, treating them as zeros
     /// and then normalizing non-excluded X values into the "live zone" range `[-1.0, negative_max]`.
     ///
     /// # Requirements
@@ -399,7 +399,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[negative_max, positive_min]` on the Y-axis,
+    /// excluding values within the range `[negative_max, positive_min]` on the Y-axis,
     /// treating them as zeros, then normalizing non-excluded Y values into the "live zone",
     /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
@@ -417,7 +417,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the deadzone range `[-threshold, threshold]` on the Y-axis,
+    /// excluding values within the range `[-threshold, threshold]` on the Y-axis,
     /// treating them as zeros, then normalizing non-excluded Y values into the "live zone",
     /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
@@ -435,8 +435,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// only excluding Y values that less than or equal to `positive_min`
-    /// and then normalizing non-excluded Y values into the "live zone" range `[positive_min, 1.0]`.
+    /// only excluding Y values that less than or equal to `positive_min`, treating them as zeros
+    /// and then normalizing non-excluded Y values into the range `[positive_min, 1.0]`.
     ///
     /// # Requirements
     ///
@@ -451,8 +451,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// only excluding Y values that greater than or equal to `negative_max`
-    /// and then normalizing non-excluded Y values into the "live zone" range `[-1.0, negative_max]`.
+    /// only excluding Y values that greater than or equal to `negative_max`, treating them as zeros
+    /// and then normalizing non-excluded Y values into the range `[-1.0, negative_max]`.
     ///
     /// # Requirements
     ///
@@ -485,7 +485,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// ignoring values within the dead zone range `[negative_max, positive_min]` on both axes,
+    /// ignoring values within the range `[negative_max, positive_min]` on both axes,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -501,7 +501,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// ignoring values within the dead zone range `[-threshold, threshold]` on both axes,
+    /// ignoring values within the range `[-threshold, threshold]` on both axes,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -517,7 +517,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only passing positive values that greater than `positive_min` on both axes.
+    /// only passing positive values that greater than `positive_min` on both axes,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///
@@ -532,7 +533,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only passing negative values that less than `negative_max` on both axes.
+    /// only passing negative values that less than `negative_max` on both axes,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///
@@ -547,7 +549,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[negative_max, positive_min]` on the X-axis,
+    /// only ignoring values within the range `[negative_max, positive_min]` on the X-axis,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -563,7 +565,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[-threshold, threshold]` on the X-axis,
+    /// only ignoring values within the range `[-threshold, threshold]` on the X-axis,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -579,7 +581,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only excluding X values that less than or equal to `positive_min`.
+    /// only excluding X values that less than or equal to `positive_min`,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///
@@ -594,7 +597,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only excluding X values that greater than or equal to `negative_max`.
+    /// only excluding X values that greater than or equal to `negative_max`,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///
@@ -609,7 +613,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[negative_max, positive_min]` on the Y-axis,
+    /// only ignoring values within the range `[negative_max, positive_min]` on the Y-axis,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -625,7 +629,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[-threshold, threshold]` on the Y-axis,
+    /// only ignoring values within the range `[-threshold, threshold]` on the Y-axis,
     /// treating them as zeros.
     ///
     /// # Requirements
@@ -641,7 +645,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only excluding Y values that less than or equal to `positive_min`.
+    /// only excluding Y values that less than or equal to `positive_min`,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///
@@ -656,7 +661,8 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only excluding Y values that greater than or equal to `negative_max`.
+    /// only excluding Y values that greater than or equal to `negative_max`,
+    /// treating them as zeros.
     ///
     /// # Requirements
     ///

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -300,7 +300,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// only passing positive values that greater than `positive_min` on both axes
-    /// and then normalizing non-excluded values into the "live zone" range `[positive_min, 1.0]`.
+    /// and then normalizing them into the "live zone" range `[positive_min, 1.0]`.
     ///
     /// # Requirements
     ///
@@ -316,7 +316,7 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// only passing negative values that less than `negative_max` on both axes.
-    /// and then normalizing non-excluded values into the "live zone" range `[-1.0, negative_max]`.
+    /// and then normalizing them into the "live zone" range `[-1.0, negative_max]`.
     ///
     /// # Requirements
     ///

--- a/src/input_processing/dual_axis/mod.rs
+++ b/src/input_processing/dual_axis/mod.rs
@@ -205,21 +205,79 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
         self.with_processor(DualAxisBounds::symmetric_all(threshold))
     }
 
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting values to a minimum value on both axes.
+    #[inline]
+    fn at_least(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_least_all(min))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting X values to a minimum value.
+    #[inline]
+    fn at_least_only_x(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_least_only_x(min))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting Y values to a minimum value.
+    #[inline]
+    fn at_least_only_y(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_least_only_y(min))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting values to a maximum value on both axes.
+    #[inline]
+    fn at_most(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_most_all(min))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting X values to a maximum value.
+    #[inline]
+    fn at_most_only_x(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_most_only_x(min))
+    }
+
+    /// Appends a [`DualAxisBounds`] processor as the next processing step,
+    /// restricting Y values to a maximum value.
+    #[inline]
+    fn at_most_only_y(self, min: f32) -> Self {
+        self.with_processor(DualAxisBounds::at_most_only_y(min))
+    }
+
     /// Appends a [`CircleBounds`] processor as the next processing step,
     /// restricting values to a `max` magnitude.
+    ///
+    /// # Requirements
+    ///
+    /// - `max` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_circle_bounds(self, max: f32) -> Self {
         self.with_processor(CircleBounds::new(max))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[min, max]` on both axes,
+    /// excluding values within the dead zone range `[negative_max, positive_min]` on both axes,
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::all(min, max))
+    fn with_deadzone(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::all(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
@@ -227,49 +285,185 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_symmetric(self, threshold: f32) -> Self {
         self.with_processor(DualAxisDeadZone::symmetric_all(threshold))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[min, max]` on the X-axis,
-    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
-    /// after dead zone exclusion.
+    /// only passing positive values that greater than `positive_min` on both axes
+    /// and then normalizing non-excluded values into the "live zone" range `[positive_min, 1.0]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone_x(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::only_x(min, max))
+    fn only_positive(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_positive_all(positive_min))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// only passing negative values that less than `negative_max` on both axes.
+    /// and then normalizing non-excluded values into the "live zone" range `[-1.0, negative_max]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_negative_all(negative_max))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// excluding values within the dead zone range `[negative_max, positive_min]` on the X-axis,
+    /// treating them as zeros, then normalizing non-excluded X values into the "live zone",
+    /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
+    /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn with_deadzone_x(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_x(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// excluding values within the dead zone range `[-threshold, threshold]` on the X-axis,
-    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
+    /// treating them as zeros, then normalizing non-excluded X values into the "live zone",
+    /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_x_symmetric(self, threshold: f32) -> Self {
         self.with_processor(DualAxisDeadZone::symmetric_only_x(threshold))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
-    /// excluding values within the dead zone range `[min, max]` on the Y-axis,
-    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
-    /// after dead zone exclusion.
+    /// only excluding X values that less than or equal to `positive_min`
+    /// and then normalizing non-excluded X values into the "live zone" range `[positive_min, 1.0]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone_y(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisDeadZone::only_y(min, max))
+    fn only_positive_x(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_positive_x(positive_min))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// only excluding X values that greater than or equal to `negative_max`
+    /// and then normalizing non-excluded X values into the "live zone" range `[-1.0, negative_max]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_x(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_negative_x(negative_max))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// excluding values within the dead zone range `[negative_max, positive_min]` on the Y-axis,
+    /// treating them as zeros, then normalizing non-excluded Y values into the "live zone",
+    /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
+    /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn with_deadzone_y(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_y(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
     /// excluding values within the deadzone range `[-threshold, threshold]` on the Y-axis,
-    /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
-    /// the remaining range within the [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default)
+    /// treating them as zeros, then normalizing non-excluded Y values into the "live zone",
+    /// the remaining range within the [`AxisBounds::symmetric(1.0)`](super::AxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_y_symmetric(self, threshold: f32) -> Self {
         self.with_processor(DualAxisDeadZone::symmetric_only_y(threshold))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// only excluding Y values that less than or equal to `positive_min`
+    /// and then normalizing non-excluded Y values into the "live zone" range `[positive_min, 1.0]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_positive_y(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_positive_y(positive_min))
+    }
+
+    /// Appends a [`DualAxisDeadZone`] processor as the next processing step,
+    /// only excluding Y values that greater than or equal to `negative_max`
+    /// and then normalizing non-excluded Y values into the "live zone" range `[-1.0, negative_max]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_y(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisDeadZone::only_negative_y(negative_max))
     }
 
     /// Appends a [`CircleDeadZone`] processor as the next processing step,
@@ -277,61 +471,215 @@ pub trait WithDualAxisProcessingPipelineExt: Sized {
     /// then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`CircleBounds::new(1.0)`](CircleBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_circle_deadzone(self, min: f32) -> Self {
         self.with_processor(CircleDeadZone::new(min))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// ignoring values within the dead zone range `[min, max]` on both axes,
+    /// ignoring values within the dead zone range `[negative_max, positive_min]` on both axes,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone_unscaled(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisExclusion::all(min, max))
+    fn with_deadzone_unscaled(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::all(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// ignoring values within the dead zone range `[-threshold, threshold]` on both axes,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_symmetric_unscaled(self, threshold: f32) -> Self {
         self.with_processor(DualAxisExclusion::symmetric_all(threshold))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[min, max]` on the X-axis,
-    /// treating them as zeros.
+    /// only passing positive values that greater than `positive_min` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone_x_unscaled(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisExclusion::only_x(min, max))
+    fn only_positive_unscaled(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_positive_all(positive_min))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only passing negative values that less than `negative_max` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_unscaled(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_negative_all(negative_max))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only ignoring values within the dead zone range `[negative_max, positive_min]` on the X-axis,
+    /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn with_deadzone_x_unscaled(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_x(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// only ignoring values within the dead zone range `[-threshold, threshold]` on the X-axis,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_x_symmetric_unscaled(self, threshold: f32) -> Self {
         self.with_processor(DualAxisExclusion::symmetric_only_x(threshold))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
-    /// only ignoring values within the dead zone range `[min, max]` on the Y-axis,
-    /// treating them as zeros.
+    /// only excluding X values that less than or equal to `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
-    fn with_deadzone_y_unscaled(self, min: f32, max: f32) -> Self {
-        self.with_processor(DualAxisExclusion::only_y(min, max))
+    fn only_positive_x_unscaled(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_positive_x(positive_min))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only excluding X values that greater than or equal to `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_x_unscaled(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_negative_x(negative_max))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only ignoring values within the dead zone range `[negative_max, positive_min]` on the Y-axis,
+    /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn with_deadzone_y_unscaled(self, negative_max: f32, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_y(negative_max, positive_min))
     }
 
     /// Appends a [`DualAxisExclusion`] processor as the next processing step,
     /// only ignoring values within the dead zone range `[-threshold, threshold]` on the Y-axis,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_y_symmetric_unscaled(self, threshold: f32) -> Self {
         self.with_processor(DualAxisExclusion::symmetric_only_y(threshold))
     }
 
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only excluding Y values that less than or equal to `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_positive_y_unscaled(self, positive_min: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_positive_y(positive_min))
+    }
+
+    /// Appends a [`DualAxisExclusion`] processor as the next processing step,
+    /// only excluding Y values that greater than or equal to `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_y_unscaled(self, negative_max: f32) -> Self {
+        self.with_processor(DualAxisExclusion::only_negative_y(negative_max))
+    }
+
     /// Appends a [`CircleExclusion`] processor as the next processing step,
     /// ignoring values below a `min` magnitude, treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_circle_deadzone_unscaled(self, min: f32) -> Self {
         self.with_processor(CircleExclusion::new(min))

--- a/src/input_processing/dual_axis/range.rs
+++ b/src/input_processing/dual_axis/range.rs
@@ -46,10 +46,10 @@ use crate::input_processing::single_axis::*;
 #[must_use]
 pub struct DualAxisBounds {
     /// The [`AxisBounds`] for the X-axis inputs.
-    pub(crate) bounds_x: AxisBounds,
+    pub bounds_x: AxisBounds,
 
     /// The [`AxisBounds`] for the Y-axis inputs.
-    pub(crate) bounds_y: AxisBounds,
+    pub bounds_y: AxisBounds,
 }
 
 impl DualAxisBounds {
@@ -400,10 +400,10 @@ impl From<AxisBounds> for DualAxisProcessor {
 #[must_use]
 pub struct DualAxisExclusion {
     /// The [`AxisExclusion`] for the X-axis inputs.
-    pub(crate) exclusion_x: AxisExclusion,
+    pub exclusion_x: AxisExclusion,
 
     /// The [`AxisExclusion`] for the Y-axis inputs.
-    pub(crate) exclusion_y: AxisExclusion,
+    pub exclusion_y: AxisExclusion,
 }
 
 impl DualAxisExclusion {
@@ -544,6 +544,142 @@ impl DualAxisExclusion {
     pub fn symmetric_only_y(threshold: f32) -> Self {
         Self {
             exclusion_y: AxisExclusion::symmetric(threshold),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes positive values that greater than `positive_min` on each axis.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0` on each axis.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive(x_positive_min: f32, y_positive_min: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_positive(x_positive_min),
+            exclusion_y: AxisExclusion::only_positive(y_positive_min),
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes positive values that greater than `positive_min` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_all(positive_min: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_positive(positive_min),
+            exclusion_y: AxisExclusion::only_positive(positive_min),
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes positive X values that greater than `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_x(positive_min: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_positive(positive_min),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes positive Y values that greater than `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_y(positive_min: f32) -> Self {
+        Self {
+            exclusion_y: AxisExclusion::only_positive(positive_min),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes negative values that less than `negative_max` on each axis.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` on each axis.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative(x_negative_max: f32, y_negative_max: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_negative(x_negative_max),
+            exclusion_y: AxisExclusion::only_negative(y_negative_max),
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes negative values that less than `negative_max` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_all(negative_max: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_negative(negative_max),
+            exclusion_y: AxisExclusion::only_negative(negative_max),
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes negative X values that less than `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_x(negative_max: f32) -> Self {
+        Self {
+            exclusion_x: AxisExclusion::only_negative(negative_max),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisExclusion`] that only passes negative Y values that less than `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_y(negative_max: f32) -> Self {
+        Self {
+            exclusion_y: AxisExclusion::only_negative(negative_max),
             ..Self::ZERO
         }
     }
@@ -703,10 +839,10 @@ impl From<AxisExclusion> for DualAxisProcessor {
 #[must_use]
 pub struct DualAxisDeadZone {
     /// The [`AxisDeadZone`] for the X-axis inputs.
-    pub(crate) deadzone_x: AxisDeadZone,
+    pub deadzone_x: AxisDeadZone,
 
     /// The [`AxisDeadZone`] for the Y-axis inputs.
-    pub(crate) deadzone_y: AxisDeadZone,
+    pub deadzone_y: AxisDeadZone,
 }
 
 impl DualAxisDeadZone {
@@ -847,6 +983,142 @@ impl DualAxisDeadZone {
     pub fn symmetric_only_y(threshold: f32) -> Self {
         Self {
             deadzone_y: AxisDeadZone::symmetric(threshold),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only passes positive values that greater than `positive_min` on each axis.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0` on each axis.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive(x_positive_min: f32, y_positive_min: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_positive(x_positive_min),
+            deadzone_y: AxisDeadZone::only_positive(y_positive_min),
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only passes positive values that greater than `positive_min` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_all(positive_min: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_positive(positive_min),
+            deadzone_y: AxisDeadZone::only_positive(positive_min),
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only excludes X values that less than or equal to `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_x(positive_min: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_positive(positive_min),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only excludes Y values that less than or equal to `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive_y(positive_min: f32) -> Self {
+        Self {
+            deadzone_y: AxisDeadZone::only_positive(positive_min),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only passes negative values that less than `negative_max` on each axis.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` on each axis.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative(x_negative_max: f32, y_negative_max: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_negative(x_negative_max),
+            deadzone_y: AxisDeadZone::only_negative(y_negative_max),
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only passes negative values that less than `negative_max` on both axes.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_all(negative_max: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_negative(negative_max),
+            deadzone_y: AxisDeadZone::only_negative(negative_max),
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only excludes X values that greater than or equal to `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_x(negative_max: f32) -> Self {
+        Self {
+            deadzone_x: AxisDeadZone::only_negative(negative_max),
+            ..Self::ZERO
+        }
+    }
+
+    /// Creates a [`DualAxisDeadZone`] that only excludes Y values that greater than or equal to `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative_y(negative_max: f32) -> Self {
+        Self {
+            deadzone_y: AxisDeadZone::only_negative(negative_max),
             ..Self::ZERO
         }
     }

--- a/src/input_processing/dual_axis/range.rs
+++ b/src/input_processing/dual_axis/range.rs
@@ -441,8 +441,7 @@ impl DualAxisExclusion {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn all(negative_max: f32, positive_min: f32) -> Self {
-        let range = (negative_max, positive_min);
-        Self::new(range, range)
+        AxisExclusion::new(negative_max, positive_min).extend_dual()
     }
 
     /// Creates a [`DualAxisExclusion`] that only ignores X values within the range `[negative_max, positive_min]`.
@@ -509,7 +508,7 @@ impl DualAxisExclusion {
     #[doc(alias = "magnitude_all")]
     #[inline]
     pub fn symmetric_all(threshold: f32) -> Self {
-        Self::symmetric(threshold, threshold)
+        AxisExclusion::symmetric(threshold).extend_dual()
     }
 
     /// Creates a [`DualAxisExclusion`] that only ignores X values within the range `[-threshold, threshold]`.
@@ -576,10 +575,7 @@ impl DualAxisExclusion {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn only_positive_all(positive_min: f32) -> Self {
-        Self {
-            exclusion_x: AxisExclusion::only_positive(positive_min),
-            exclusion_y: AxisExclusion::only_positive(positive_min),
-        }
+        AxisExclusion::only_positive(positive_min).extend_dual()
     }
 
     /// Creates a [`DualAxisExclusion`] that only passes positive X values that greater than `positive_min`.
@@ -644,10 +640,7 @@ impl DualAxisExclusion {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn only_negative_all(negative_max: f32) -> Self {
-        Self {
-            exclusion_x: AxisExclusion::only_negative(negative_max),
-            exclusion_y: AxisExclusion::only_negative(negative_max),
-        }
+        AxisExclusion::only_negative(negative_max).extend_dual()
     }
 
     /// Creates a [`DualAxisExclusion`] that only passes negative X values that less than `negative_max`.
@@ -880,8 +873,7 @@ impl DualAxisDeadZone {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn all(negative_max: f32, positive_min: f32) -> Self {
-        let range = (negative_max, positive_min);
-        Self::new(range, range)
+        AxisDeadZone::new(negative_max, positive_min).extend_dual()
     }
 
     /// Creates a [`DualAxisDeadZone`] that only excludes X values within the range `[negative_max, positive_min]`.
@@ -948,7 +940,7 @@ impl DualAxisDeadZone {
     #[doc(alias = "magnitude_all")]
     #[inline]
     pub fn symmetric_all(threshold: f32) -> Self {
-        Self::symmetric(threshold, threshold)
+        AxisDeadZone::symmetric(threshold).extend_dual()
     }
 
     /// Creates a [`DualAxisDeadZone`] that only excludes X values within the range `[-threshold, threshold]`.
@@ -1015,10 +1007,7 @@ impl DualAxisDeadZone {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn only_positive_all(positive_min: f32) -> Self {
-        Self {
-            deadzone_x: AxisDeadZone::only_positive(positive_min),
-            deadzone_y: AxisDeadZone::only_positive(positive_min),
-        }
+        AxisDeadZone::only_positive(positive_min).extend_dual()
     }
 
     /// Creates a [`DualAxisDeadZone`] that only excludes X values that less than or equal to `positive_min`.
@@ -1083,10 +1072,7 @@ impl DualAxisDeadZone {
     /// Panics if the requirements aren't met.
     #[inline]
     pub fn only_negative_all(negative_max: f32) -> Self {
-        Self {
-            deadzone_x: AxisDeadZone::only_negative(negative_max),
-            deadzone_y: AxisDeadZone::only_negative(negative_max),
-        }
+        AxisDeadZone::only_negative(negative_max).extend_dual()
     }
 
     /// Creates a [`DualAxisDeadZone`] that only excludes X values that greater than or equal to `negative_max`.

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -159,10 +159,24 @@ pub trait WithAxisProcessingPipelineExt: Sized {
     }
 
     /// Appends an [`AxisBounds`] processor as the next processing step,
-    /// restricting values to a `threshold` magnitude.
+    /// restricting values within the range `[-threshold, threshold]`.
     #[inline]
     fn with_bounds_symmetric(self, threshold: f32) -> Self {
         self.with_processor(AxisBounds::symmetric(threshold))
+    }
+
+    /// Appends an [`AxisBounds`] processor as the next processing step,
+    /// restricting values to a minimum value.
+    #[inline]
+    fn at_least(self, min: f32) -> Self {
+        self.with_processor(AxisBounds::at_least(min))
+    }
+
+    /// Appends an [`AxisBounds`] processor as the next processing step,
+    /// restricting values to a maximum value.
+    #[inline]
+    fn at_most(self, max: f32) -> Self {
+        self.with_processor(AxisBounds::at_most(max))
     }
 
     /// Appends an [`AxisDeadZone`] processor as the next processing step,
@@ -170,6 +184,14 @@ pub trait WithAxisProcessingPipelineExt: Sized {
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`AxisBounds::magnitude(1.0)`](AxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone(self, negative_max: f32, positive_min: f32) -> Self {
         self.with_processor(AxisDeadZone::new(negative_max, positive_min))
@@ -180,18 +202,62 @@ pub trait WithAxisProcessingPipelineExt: Sized {
     /// treating them as zeros, then normalizing non-excluded input values into the "live zone",
     /// the remaining range within the [`AxisBounds::magnitude(1.0)`](AxisBounds::default)
     /// after dead zone exclusion.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_symmetric(self, threshold: f32) -> Self {
         self.with_processor(AxisDeadZone::symmetric(threshold))
     }
 
-    fn negative_only(self, threshold: f32) -> Self {
-        self.with_processor(AxisDeadZone::negative_only())
+    /// Appends an [`AxisDeadZone`] processor as the next processing step,
+    /// only passing positive values that greater than `positive_min`
+    /// and then normalizing them into the "live zone" range `[positive_min, 1.0]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_positive(self, positive_min: f32) -> Self {
+        self.with_processor(AxisDeadZone::only_positive(positive_min))
+    }
+
+    /// Appends an [`AxisDeadZone`] processor as the next processing step,
+    /// only passing negative values that less than `negative_max`
+    /// and then normalizing them into the "live zone" range `[-1.0, negative_max]`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative(self, negative_max: f32) -> Self {
+        self.with_processor(AxisDeadZone::only_negative(negative_max))
     }
 
     /// Appends an [`AxisExclusion`] processor as the next processing step,
     /// ignoring values within the dead zone range `[negative_max, positive_min]` on the axis,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0` <= `positive_min`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_unscaled(self, negative_max: f32, positive_min: f32) -> Self {
         self.with_processor(AxisExclusion::new(negative_max, positive_min))
@@ -200,9 +266,47 @@ pub trait WithAxisProcessingPipelineExt: Sized {
     /// Appends an [`AxisExclusion`] processor as the next processing step,
     /// ignoring values within the dead zone range `[-threshold, threshold]` on the axis,
     /// treating them as zeros.
+    ///
+    /// # Requirements
+    ///
+    /// - `threshold` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
     #[inline]
     fn with_deadzone_symmetric_unscaled(self, threshold: f32) -> Self {
         self.with_processor(AxisExclusion::symmetric(threshold))
+    }
+
+    /// Appends an [`AxisExclusion`] processor as the next processing step,
+    /// only passing positive values that greater than `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_positive_unscaled(self, positive_min: f32) -> Self {
+        self.with_processor(AxisExclusion::only_positive(positive_min))
+    }
+
+    /// Appends an [`AxisExclusion`] processor as the next processing step,
+    /// only passing negative values that less than `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    fn only_negative_unscaled(self, negative_max: f32) -> Self {
+        self.with_processor(AxisExclusion::only_negative(negative_max))
     }
 }
 

--- a/src/input_processing/single_axis/mod.rs
+++ b/src/input_processing/single_axis/mod.rs
@@ -185,6 +185,10 @@ pub trait WithAxisProcessingPipelineExt: Sized {
         self.with_processor(AxisDeadZone::symmetric(threshold))
     }
 
+    fn negative_only(self, threshold: f32) -> Self {
+        self.with_processor(AxisDeadZone::negative_only())
+    }
+
     /// Appends an [`AxisExclusion`] processor as the next processing step,
     /// ignoring values within the dead zone range `[negative_max, positive_min]` on the axis,
     /// treating them as zeros.

--- a/src/input_processing/single_axis/range.rs
+++ b/src/input_processing/single_axis/range.rs
@@ -30,10 +30,10 @@ use super::AxisProcessor;
 #[must_use]
 pub struct AxisBounds {
     /// The minimum value of valid inputs.
-    pub(crate) min: f32,
+    pub min: f32,
 
     /// The maximum value of valid inputs.
-    pub(crate) max: f32,
+    pub max: f32,
 }
 
 impl AxisBounds {
@@ -189,10 +189,10 @@ impl Hash for AxisBounds {
 #[must_use]
 pub struct AxisExclusion {
     /// The maximum negative value treated as zero.
-    pub(crate) negative_max: f32,
+    pub negative_max: f32,
 
     /// The minimum positive value treated as zero.
-    pub(crate) positive_min: f32,
+    pub positive_min: f32,
 }
 
 impl AxisExclusion {
@@ -234,6 +234,34 @@ impl AxisExclusion {
     #[inline]
     pub fn symmetric(threshold: f32) -> Self {
         Self::new(-threshold, threshold)
+    }
+
+    /// Creates an [`AxisExclusion`] that only passes positive values that greater than `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive(positive_min: f32) -> Self {
+        Self::new(f32::NEG_INFINITY, positive_min)
+    }
+
+    /// Creates an [`AxisExclusion`] that only passes negative values that less than `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative(negative_max: f32) -> Self {
+        Self::new(negative_max, f32::INFINITY)
     }
 
     /// Returns the minimum and maximum bounds.
@@ -420,7 +448,35 @@ impl AxisDeadZone {
     #[doc(alias = "magnitude")]
     #[inline]
     pub fn symmetric(threshold: f32) -> Self {
-        AxisDeadZone::new(-threshold, threshold)
+        Self::new(-threshold, threshold)
+    }
+
+    /// Creates an [`AxisDeadZone`] that only passes positive values that greater than `positive_min`.
+    ///
+    /// # Requirements
+    ///
+    /// - `positive_min` >= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_positive(positive_min: f32) -> Self {
+        Self::new(f32::NEG_INFINITY, positive_min)
+    }
+
+    /// Creates an [`AxisDeadZone`] that only passes negative values that less than `negative_max`.
+    ///
+    /// # Requirements
+    ///
+    /// - `negative_max` <= `0.0`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the requirements aren't met.
+    #[inline]
+    pub fn only_negative(negative_max: f32) -> Self {
+        Self::new(negative_max, f32::INFINITY)
     }
 
     /// Returns the [`AxisExclusion`] used by this deadzone.

--- a/src/input_processing/single_axis/range.rs
+++ b/src/input_processing/single_axis/range.rs
@@ -30,10 +30,10 @@ use super::AxisProcessor;
 #[must_use]
 pub struct AxisBounds {
     /// The minimum value of valid inputs.
-    pub min: f32,
+    pub(crate) min: f32,
 
     /// The maximum value of valid inputs.
-    pub max: f32,
+    pub(crate) max: f32,
 }
 
 impl AxisBounds {
@@ -189,10 +189,10 @@ impl Hash for AxisBounds {
 #[must_use]
 pub struct AxisExclusion {
     /// The maximum negative value treated as zero.
-    pub negative_max: f32,
+    pub(crate) negative_max: f32,
 
     /// The minimum positive value treated as zero.
-    pub positive_min: f32,
+    pub(crate) positive_min: f32,
 }
 
 impl AxisExclusion {
@@ -415,8 +415,8 @@ impl AxisDeadZone {
         livezone_upper_recip: 1.0,
     };
 
-    /// Creates an [`AxisDeadZone`] that excludes input values
-    /// within the given deadzone `[negative_max, positive_min]`.
+    /// Creates an [`AxisDeadZone`] that excludes input values within the range `[negative_max, positive_min]`
+    /// and then normalizes non-excluded input values into the valid range `[-1.0, 1.0]`.
     ///
     /// # Requirements
     ///
@@ -435,7 +435,7 @@ impl AxisDeadZone {
         }
     }
 
-    /// Creates an [`AxisDeadZone`] that excludes input values below a `threshold` magnitude
+    /// Creates an [`AxisDeadZone`] that excludes input values within the range `[-threshold, threshold]`
     /// and then normalizes non-excluded input values into the valid range `[-1.0, 1.0]`.
     ///
     /// # Requirements
@@ -451,7 +451,8 @@ impl AxisDeadZone {
         Self::new(-threshold, threshold)
     }
 
-    /// Creates an [`AxisDeadZone`] that only passes positive values that greater than `positive_min`.
+    /// Creates an [`AxisDeadZone`] that only passes positive values that greater than `positive_min`
+    /// and then normalizes them into the valid range `[-1.0, 1.0]`.
     ///
     /// # Requirements
     ///
@@ -465,7 +466,8 @@ impl AxisDeadZone {
         Self::new(f32::NEG_INFINITY, positive_min)
     }
 
-    /// Creates an [`AxisDeadZone`] that only passes negative values that less than `negative_max`.
+    /// Creates an [`AxisDeadZone`] that only passes negative values that less than `negative_max`
+    /// and then normalizes them into the valid range `[-1.0, 1.0]`.
     ///
     /// # Requirements
     ///


### PR DESCRIPTION
- added missing docs about panicking.
- allowed creating `DualAxisBounds`, `DualAxisExclusion`, and `DualAxisDeadZone` from their struct definitions directly.
- added `at_least` and `at_most` methods for those implementing `WithAxisProcessorExt` trait.
- added `at_least`, `at_least_only_x`, `at_least_only_y`, `at_most`, `at_most_only_x`, and `at_most_only_y` methods for those implementing `WithDualAxisProcessorExt` trait.
- added `only_positive` and `only_negative` builders for `AxisDeadZone` and `AxisExclusion`.
  - added corresponding extension methods for those implementing `WithAxisProcessorExt` trait.
- added `only_positive`, `only_positive_x`, `only_positive_y`, `only_negative`, `only_negative_x`, and `only_negative_y` builders for `DualAxisDeadZone` and `DualAxisExclusion`.
  - added corresponding extension methods for those implementing `WithDualAxisProcessorExt` trait.
- refactored some builder methods to reduce a duplicated assert