### PR TITLE
registries: no need for `static mut` or unsafe + use std's LazyLock

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,6 @@ serde_flexitos = "0.2"
 dyn-clone = "1.0"
 dyn-eq = "0.1"
 dyn-hash = "0.2"
-once_cell = "1.19"
 
 [dev-dependencies]
 bevy = { version = "0.14.0-rc.3", default-features = false, features = [

--- a/macros/src/actionlike.rs
+++ b/macros/src/actionlike.rs
@@ -4,9 +4,9 @@ use quote::quote;
 use std::collections::HashMap;
 use syn::{Attribute, Data, DataEnum, DeriveInput, Error, Ident};
 
-/// This approach and implementation is inspired by the `strum` crate,
-/// Copyright (c) 2019 Peter Glotfelty
-/// available under the MIT License at <https://github.com/Peternator7/strum>
+// This approach and implementation is inspired by the `strum` crate,
+// Copyright (c) 2019 Peter Glotfelty
+// available under the MIT License at <https://github.com/Peternator7/strum>
 
 pub(crate) fn actionlike_inner(ast: &DeriveInput) -> syn::Result<TokenStream> {
     // Splitting the abstract syntax tree

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -1,7 +1,7 @@
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 
 use bevy::app::App;
 use bevy::prelude::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, TypePath, Vec2};
@@ -13,7 +13,6 @@ use bevy::reflect::{
 use dyn_clone::DynClone;
 use dyn_eq::DynEq;
 use dyn_hash::DynHash;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_flexitos::ser::require_erased_serialize_impl;
 use serde_flexitos::{serialize_trait_object, Registry};
@@ -281,14 +280,14 @@ impl<'de> Deserialize<'de> for Box<dyn CustomDualAxisProcessor> {
     where
         D: Deserializer<'de>,
     {
-        let registry = unsafe { PROCESSOR_REGISTRY.read().unwrap() };
+        let registry = PROCESSOR_REGISTRY.read().unwrap();
         registry.deserialize_trait_object(deserializer)
     }
 }
 
 /// Registry of deserializers for [`CustomDualAxisProcessor`]s.
-static mut PROCESSOR_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn CustomDualAxisProcessor>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("CustomDualAxisProcessor")));
+static PROCESSOR_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn CustomDualAxisProcessor>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("CustomDualAxisProcessor")));
 
 /// A trait for registering a specific [`CustomDualAxisProcessor`].
 pub trait RegisterDualAxisProcessorExt {
@@ -303,7 +302,7 @@ impl RegisterDualAxisProcessorExt for App {
     where
         T: RegisterTypeTag<'de, dyn CustomDualAxisProcessor> + GetTypeRegistration,
     {
-        let mut registry = unsafe { PROCESSOR_REGISTRY.write().unwrap() };
+        let mut registry = PROCESSOR_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -261,7 +261,7 @@ impl FromReflect for Box<dyn CustomDualAxisProcessor> {
     }
 }
 
-impl<'a> Serialize for dyn CustomDualAxisProcessor + 'a {
+impl Serialize for dyn CustomDualAxisProcessor + '_ {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -260,7 +260,7 @@ impl FromReflect for Box<dyn CustomAxisProcessor> {
     }
 }
 
-impl<'a> Serialize for dyn CustomAxisProcessor + 'a {
+impl Serialize for dyn CustomAxisProcessor + '_ {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -1,7 +1,7 @@
 use std::any::{Any, TypeId};
 use std::fmt::{Debug, Formatter};
 use std::hash::{Hash, Hasher};
-use std::sync::RwLock;
+use std::sync::{LazyLock, RwLock};
 
 use bevy::app::App;
 use bevy::prelude::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, TypePath};
@@ -13,7 +13,6 @@ use bevy::reflect::{
 use dyn_clone::DynClone;
 use dyn_eq::DynEq;
 use dyn_hash::DynHash;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_flexitos::ser::require_erased_serialize_impl;
 use serde_flexitos::{serialize_trait_object, Registry};
@@ -280,14 +279,14 @@ impl<'de> Deserialize<'de> for Box<dyn CustomAxisProcessor> {
     where
         D: Deserializer<'de>,
     {
-        let registry = unsafe { PROCESSOR_REGISTRY.read().unwrap() };
+        let registry = PROCESSOR_REGISTRY.read().unwrap();
         registry.deserialize_trait_object(deserializer)
     }
 }
 
 /// Registry of deserializers for [`CustomAxisProcessor`]s.
-static mut PROCESSOR_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn CustomAxisProcessor>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("CustomAxisProcessor")));
+static PROCESSOR_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn CustomAxisProcessor>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("CustomAxisProcessor")));
 
 /// A trait for registering a specific [`CustomAxisProcessor`].
 pub trait RegisterCustomAxisProcessorExt {
@@ -302,7 +301,7 @@ impl RegisterCustomAxisProcessorExt for App {
     where
         T: RegisterTypeTag<'de, dyn CustomAxisProcessor> + GetTypeRegistration,
     {
-        let mut registry = unsafe { PROCESSOR_REGISTRY.write().unwrap() };
+        let mut registry = PROCESSOR_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self

--- a/src/user_input/trait_serde.rs
+++ b/src/user_input/trait_serde.rs
@@ -98,7 +98,7 @@ mod buttonlike {
 
     use super::*;
 
-    impl<'a> Serialize for dyn Buttonlike + 'a {
+    impl Serialize for dyn Buttonlike + '_ {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -128,7 +128,7 @@ mod axislike {
 
     use super::*;
 
-    impl<'a> Serialize for dyn Axislike + 'a {
+    impl Serialize for dyn Axislike + '_ {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -158,7 +158,7 @@ mod dualaxislike {
 
     use super::*;
 
-    impl<'a> Serialize for dyn DualAxislike + 'a {
+    impl Serialize for dyn DualAxislike + '_ {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,
@@ -188,7 +188,7 @@ mod tripleaxislike {
 
     use super::*;
 
-    impl<'a> Serialize for dyn TripleAxislike + 'a {
+    impl Serialize for dyn TripleAxislike + '_ {
         fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
         where
             S: Serializer,

--- a/src/user_input/trait_serde.rs
+++ b/src/user_input/trait_serde.rs
@@ -4,29 +4,29 @@ use std::sync::RwLock;
 
 use bevy::app::App;
 use bevy::reflect::GetTypeRegistration;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use serde_flexitos::ser::require_erased_serialize_impl;
 use serde_flexitos::{serialize_trait_object, Registry};
+use std::sync::LazyLock;
 
 use super::{Axislike, Buttonlike, DualAxislike, TripleAxislike};
 use crate::typetag::{InfallibleMapRegistry, RegisterTypeTag};
 
 /// Registry of deserializers for [`Buttonlike`]s.
-static mut BUTTONLIKE_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn Buttonlike>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("Buttonlike")));
+static BUTTONLIKE_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn Buttonlike>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("Buttonlike")));
 
 /// Registry of deserializers for [`Axislike`]s.
-static mut AXISLIKE_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn Axislike>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("Axislike")));
+static AXISLIKE_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn Axislike>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("Axislike")));
 
 /// Registry of deserializers for [`DualAxislike`]s.
-static mut DUAL_AXISLIKE_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn DualAxislike>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("DualAxislike")));
+static DUAL_AXISLIKE_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn DualAxislike>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("DualAxislike")));
 
 /// Registry of deserializers for [`TripleAxislike`]s.
-static mut TRIPLE_AXISLIKE_REGISTRY: Lazy<RwLock<InfallibleMapRegistry<dyn TripleAxislike>>> =
-    Lazy::new(|| RwLock::new(InfallibleMapRegistry::new("TripleAxislike")));
+static TRIPLE_AXISLIKE_REGISTRY: LazyLock<RwLock<InfallibleMapRegistry<dyn TripleAxislike>>> =
+    LazyLock::new(|| RwLock::new(InfallibleMapRegistry::new("TripleAxislike")));
 
 /// A trait for registering inputs.
 pub trait RegisterUserInput {
@@ -56,7 +56,7 @@ impl RegisterUserInput for App {
     where
         T: RegisterTypeTag<'de, dyn Buttonlike> + GetTypeRegistration,
     {
-        let mut registry = unsafe { BUTTONLIKE_REGISTRY.write().unwrap() };
+        let mut registry = BUTTONLIKE_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self
@@ -66,7 +66,7 @@ impl RegisterUserInput for App {
     where
         T: RegisterTypeTag<'de, dyn Axislike> + GetTypeRegistration,
     {
-        let mut registry = unsafe { AXISLIKE_REGISTRY.write().unwrap() };
+        let mut registry = AXISLIKE_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self
@@ -76,7 +76,7 @@ impl RegisterUserInput for App {
     where
         T: RegisterTypeTag<'de, dyn DualAxislike> + GetTypeRegistration,
     {
-        let mut registry = unsafe { DUAL_AXISLIKE_REGISTRY.write().unwrap() };
+        let mut registry = DUAL_AXISLIKE_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self
@@ -86,7 +86,7 @@ impl RegisterUserInput for App {
     where
         T: RegisterTypeTag<'de, dyn TripleAxislike> + GetTypeRegistration,
     {
-        let mut registry = unsafe { TRIPLE_AXISLIKE_REGISTRY.write().unwrap() };
+        let mut registry = TRIPLE_AXISLIKE_REGISTRY.write().unwrap();
         T::register_typetag(&mut registry);
         self.register_type::<T>();
         self
@@ -117,7 +117,7 @@ mod buttonlike {
         where
             D: Deserializer<'de>,
         {
-            let registry = unsafe { BUTTONLIKE_REGISTRY.read().unwrap() };
+            let registry = BUTTONLIKE_REGISTRY.read().unwrap();
             registry.deserialize_trait_object(deserializer)
         }
     }
@@ -147,7 +147,7 @@ mod axislike {
         where
             D: Deserializer<'de>,
         {
-            let registry = unsafe { AXISLIKE_REGISTRY.read().unwrap() };
+            let registry = AXISLIKE_REGISTRY.read().unwrap();
             registry.deserialize_trait_object(deserializer)
         }
     }
@@ -177,7 +177,7 @@ mod dualaxislike {
         where
             D: Deserializer<'de>,
         {
-            let registry = unsafe { DUAL_AXISLIKE_REGISTRY.read().unwrap() };
+            let registry = DUAL_AXISLIKE_REGISTRY.read().unwrap();
             registry.deserialize_trait_object(deserializer)
         }
     }
@@ -207,7 +207,7 @@ mod tripleaxislike {
         where
             D: Deserializer<'de>,
         {
-            let registry = unsafe { TRIPLE_AXISLIKE_REGISTRY.read().unwrap() };
+            let registry = TRIPLE_AXISLIKE_REGISTRY.read().unwrap();
             registry.deserialize_trait_object(deserializer)
         }
     }


### PR DESCRIPTION
This fixes nightly rustc yelling about:

    error: creating a shared reference to mutable static is discouraged
      --> src/user_input/trait_serde.rs:69:37
       |
    69 |         let mut registry = unsafe { AXISLIKE_REGISTRY.write().unwrap() };
       |                                     ^^^^^^^^^^^^^^^^^^^^^^^^^ shared reference to mutable static
       |
       = note: for more information, see <https://doc.rust-lang.org/nightly/edition-guide/rust-2024/static-mut-references.html>
       = note: shared references to mutable statics are dangerous; it's undefined behavior if the static is mutated or if a mutable reference is created for it while the shared reference lives

And drops a dependency.

Ref #662 which had build failures.