### PR TITLE
Add deserializer function for MouseButton

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -10,6 +10,7 @@
   - `GamepadButton` and `GamepadButtonType` now get values from `Axis<GamepadButton>`
   - `VirtualAxis`, `VirtualDPad`, and `VirtualDPad3D` now report axis values based on the values of the constitute buttons
   - added `value` field to `ActionDiff::Pressed`
+- added missing deserializer function for `MouseButton`
 
 ### Usability (0.16.0)
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -208,6 +208,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
         app.register_type::<AccumulatedMouseMovement>()
             .register_type::<AccumulatedMouseScroll>()
             .register_buttonlike_input::<MouseMoveDirection>()
+            .register_buttonlike_input::<MouseButton>()
             .register_axislike_input::<MouseMoveAxis>()
             .register_dual_axislike_input::<MouseMove>()
             .register_buttonlike_input::<MouseScrollDirection>()

--- a/src/user_input/trait_serde.rs
+++ b/src/user_input/trait_serde.rs
@@ -258,6 +258,31 @@ mod tests {
 
     #[cfg(feature = "mouse")]
     #[test]
+    fn test_mouse_button_serde() {
+        use bevy::prelude::MouseButton;
+        use serde_test::{assert_tokens, Token};
+
+        use crate::prelude::Buttonlike;
+
+        register_input_deserializers();
+
+        let boxed_input: Box<dyn Buttonlike> = Box::new(MouseButton::Left);
+        assert_tokens(
+            &boxed_input,
+            &[
+                Token::Map { len: Some(1) },
+                Token::BorrowedStr("MouseButton"),
+                Token::UnitVariant {
+                    name: "MouseButton",
+                    variant: "Left",
+                },
+                Token::MapEnd,
+            ],
+        );
+    }
+
+    #[cfg(feature = "mouse")]
+    #[test]
     fn test_axis_serde() {
         use crate::prelude::{Axislike, MouseScrollAxis};
         use serde_test::{assert_tokens, Token};


### PR DESCRIPTION
In our project, we want to store and load control to `.ron` file. 
After update to `0.15` there was error `tokens failed to deserialize: no deserialize function was registered for id '"MouseButton"'`
I checked the latest fixes, and it looks like there was just missing `register_buttonlike_input` for `MouseButton`