### PR TITLE
Make processors, Virtual pads, and GamepadStick fields public

### DIFF
--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -290,10 +290,10 @@ impl Axislike for GamepadAxis {
 #[must_use]
 pub struct GamepadControlAxis {
     /// The wrapped axis.
-    pub(crate) axis: GamepadAxisType,
+    pub axis: GamepadAxisType,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<AxisProcessor>,
+    pub processors: Vec<AxisProcessor>,
 }
 
 impl GamepadControlAxis {
@@ -429,13 +429,13 @@ impl WithAxisProcessingPipelineExt for GamepadControlAxis {
 #[must_use]
 pub struct GamepadStick {
     /// Horizontal movement of the stick.
-    pub(crate) x: GamepadAxisType,
+    pub x: GamepadAxisType,
 
     /// Vertical movement of the stick.
-    pub(crate) y: GamepadAxisType,
+    pub y: GamepadAxisType,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<DualAxisProcessor>,
+    pub processors: Vec<DualAxisProcessor>,
 }
 
 impl GamepadStick {

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -261,7 +261,7 @@ pub struct MouseMoveAxis {
     pub axis: DualAxisType,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<AxisProcessor>,
+    pub processors: Vec<AxisProcessor>,
 }
 
 impl MouseMoveAxis {
@@ -382,7 +382,7 @@ impl WithAxisProcessingPipelineExt for MouseMoveAxis {
 #[must_use]
 pub struct MouseMove {
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<DualAxisProcessor>,
+    pub processors: Vec<DualAxisProcessor>,
 }
 
 impl UpdatableInput for MouseMove {
@@ -628,7 +628,7 @@ pub struct MouseScrollAxis {
     pub axis: DualAxisType,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<AxisProcessor>,
+    pub processors: Vec<AxisProcessor>,
 }
 
 impl MouseScrollAxis {
@@ -761,7 +761,7 @@ impl WithAxisProcessingPipelineExt for MouseScrollAxis {
 #[must_use]
 pub struct MouseScroll {
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<DualAxisProcessor>,
+    pub processors: Vec<DualAxisProcessor>,
 }
 
 impl UpdatableInput for MouseScroll {

--- a/src/user_input/virtual_axial.rs
+++ b/src/user_input/virtual_axial.rs
@@ -59,13 +59,13 @@ use serde::{Deserialize, Serialize};
 #[must_use]
 pub struct VirtualAxis {
     /// The button that represents the negative direction.
-    pub(crate) negative: Box<dyn Buttonlike>,
+    pub negative: Box<dyn Buttonlike>,
 
     /// The button that represents the positive direction.
-    pub(crate) positive: Box<dyn Buttonlike>,
+    pub positive: Box<dyn Buttonlike>,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<AxisProcessor>,
+    pub processors: Vec<AxisProcessor>,
 }
 
 impl VirtualAxis {
@@ -295,19 +295,19 @@ impl WithAxisProcessingPipelineExt for VirtualAxis {
 #[must_use]
 pub struct VirtualDPad {
     /// The button for the upward direction.
-    pub(crate) up: Box<dyn Buttonlike>,
+    pub up: Box<dyn Buttonlike>,
 
     /// The button for the downward direction.
-    pub(crate) down: Box<dyn Buttonlike>,
+    pub down: Box<dyn Buttonlike>,
 
     /// The button for the leftward direction.
-    pub(crate) left: Box<dyn Buttonlike>,
+    pub left: Box<dyn Buttonlike>,
 
     /// The button for the rightward direction.
-    pub(crate) right: Box<dyn Buttonlike>,
+    pub right: Box<dyn Buttonlike>,
 
     /// A processing pipeline that handles input values.
-    pub(crate) processors: Vec<DualAxisProcessor>,
+    pub processors: Vec<DualAxisProcessor>,
 }
 
 impl VirtualDPad {
@@ -503,22 +503,22 @@ impl WithDualAxisProcessingPipelineExt for VirtualDPad {
 #[must_use]
 pub struct VirtualDPad3D {
     /// The button for the upward direction.
-    pub(crate) up: Box<dyn Buttonlike>,
+    pub up: Box<dyn Buttonlike>,
 
     /// The button for the downward direction.
-    pub(crate) down: Box<dyn Buttonlike>,
+    pub down: Box<dyn Buttonlike>,
 
     /// The button for the leftward direction.
-    pub(crate) left: Box<dyn Buttonlike>,
+    pub left: Box<dyn Buttonlike>,
 
     /// The button for the rightward direction.
-    pub(crate) right: Box<dyn Buttonlike>,
+    pub right: Box<dyn Buttonlike>,
 
     /// The button for the forward direction.
-    pub(crate) forward: Box<dyn Buttonlike>,
+    pub forward: Box<dyn Buttonlike>,
 
     /// The button for the backward direction.
-    pub(crate) backward: Box<dyn Buttonlike>,
+    pub backward: Box<dyn Buttonlike>,
 }
 
 impl VirtualDPad3D {


### PR DESCRIPTION
Fixes #656

Makes it easier to tune controls using inspectors and also to construct VirtualDPads using dynamic values.