### PR TITLE
Make the macros deterministic, using BTreeMap instead of HashMap

### DIFF
--- a/macros/src/actionlike.rs
+++ b/macros/src/actionlike.rs
@@ -1,7 +1,7 @@
 use crate::utils;
 use proc_macro2::{Span, TokenStream};
 use quote::quote;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use syn::{Attribute, Data, DataEnum, DeriveInput, Error, Ident};
 
 // This approach and implementation is inspired by the `strum` crate,
@@ -81,8 +81,8 @@ fn generate_input_control_kind_body(
 fn parse_variant_controls(
     data: &DataEnum,
     default_control: &Ident,
-) -> syn::Result<HashMap<Ident, Ident>> {
-    let mut map = HashMap::<Ident, Ident>::new();
+) -> syn::Result<BTreeMap<Ident, Ident>> {
+    let mut map = BTreeMap::<Ident, Ident>::new();
     for variant in data.variants.iter() {
         for attr in variant
             .attrs


### PR DESCRIPTION
This fixes compile errors in non-cargo build systems, which rely on the rustc crate hash being the same between two compiles (i.e. build with/without codegen).

HashMap order is nondeterministic due to SipHasher initialization, so macro-generated code would change between compiles (in this case, the order of the generated match statement branches).

Can confirm buck2 can now build and link leafwing-input-manager.