### PR TITLE
Use native target in ci instead of linux

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -23,7 +23,6 @@ const CLIPPY_FLAGS: [&str; 3] = [
     "-Dwarnings",
 ];
 
-const COMPILE_TARGETS: &[&str] = &["x86_64-unknown-linux-gnu", "wasm32-unknown-unknown"];
 
 fn main() {
     // When run locally, results may differ from actual CI runs triggered by
@@ -149,10 +148,11 @@ fn main() {
         }
 
         if what_to_run.contains(Check::COMPILE_CHECK) {
-            for target in COMPILE_TARGETS {
+            let compile_targets = &[vec![], vec!["--target", "wasm32-unknown-unknown"]];
+            for target in compile_targets {
                 cmd!(
                     sh,
-                    "cargo check --workspace {feature_option} {extra...} --target {target}"
+                    "cargo check --workspace {feature_option} {extra...} {target...}"
                 )
                 .run()
                 .expect("Please fix compiler errors in above output.");


### PR DESCRIPTION
* #646

This builds for me in W11 after removing the explicit linux target. Let's see if it will work in GHA.