### PR TITLE
Upgrade to Bevy 0.15.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ egui = ['dep:bevy_egui']
 
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.15.1" }
-bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+bevy = { version = "0.15.0-dev", default-features = false, features = [
   "serialize",
 ] }
 bevy_egui = { version = "0.29", optional = true }
@@ -63,7 +63,7 @@ dyn-hash = "0.2"
 once_cell = "1.19"
 
 [dev-dependencies]
-bevy = { version = "0.14.0-rc.3", default-features = false, features = [
+bevy = { version = "0.15.0-dev", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "bevy_text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ egui = ['dep:bevy_egui']
 
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.15.1" }
-bevy = { version = "0.15.0-dev", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
   "serialize",
 ] }
 bevy_egui = { version = "0.31", optional = true }
@@ -62,7 +62,7 @@ dyn-eq = "0.1"
 dyn-hash = "0.2"
 
 [dev-dependencies]
-bevy = { version = "0.15.0-dev", default-features = false, features = [
+bevy = { version = "0.15.0", default-features = false, features = [
   "bevy_asset",
   "bevy_sprite",
   "bevy_text",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ leafwing_input_manager_macros = { path = "macros", version = "0.15.1" }
 bevy = { version = "0.15.0-dev", default-features = false, features = [
   "serialize",
 ] }
-bevy_egui = { version = "0.30", optional = true }
+bevy_egui = { version = "0.31", optional = true }
 
 derive_more = { version = "0.99", default-features = false, features = [
   "display",

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ and a single input can result in multiple actions being triggered, which can be 
 - Look up your current input state in a single `ActionState` component
   - That pesky maximum of 16 system parameters got you down? Say goodbye to that input handling mega-system
 - Ergonomic insertion API that seamlessly blends multiple input types for you
-  - Can't decide between `input_map.insert(Action::Jump, KeyCode::Space)` and `input_map.insert(Action::Jump, GamepadButtonType::South)`? Have both!
+  - Can't decide between `input_map.insert(Action::Jump, KeyCode::Space)` and `input_map.insert(Action::Jump, GamepadButton::South)`? Have both!
 - Full support for arbitrary button combinations: chord your heart out.
   - `input_map.insert(Action::Console, ButtonlikeChord::new([KeyCode::ControlLeft, KeyCode::Shift, KeyCode::KeyC]))`
 - Sophisticated input disambiguation with the `ClashStrategy` enum: stop triggering individual buttons when you meant to press a chord!

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -32,7 +32,7 @@ fn spawn_player(mut commands: Commands) {
         // Let's bind the left stick for the move action
         .with_dual_axis(Action::Move, GamepadStick::LEFT)
         // And then bind the right gamepad trigger to the throttle action
-        .with(Action::Throttle, GamepadButtonType::RightTrigger2)
+        .with(Action::Throttle, GamepadButton::RightTrigger2)
         // And we'll use the right stick's x-axis as a rudder control
         .with_axis(
             // Add an AxisDeadzone to process horizontal values of the right stick.

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -57,7 +57,7 @@ fn move_player(query: Query<&ActionState<Action>, With<Player>>) {
 
     if action_state.pressed(&Action::Throttle) {
         // Note that some gamepad buttons are also tied to axes, so even though we used a
-        // GamepadButtonType::RightTrigger2 binding to trigger the throttle action,
+        // GamepadButton::RightTrigger2 binding to trigger the throttle action,
         // we can get a variable value here if you have a variable right trigger on your gamepad.
         //
         // If you don't have a variable trigger, this will just return 0.0 when not pressed and 1.0

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -27,8 +27,8 @@ impl PlayerAction {
 
         // Default gamepad input bindings
         input_map.insert_dual_axis(Self::Run, GamepadStick::LEFT);
-        input_map.insert(Self::Jump, GamepadButtonType::South);
-        input_map.insert(Self::UseItem, GamepadButtonType::RightTrigger2);
+        input_map.insert(Self::Jump, GamepadButton::South);
+        input_map.insert(Self::UseItem, GamepadButton::RightTrigger2);
 
         // Default kbm input bindings
         input_map.insert_dual_axis(Self::Run, VirtualDPad::wasd());

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -25,10 +25,10 @@ fn setup(mut commands: Commands) {
         .spawn(Camera2d)
         .insert(InputManagerBundle::with_map(input_map));
 
-    commands.spawn(SpriteBundle {
-        transform: Transform::from_scale(Vec3::new(100., 100., 1.)),
-        ..default()
-    });
+    commands.spawn((
+        Sprite::default(),
+        Transform::from_scale(Vec3::new(100., 100., 1.)),
+    ));
 }
 
 fn pan_camera(mut query: Query<(&mut Transform, &ActionState<CameraMovement>), With<Camera2d>>) {

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -22,7 +22,7 @@ fn setup(mut commands: Commands) {
     // via the `MouseMoveDirection` enum.
     let input_map = InputMap::default().with_dual_axis(CameraMovement::Pan, MouseMove::default());
     commands
-        .spawn(Camera2dBundle::default())
+        .spawn(Camera2d)
         .insert(InputManagerBundle::with_map(input_map));
 
     commands.spawn(SpriteBundle {

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -1,4 +1,4 @@
-use bevy::prelude::*;
+use bevy::{prelude::*, render::camera::ScalingMode};
 use leafwing_input_manager::prelude::*;
 
 fn main() {
@@ -33,7 +33,7 @@ fn setup(mut commands: Commands) {
         // Or even a digital dual-axis input!
         .with_dual_axis(CameraMovement::Pan, MouseScroll::default().digital());
     commands
-        .spawn(Camera2dBundle::default())
+        .spawn(Camera2d)
         .insert(InputManagerBundle::with_map(input_map));
 
     commands.spawn(SpriteBundle {
@@ -55,7 +55,10 @@ fn zoom_camera(
     // We want to zoom in when we use mouse wheel up,
     // so we increase the scale proportionally
     // Note that the projection's scale should always be positive (or our images will flip)
-    camera_projection.scale *= 1. - zoom_delta * CAMERA_ZOOM_RATE;
+    match camera_projection.scaling_mode {
+        ScalingMode::WindowSize(ref mut scale) => *scale *= 1. - zoom_delta * CAMERA_ZOOM_RATE,
+        ref mut scale => *scale = ScalingMode::WindowSize(1. - zoom_delta * CAMERA_ZOOM_RATE),
+    }
 }
 
 fn pan_camera(mut query: Query<(&mut Transform, &ActionState<CameraMovement>), With<Camera2d>>) {

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -30,7 +30,7 @@ struct PlayerBundle {
 }
 
 impl PlayerBundle {
-    fn input_map(player: Player) -> InputMap<Action> {
+    fn input_map(player: Player, gamepad_0: Entity, gamepad_1: Entity) -> InputMap<Action> {
         let mut input_map = match player {
             Player::One => InputMap::new([
                 (Action::Left, KeyCode::KeyA),
@@ -42,21 +42,21 @@ impl PlayerBundle {
             // and gracefully handle disconnects
             // Note that this step is not required:
             // if it is skipped, all input maps will read from all connected gamepads
-            .with_gamepad(Gamepad { id: 0 }),
+            .with_gamepad(gamepad_0),
             Player::Two => InputMap::new([
                 (Action::Left, KeyCode::ArrowLeft),
                 (Action::Right, KeyCode::ArrowRight),
                 (Action::Jump, KeyCode::ArrowUp),
             ])
-            .with_gamepad(Gamepad { id: 1 }),
+            .with_gamepad(gamepad_1),
         };
 
         // Each player will use the same gamepad controls, but on separate gamepads.
         input_map.insert_multiple([
-            (Action::Left, GamepadButtonType::DPadLeft),
-            (Action::Right, GamepadButtonType::DPadRight),
-            (Action::Jump, GamepadButtonType::DPadUp),
-            (Action::Jump, GamepadButtonType::South),
+            (Action::Left, GamepadButton::DPadLeft),
+            (Action::Right, GamepadButton::DPadRight),
+            (Action::Jump, GamepadButton::DPadUp),
+            (Action::Jump, GamepadButton::South),
         ]);
 
         input_map
@@ -64,14 +64,17 @@ impl PlayerBundle {
 }
 
 fn spawn_players(mut commands: Commands) {
+    let gamepad_0 = commands.spawn(()).id();
+    let gamepad_1 = commands.spawn(()).id();
+
     commands.spawn(PlayerBundle {
         player: Player::One,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::One)),
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::One, gamepad_0, gamepad_1)),
     });
 
     commands.spawn(PlayerBundle {
         player: Player::Two,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::Two)),
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::Two, gamepad_0, gamepad_1)),
     });
 }
 

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -69,12 +69,20 @@ fn spawn_players(mut commands: Commands) {
 
     commands.spawn(PlayerBundle {
         player: Player::One,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::One, gamepad_0, gamepad_1)),
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(
+            Player::One,
+            gamepad_0,
+            gamepad_1,
+        )),
     });
 
     commands.spawn(PlayerBundle {
         player: Player::Two,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(Player::Two, gamepad_0, gamepad_1)),
+        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(
+            Player::Two,
+            gamepad_0,
+            gamepad_1,
+        )),
     });
 }
 

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -6,7 +6,7 @@
 //! Note that [`ActionState`] can also be serialized and sent directly.
 //! This approach will be less bandwidth efficient, but involve less complexity and CPU work.
 
-use bevy::ecs::event::ManualEventReader;
+use bevy::ecs::event::EventCursor;
 use bevy::input::InputPlugin;
 use bevy::prelude::*;
 use leafwing_input_manager::action_diff::ActionDiffEvent;
@@ -137,13 +137,13 @@ fn spawn_player(mut commands: Commands) {
 fn send_events<A: Send + Sync + 'static + Debug + Clone + Event>(
     client_app: &App,
     server_app: &mut App,
-    reader: Option<ManualEventReader<A>>,
-) -> ManualEventReader<A> {
+    reader: Option<EventCursor<A>>,
+) -> EventCursor<A> {
     let client_events: &Events<A> = client_app.world().resource();
     let mut server_events: Mut<Events<A>> = server_app.world_mut().resource_mut();
 
     // Get an event reader, one way or another
-    let mut reader = reader.unwrap_or_else(|| client_events.get_reader());
+    let mut reader = reader.unwrap_or_else(|| client_events.get_cursor());
 
     // Push the clients' events to the server
     for client_event in reader.read(client_events) {

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -74,34 +74,34 @@ impl PlayerBundle {
 
         // Movement
         input_map.insert(Up, KeyCode::ArrowUp);
-        input_map.insert(Up, GamepadButtonType::DPadUp);
+        input_map.insert(Up, GamepadButton::DPadUp);
 
         input_map.insert(Down, KeyCode::ArrowDown);
-        input_map.insert(Down, GamepadButtonType::DPadDown);
+        input_map.insert(Down, GamepadButton::DPadDown);
 
         input_map.insert(Left, KeyCode::ArrowLeft);
-        input_map.insert(Left, GamepadButtonType::DPadLeft);
+        input_map.insert(Left, GamepadButton::DPadLeft);
 
         input_map.insert(Right, KeyCode::ArrowRight);
-        input_map.insert(Right, GamepadButtonType::DPadRight);
+        input_map.insert(Right, GamepadButton::DPadRight);
 
         // Abilities
         input_map.insert(Ability1, KeyCode::KeyQ);
-        input_map.insert(Ability1, GamepadButtonType::West);
+        input_map.insert(Ability1, GamepadButton::West);
         input_map.insert(Ability1, MouseButton::Left);
 
         input_map.insert(Ability2, KeyCode::KeyW);
-        input_map.insert(Ability2, GamepadButtonType::North);
+        input_map.insert(Ability2, GamepadButton::North);
         input_map.insert(Ability2, MouseButton::Right);
 
         input_map.insert(Ability3, KeyCode::KeyE);
-        input_map.insert(Ability3, GamepadButtonType::East);
+        input_map.insert(Ability3, GamepadButton::East);
 
         input_map.insert(Ability4, KeyCode::Space);
-        input_map.insert(Ability4, GamepadButtonType::South);
+        input_map.insert(Ability4, GamepadButton::South);
 
         input_map.insert(Ultimate, KeyCode::KeyR);
-        input_map.insert(Ultimate, GamepadButtonType::LeftTrigger2);
+        input_map.insert(Ultimate, GamepadButton::LeftTrigger2);
 
         input_map
     }

--- a/examples/twin_stick_controller.rs
+++ b/examples/twin_stick_controller.rs
@@ -48,7 +48,7 @@ impl PlayerAction {
         // Default gamepad input bindings
         input_map.insert_dual_axis(Self::Move, GamepadStick::LEFT);
         input_map.insert_dual_axis(Self::Look, GamepadStick::RIGHT);
-        input_map.insert(Self::Shoot, GamepadButtonType::RightTrigger);
+        input_map.insert(Self::Shoot, GamepadButton::RightTrigger);
 
         // Default kbm input bindings
         input_map.insert_dual_axis(Self::Move, VirtualDPad::wasd());
@@ -132,7 +132,7 @@ fn player_mouse_look(
     let player_position = player_transform.translation;
     if let Some(p) = window
         .cursor_position()
-        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor))
+        .and_then(|cursor| camera.viewport_to_world(camera_transform, cursor).ok())
         .and_then(|ray| {
             Some(ray).zip(ray.intersect_plane(player_position, InfinitePlane3d::new(Vec3::Y)))
         })
@@ -182,11 +182,9 @@ struct Player;
 
 fn setup_scene(mut commands: Commands) {
     // We need a camera
-    commands.spawn(Camera3dBundle {
-        transform: Transform::from_xyz(0.0, 10.0, 15.0)
-            .looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y),
-        ..default()
-    });
+    commands
+        .spawn(Camera3d::default())
+        .insert(Transform::from_xyz(0.0, 10.0, 15.0).looking_at(Vec3::new(0.0, 0.0, 0.0), Vec3::Y));
 
     // And a player
     commands.spawn(Player).insert(Transform::default());

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -31,8 +31,8 @@ fn spawn_player(mut commands: Commands) {
         VirtualDPad::new(
             KeyCode::KeyW,
             KeyCode::KeyS,
-            GamepadButtonType::DPadLeft,
-            GamepadButtonType::DPadRight,
+            GamepadButton::DPadLeft,
+            GamepadButton::DPadRight,
         ),
     );
     commands

--- a/macros/src/typetag.rs
+++ b/macros/src/typetag.rs
@@ -42,7 +42,7 @@ pub(crate) fn expand_serde_typetag(input: &ItemImpl) -> syn::Result<TokenStream>
             ) {
                 #crate_path::typetag::Registry::register(
                     registry,
-                    #ident,
+                    (#ident).into(),
                     |de| Ok(::std::boxed::Box::new(
                         ::bevy::reflect::erased_serde::deserialize::<#self_ty>(de)?,
                     )),

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -1109,14 +1109,14 @@ mod tests {
         use std::time::{Duration, Instant};
 
         use crate::input_map::InputMap;
-        use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+        use crate::plugin::CentralInputStorePlugin;
         use crate::prelude::updating::CentralInputStore;
         use crate::prelude::ClashStrategy;
         use crate::user_input::Buttonlike;
         use bevy::input::InputPlugin;
 
         let mut app = App::new();
-        app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+        app.add_plugins((InputPlugin, CentralInputStorePlugin));
 
         #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, bevy::prelude::Reflect)]
         enum Action {
@@ -1224,7 +1224,7 @@ mod tests {
         use std::time::{Duration, Instant};
 
         use crate::input_map::InputMap;
-        use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+        use crate::plugin::CentralInputStorePlugin;
         use crate::prelude::updating::CentralInputStore;
         use crate::prelude::ClashStrategy;
         use crate::user_input::chord::ButtonlikeChord;
@@ -1248,7 +1248,7 @@ mod tests {
 
         let mut app = App::new();
         app.add_plugins(InputPlugin)
-            .add_plugins((AccumulatorPlugin, CentralInputStorePlugin));
+            .add_plugins(CentralInputStorePlugin);
 
         // Action state
         let mut action_state = ActionState::<Action>::default();

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -1138,11 +1138,7 @@ mod tests {
 
         // Starting state
         let input_store = app.world().resource::<CentralInputStore>();
-        action_state.update(input_map.process_actions(
-            &Gamepads::default(),
-            input_store,
-            ClashStrategy::PressAll,
-        ));
+        action_state.update(input_map.process_actions(None, input_store, ClashStrategy::PressAll));
 
         println!(
             "Initialized button data: {:?}",
@@ -1160,11 +1156,7 @@ mod tests {
         app.update();
         let input_store = app.world().resource::<CentralInputStore>();
 
-        action_state.update(input_map.process_actions(
-            &Gamepads::default(),
-            input_store,
-            ClashStrategy::PressAll,
-        ));
+        action_state.update(input_map.process_actions(None, input_store, ClashStrategy::PressAll));
 
         assert!(action_state.pressed(&Action::Run));
         assert!(action_state.just_pressed(&Action::Run));
@@ -1173,11 +1165,7 @@ mod tests {
 
         // Waiting
         action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
-        action_state.update(input_map.process_actions(
-            &Gamepads::default(),
-            input_store,
-            ClashStrategy::PressAll,
-        ));
+        action_state.update(input_map.process_actions(None, input_store, ClashStrategy::PressAll));
 
         assert!(action_state.pressed(&Action::Run));
         assert!(!action_state.just_pressed(&Action::Run));
@@ -1189,11 +1177,7 @@ mod tests {
         app.update();
         let input_store = app.world().resource::<CentralInputStore>();
 
-        action_state.update(input_map.process_actions(
-            &Gamepads::default(),
-            input_store,
-            ClashStrategy::PressAll,
-        ));
+        action_state.update(input_map.process_actions(None, input_store, ClashStrategy::PressAll));
 
         assert!(!action_state.pressed(&Action::Run));
         assert!(!action_state.just_pressed(&Action::Run));
@@ -1202,11 +1186,7 @@ mod tests {
 
         // Waiting
         action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
-        action_state.update(input_map.process_actions(
-            &Gamepads::default(),
-            input_store,
-            ClashStrategy::PressAll,
-        ));
+        action_state.update(input_map.process_actions(None, input_store, ClashStrategy::PressAll));
 
         assert!(!action_state.pressed(&Action::Run));
         assert!(!action_state.just_pressed(&Action::Run));
@@ -1276,7 +1256,7 @@ mod tests {
         // Starting state
         let input_store = app.world().resource::<CentralInputStore>();
         action_state.update(input_map.process_actions(
-            &Gamepads::default(),
+            None,
             input_store,
             ClashStrategy::PrioritizeLongest,
         ));
@@ -1290,7 +1270,7 @@ mod tests {
         let input_store = app.world().resource::<CentralInputStore>();
 
         action_state.update(input_map.process_actions(
-            &Gamepads::default(),
+            None,
             input_store,
             ClashStrategy::PrioritizeLongest,
         ));
@@ -1302,7 +1282,7 @@ mod tests {
         // Waiting
         action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
         action_state.update(input_map.process_actions(
-            &Gamepads::default(),
+            None,
             input_store,
             ClashStrategy::PrioritizeLongest,
         ));
@@ -1317,7 +1297,7 @@ mod tests {
         let input_store = app.world().resource::<CentralInputStore>();
 
         action_state.update(input_map.process_actions(
-            &Gamepads::default(),
+            None,
             input_store,
             ClashStrategy::PrioritizeLongest,
         ));
@@ -1331,7 +1311,7 @@ mod tests {
         // Waiting
         action_state.tick(Instant::now(), Instant::now() - Duration::from_micros(1));
         action_state.update(input_map.process_actions(
-            &Gamepads::default(),
+            None,
             input_store,
             ClashStrategy::PrioritizeLongest,
         ));

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -476,8 +476,8 @@ mod tests {
         use super::*;
         use crate::{
             input_map::UpdatedValue,
-            plugin::{AccumulatorPlugin, CentralInputStorePlugin},
-            prelude::{AccumulatedMouseMovement, AccumulatedMouseScroll, ModifierKey, VirtualDPad},
+            plugin::CentralInputStorePlugin,
+            prelude::{ModifierKey, VirtualDPad},
         };
         use bevy::{input::InputPlugin, prelude::*};
         use Action::*;
@@ -579,9 +579,7 @@ mod tests {
         #[test]
         fn resolve_prioritize_longest() {
             let mut app = App::new();
-            app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
-            app.init_resource::<AccumulatedMouseMovement>();
-            app.init_resource::<AccumulatedMouseScroll>();
+            app.add_plugins((InputPlugin, CentralInputStorePlugin));
 
             let input_map = test_input_map();
             let simple_clash = input_map.possible_clash(&One, &OneAndTwo).unwrap();
@@ -637,7 +635,7 @@ mod tests {
         #[test]
         fn handle_simple_clash() {
             let mut app = App::new();
-            app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+            app.add_plugins((InputPlugin, CentralInputStorePlugin));
             let input_map = test_input_map();
             let gamepad = app.world_mut().spawn(()).id();
 
@@ -672,8 +670,6 @@ mod tests {
         fn handle_clashes_dpad_chord() {
             let mut app = App::new();
             app.add_plugins(InputPlugin);
-            app.init_resource::<AccumulatedMouseMovement>();
-            app.init_resource::<AccumulatedMouseScroll>();
             let input_map = test_input_map();
             let gamepad = app.world_mut().spawn(()).id();
 
@@ -727,9 +723,7 @@ mod tests {
         #[test]
         fn check_which_pressed() {
             let mut app = App::new();
-            app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
-            app.init_resource::<AccumulatedMouseMovement>();
-            app.init_resource::<AccumulatedMouseScroll>();
+            app.add_plugins((InputPlugin, CentralInputStorePlugin));
             let input_map = test_input_map();
 
             Digit1.press(app.world_mut());

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -6,7 +6,7 @@
 
 use std::cmp::Ordering;
 
-use bevy::prelude::{Gamepad, Resource};
+use bevy::prelude::{Entity, Resource};
 use serde::{Deserialize, Serialize};
 
 use crate::input_map::{InputMap, UpdatedActions};
@@ -175,7 +175,7 @@ impl<A: Actionlike> InputMap<A> {
         updated_actions: &mut UpdatedActions<A>,
         input_store: &CentralInputStore,
         clash_strategy: ClashStrategy,
-        gamepad: Gamepad,
+        gamepad: Entity,
     ) {
         for clash in self.get_clashes(updated_actions, input_store, gamepad) {
             // Remove the action in the pair that was overruled, if any
@@ -209,7 +209,7 @@ impl<A: Actionlike> InputMap<A> {
         &self,
         updated_actions: &UpdatedActions<A>,
         input_store: &CentralInputStore,
-        gamepad: Gamepad,
+        gamepad: Entity,
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
 
@@ -321,7 +321,7 @@ impl<A: Actionlike> Clash<A> {
 fn check_clash<A: Actionlike>(
     clash: &Clash<A>,
     input_store: &CentralInputStore,
-    gamepad: Gamepad,
+    gamepad: Entity,
 ) -> Option<Clash<A>> {
     let mut actual_clash: Clash<A> = clash.clone();
 
@@ -355,7 +355,7 @@ fn resolve_clash<A: Actionlike>(
     clash: &Clash<A>,
     clash_strategy: ClashStrategy,
     input_store: &CentralInputStore,
-    gamepad: Gamepad,
+    gamepad: Entity,
 ) -> Option<A> {
     // Figure out why the actions are pressed
     let reasons_a_is_pressed: Vec<&dyn Buttonlike> = clash
@@ -589,6 +589,7 @@ mod tests {
             Digit2.press(app.world_mut());
             app.update();
 
+            let gamepad = app.world_mut().spawn(()).id();
             let input_store = app.world().resource::<CentralInputStore>();
 
             assert_eq!(
@@ -596,7 +597,7 @@ mod tests {
                     &simple_clash,
                     ClashStrategy::PrioritizeLongest,
                     input_store,
-                    Gamepad::new(0),
+                    gamepad,
                 ),
                 Some(One)
             );
@@ -609,7 +610,7 @@ mod tests {
                     &reversed_clash,
                     ClashStrategy::PrioritizeLongest,
                     input_store,
-                    Gamepad::new(0),
+                    gamepad,
                 ),
                 Some(One)
             );
@@ -627,7 +628,7 @@ mod tests {
                     &chord_clash,
                     ClashStrategy::PrioritizeLongest,
                     input_store,
-                    Gamepad::new(0),
+                    gamepad,
                 ),
                 Some(OneAndTwo)
             );
@@ -638,6 +639,7 @@ mod tests {
             let mut app = App::new();
             app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
             let input_map = test_input_map();
+            let gamepad = app.world_mut().spawn(()).id();
 
             Digit1.press(app.world_mut());
             Digit2.press(app.world_mut());
@@ -655,7 +657,7 @@ mod tests {
                 &mut updated_actions,
                 input_store,
                 ClashStrategy::PrioritizeLongest,
-                Gamepad::new(0),
+                gamepad,
             );
 
             let mut expected = UpdatedActions::default();
@@ -673,6 +675,7 @@ mod tests {
             app.init_resource::<AccumulatedMouseMovement>();
             app.init_resource::<AccumulatedMouseScroll>();
             let input_map = test_input_map();
+            let gamepad = app.world_mut().spawn(()).id();
 
             ControlLeft.press(app.world_mut());
             ArrowUp.press(app.world_mut());
@@ -710,7 +713,7 @@ mod tests {
                 &mut updated_actions,
                 input_store,
                 ClashStrategy::PrioritizeLongest,
-                Gamepad::new(0),
+                gamepad,
             );
 
             // Only the chord should be pressed,
@@ -736,11 +739,8 @@ mod tests {
 
             let input_store = app.world().resource::<CentralInputStore>();
 
-            let action_data = input_map.process_actions(
-                &Gamepads::default(),
-                input_store,
-                ClashStrategy::PrioritizeLongest,
-            );
+            let action_data =
+                input_map.process_actions(None, input_store, ClashStrategy::PrioritizeLongest);
 
             for (action, &updated_value) in action_data.iter() {
                 if *action == CtrlOne || *action == OneAndTwo {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -441,7 +441,7 @@ impl<A: Actionlike> InputMap<A> {
 
 // Configuration
 impl<A: Actionlike> InputMap<A> {
-    /// Fetches the [`Gamepad`] associated with the entity controlled by this input map.
+    /// Fetches the gamepad [`Entity`] associated with the one controlled by this input map.
     ///
     /// If this is [`None`], input from any connected gamepad will be used.
     #[must_use]
@@ -450,7 +450,7 @@ impl<A: Actionlike> InputMap<A> {
         self.associated_gamepad
     }
 
-    /// Assigns a particular [`Gamepad`] to the entity controlled by this input map.
+    /// Assigns a particular gamepad [`Entity`] to the one controlled by this input map.
     ///
     /// Use this when an [`InputMap`] should exclusively accept input
     /// from a particular gamepad.
@@ -467,7 +467,7 @@ impl<A: Actionlike> InputMap<A> {
         self
     }
 
-    /// Assigns a particular [`Gamepad`] to the entity controlled by this input map.
+    /// Assigns a particular gamepad [`Entity`] to the one controlled by this input map.
     ///
     /// Use this when an [`InputMap`] should exclusively accept input
     /// from a particular gamepad.
@@ -484,7 +484,7 @@ impl<A: Actionlike> InputMap<A> {
         self
     }
 
-    /// Clears any [`Gamepad`] associated with the entity controlled by this input map.
+    /// Clears any gamepad [`Entity`] associated with the one controlled by this input map.
     #[inline]
     pub fn clear_gamepad(&mut self) -> &mut Self {
         self.associated_gamepad = None;

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
-use bevy::prelude::{Component, Deref, DerefMut, Gamepad, Gamepads, Reflect, Resource};
+use bevy::prelude::{Component, Deref, DerefMut, Entity, Gamepad, Query, Reflect, Resource, With};
 use bevy::utils::HashMap;
 use bevy::{log::error, prelude::ReflectComponent};
 use bevy::{
@@ -25,8 +25,8 @@ use crate::{Actionlike, InputControlKind};
 use crate::user_input::gamepad::find_gamepad;
 
 #[cfg(not(feature = "gamepad"))]
-fn find_gamepad(_gamepads: &Gamepads) -> Gamepad {
-    Gamepad::new(0)
+fn find_gamepad(_: Option<Query<Entity, With<Gamepad>>>) -> Entity {
+    Entity::PLACEHOLDER
 }
 
 /// A Multi-Map that allows you to map actions to multiple [`UserInputs`](crate::user_input::UserInput)s,
@@ -117,8 +117,8 @@ pub struct InputMap<A: Actionlike> {
     /// The underlying map that stores action-input mappings for [`TripleAxislike`] actions.
     triple_axislike_map: HashMap<A, Vec<Box<dyn TripleAxislike>>>,
 
-    /// The specified [`Gamepad`] from which this map exclusively accepts input.
-    associated_gamepad: Option<Gamepad>,
+    /// The specified gamepad from which this map exclusively accepts input.
+    associated_gamepad: Option<Entity>,
 }
 
 impl<A: Actionlike> Default for InputMap<A> {
@@ -446,7 +446,7 @@ impl<A: Actionlike> InputMap<A> {
     /// If this is [`None`], input from any connected gamepad will be used.
     #[must_use]
     #[inline]
-    pub const fn gamepad(&self) -> Option<Gamepad> {
+    pub const fn gamepad(&self) -> Option<Entity> {
         self.associated_gamepad
     }
 
@@ -462,7 +462,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Because of this robust fallback behavior,
     /// this method can typically be ignored when writing single-player games.
     #[inline]
-    pub fn with_gamepad(mut self, gamepad: Gamepad) -> Self {
+    pub fn with_gamepad(mut self, gamepad: Entity) -> Self {
         self.set_gamepad(gamepad);
         self
     }
@@ -479,7 +479,7 @@ impl<A: Actionlike> InputMap<A> {
     /// Because of this robust fallback behavior,
     /// this method can typically be ignored when writing single-player games.
     #[inline]
-    pub fn set_gamepad(&mut self, gamepad: Gamepad) -> &mut Self {
+    pub fn set_gamepad(&mut self, gamepad: Entity) -> &mut Self {
         self.associated_gamepad = Some(gamepad);
         self
     }
@@ -504,8 +504,7 @@ impl<A: Actionlike> InputMap<A> {
         input_store: &CentralInputStore,
         clash_strategy: ClashStrategy,
     ) -> bool {
-        let processed_actions =
-            self.process_actions(&Gamepads::default(), input_store, clash_strategy);
+        let processed_actions = self.process_actions(None, input_store, clash_strategy);
 
         let Some(updated_value) = processed_actions.get(action) else {
             return false;
@@ -530,7 +529,7 @@ impl<A: Actionlike> InputMap<A> {
     #[must_use]
     pub fn process_actions(
         &self,
-        gamepads: &Gamepads,
+        gamepads: Option<Query<Entity, With<Gamepad>>>,
         input_store: &CentralInputStore,
         clash_strategy: ClashStrategy,
     ) -> UpdatedActions<A> {
@@ -1099,13 +1098,11 @@ mod tests {
     #[cfg(feature = "gamepad")]
     #[test]
     fn gamepad_swapping() {
-        use bevy::input::gamepad::Gamepad;
-
         let mut input_map = InputMap::<Action>::default();
         assert_eq!(input_map.gamepad(), None);
 
-        input_map.set_gamepad(Gamepad { id: 0 });
-        assert_eq!(input_map.gamepad(), Some(Gamepad { id: 0 }));
+        input_map.set_gamepad(Entity::from_raw(123));
+        assert_eq!(input_map.gamepad(), Some(Entity::from_raw(123)));
 
         input_map.clear_gamepad();
         assert_eq!(input_map.gamepad(), None);

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -1,14 +1,13 @@
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
-use std::hash::{Hash, Hasher};
+use std::any::Any;
+use std::fmt::Debug;
 use std::sync::RwLock;
 
 use bevy::app::App;
 use bevy::prelude::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, TypePath, Vec2};
-use bevy::reflect::utility::{reflect_hasher, GenericTypePathCell, NonGenericTypeInfoCell};
+use bevy::reflect::utility::{GenericTypePathCell, NonGenericTypeInfoCell};
 use bevy::reflect::{
-    erased_serde, FromType, GetTypeRegistration, ReflectFromPtr, ReflectKind, ReflectMut,
-    ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed, ValueInfo,
+    erased_serde, FromType, GetTypeRegistration, OpaqueInfo, PartialReflect, ReflectFromPtr,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed,
 };
 use dyn_clone::DynClone;
 use dyn_eq::DynEq;
@@ -108,11 +107,77 @@ dyn_clone::clone_trait_object!(CustomDualAxisProcessor);
 dyn_eq::eq_trait_object!(CustomDualAxisProcessor);
 dyn_hash::hash_trait_object!(CustomDualAxisProcessor);
 
-impl Reflect for Box<dyn CustomDualAxisProcessor> {
+impl PartialReflect for Box<dyn CustomDualAxisProcessor> {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(Self::type_info())
     }
 
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Opaque
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Opaque(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Opaque(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Opaque(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn PartialReflect> {
+        Box::new(self.clone())
+    }
+
+    fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), bevy::reflect::ApplyError> {
+        if let Some(value) = value.try_downcast_ref::<Self>() {
+            *self = value.clone();
+            Ok(())
+        } else {
+            Err(bevy::reflect::ApplyError::MismatchedTypes {
+                from_type: self
+                    .reflect_type_ident()
+                    .unwrap_or_default()
+                    .to_string()
+                    .into_boxed_str(),
+                to_type: self
+                    .reflect_type_ident()
+                    .unwrap_or_default()
+                    .to_string()
+                    .into_boxed_str(),
+            })
+        }
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
+        Ok(self)
+    }
+
+    fn try_as_reflect(&self) -> Option<&dyn Reflect> {
+        Some(self)
+    }
+
+    fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> {
+        Some(self)
+    }
+}
+
+impl Reflect for Box<dyn CustomDualAxisProcessor> {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -137,81 +202,16 @@ impl Reflect for Box<dyn CustomDualAxisProcessor> {
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        self.try_apply(value).unwrap()
-    }
-
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
-    }
-
-    fn reflect_kind(&self) -> ReflectKind {
-        ReflectKind::Value
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Value(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Value(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Value(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone())
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        let mut hasher = reflect_hasher();
-        let type_id = TypeId::of::<Self>();
-        Hash::hash(&type_id, &mut hasher);
-        Hash::hash(self, &mut hasher);
-        Some(hasher.finish())
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        value
-            .as_any()
-            .downcast_ref::<Self>()
-            .map(|value| self.dyn_eq(value))
-            .or(Some(false))
-    }
-
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self, f)
-    }
-
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
-            Ok(())
-        } else {
-            Err(bevy::reflect::ApplyError::MismatchedTypes {
-                from_type: self
-                    .reflect_type_ident()
-                    .unwrap_or_default()
-                    .to_string()
-                    .into_boxed_str(),
-                to_type: self
-                    .reflect_type_ident()
-                    .unwrap_or_default()
-                    .to_string()
-                    .into_boxed_str(),
-            })
-        }
     }
 }
 
 impl Typed for Box<dyn CustomDualAxisProcessor> {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
-        CELL.get_or_set(|| TypeInfo::Value(ValueInfo::new::<Self>()))
+        CELL.get_or_set(|| TypeInfo::Opaque(OpaqueInfo::new::<Self>()))
     }
 }
 
@@ -257,8 +257,8 @@ impl GetTypeRegistration for Box<dyn CustomDualAxisProcessor> {
 }
 
 impl FromReflect for Box<dyn CustomDualAxisProcessor> {
-    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        Some(reflect.as_any().downcast_ref::<Self>()?.clone())
+    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
+        Some(reflect.try_downcast_ref::<Self>()?.clone())
     }
 }
 

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -1,14 +1,13 @@
-use std::any::{Any, TypeId};
-use std::fmt::{Debug, Formatter};
-use std::hash::{Hash, Hasher};
+use std::any::Any;
+use std::fmt::Debug;
 use std::sync::RwLock;
 
 use bevy::app::App;
 use bevy::prelude::{FromReflect, Reflect, ReflectDeserialize, ReflectSerialize, TypePath};
-use bevy::reflect::utility::{reflect_hasher, GenericTypePathCell, NonGenericTypeInfoCell};
+use bevy::reflect::utility::{GenericTypePathCell, NonGenericTypeInfoCell};
 use bevy::reflect::{
-    erased_serde, FromType, GetTypeRegistration, ReflectFromPtr, ReflectKind, ReflectMut,
-    ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed, ValueInfo,
+    erased_serde, FromType, GetTypeRegistration, OpaqueInfo, PartialReflect, ReflectFromPtr,
+    ReflectKind, ReflectMut, ReflectOwned, ReflectRef, TypeInfo, TypeRegistration, Typed,
 };
 use dyn_clone::DynClone;
 use dyn_eq::DynEq;
@@ -107,11 +106,77 @@ dyn_clone::clone_trait_object!(CustomAxisProcessor);
 dyn_eq::eq_trait_object!(CustomAxisProcessor);
 dyn_hash::hash_trait_object!(CustomAxisProcessor);
 
-impl Reflect for Box<dyn CustomAxisProcessor> {
+impl PartialReflect for Box<dyn CustomAxisProcessor> {
     fn get_represented_type_info(&self) -> Option<&'static TypeInfo> {
         Some(Self::type_info())
     }
 
+    fn reflect_kind(&self) -> ReflectKind {
+        ReflectKind::Opaque
+    }
+
+    fn reflect_ref(&self) -> ReflectRef {
+        ReflectRef::Opaque(self)
+    }
+
+    fn reflect_mut(&mut self) -> ReflectMut {
+        ReflectMut::Opaque(self)
+    }
+
+    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
+        ReflectOwned::Opaque(self)
+    }
+
+    fn clone_value(&self) -> Box<dyn PartialReflect> {
+        Box::new(self.clone())
+    }
+
+    fn try_apply(&mut self, value: &dyn PartialReflect) -> Result<(), bevy::reflect::ApplyError> {
+        if let Some(value) = value.try_downcast_ref::<Self>() {
+            *self = value.clone();
+            Ok(())
+        } else {
+            Err(bevy::reflect::ApplyError::MismatchedTypes {
+                from_type: self
+                    .reflect_type_ident()
+                    .unwrap_or_default()
+                    .to_string()
+                    .into_boxed_str(),
+                to_type: self
+                    .reflect_type_ident()
+                    .unwrap_or_default()
+                    .to_string()
+                    .into_boxed_str(),
+            })
+        }
+    }
+
+    fn into_partial_reflect(self: Box<Self>) -> Box<dyn PartialReflect> {
+        self
+    }
+
+    fn as_partial_reflect(&self) -> &dyn PartialReflect {
+        self
+    }
+
+    fn as_partial_reflect_mut(&mut self) -> &mut dyn PartialReflect {
+        self
+    }
+
+    fn try_into_reflect(self: Box<Self>) -> Result<Box<dyn Reflect>, Box<dyn PartialReflect>> {
+        Ok(self)
+    }
+
+    fn try_as_reflect(&self) -> Option<&dyn Reflect> {
+        Some(self)
+    }
+
+    fn try_as_reflect_mut(&mut self) -> Option<&mut dyn Reflect> {
+        Some(self)
+    }
+}
+
+impl Reflect for Box<dyn CustomAxisProcessor> {
     fn into_any(self: Box<Self>) -> Box<dyn Any> {
         self
     }
@@ -136,81 +201,16 @@ impl Reflect for Box<dyn CustomAxisProcessor> {
         self
     }
 
-    fn apply(&mut self, value: &dyn Reflect) {
-        self.try_apply(value).unwrap()
-    }
-
     fn set(&mut self, value: Box<dyn Reflect>) -> Result<(), Box<dyn Reflect>> {
         *self = value.take()?;
         Ok(())
-    }
-
-    fn reflect_kind(&self) -> ReflectKind {
-        ReflectKind::Value
-    }
-
-    fn reflect_ref(&self) -> ReflectRef {
-        ReflectRef::Value(self)
-    }
-
-    fn reflect_mut(&mut self) -> ReflectMut {
-        ReflectMut::Value(self)
-    }
-
-    fn reflect_owned(self: Box<Self>) -> ReflectOwned {
-        ReflectOwned::Value(self)
-    }
-
-    fn clone_value(&self) -> Box<dyn Reflect> {
-        Box::new(self.clone())
-    }
-
-    fn reflect_hash(&self) -> Option<u64> {
-        let mut hasher = reflect_hasher();
-        let type_id = TypeId::of::<Self>();
-        Hash::hash(&type_id, &mut hasher);
-        Hash::hash(self, &mut hasher);
-        Some(hasher.finish())
-    }
-
-    fn reflect_partial_eq(&self, value: &dyn Reflect) -> Option<bool> {
-        value
-            .as_any()
-            .downcast_ref::<Self>()
-            .map(|value| self.dyn_eq(value))
-            .or(Some(false))
-    }
-
-    fn debug(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        Debug::fmt(self, f)
-    }
-
-    fn try_apply(&mut self, value: &dyn Reflect) -> Result<(), bevy::reflect::ApplyError> {
-        let value = value.as_any();
-        if let Some(value) = value.downcast_ref::<Self>() {
-            *self = value.clone();
-            Ok(())
-        } else {
-            Err(bevy::reflect::ApplyError::MismatchedTypes {
-                from_type: self
-                    .reflect_type_ident()
-                    .unwrap_or_default()
-                    .to_string()
-                    .into_boxed_str(),
-                to_type: self
-                    .reflect_type_ident()
-                    .unwrap_or_default()
-                    .to_string()
-                    .into_boxed_str(),
-            })
-        }
     }
 }
 
 impl Typed for Box<dyn CustomAxisProcessor> {
     fn type_info() -> &'static TypeInfo {
         static CELL: NonGenericTypeInfoCell = NonGenericTypeInfoCell::new();
-        CELL.get_or_set(|| TypeInfo::Value(ValueInfo::new::<Self>()))
+        CELL.get_or_set(|| TypeInfo::Opaque(OpaqueInfo::new::<Self>()))
     }
 }
 
@@ -256,8 +256,8 @@ impl GetTypeRegistration for Box<dyn CustomAxisProcessor> {
 }
 
 impl FromReflect for Box<dyn CustomAxisProcessor> {
-    fn from_reflect(reflect: &dyn Reflect) -> Option<Self> {
-        Some(reflect.as_any().downcast_ref::<Self>()?.clone())
+    fn from_reflect(reflect: &dyn PartialReflect) -> Option<Self> {
+        Some(reflect.try_downcast_ref::<Self>()?.clone())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 use crate::action_state::ActionState;
 use crate::input_map::InputMap;
 use bevy::ecs::prelude::*;
-use bevy::reflect::{FromReflect, Reflect, TypePath};
+use bevy::reflect::{FromReflect, Reflect, TypePath, Typed};
 use serde::{Deserialize, Serialize};
 use std::fmt::Debug;
 use std::hash::Hash;
@@ -103,7 +103,7 @@ pub mod prelude {
 /// }
 /// ```
 pub trait Actionlike:
-    Debug + Eq + Hash + Send + Sync + Clone + Reflect + TypePath + FromReflect + 'static
+    Debug + Eq + Hash + Send + Sync + Clone + Reflect + Typed + TypePath + FromReflect + 'static
 {
     /// Returns the kind of input control this action represents: buttonlike, axislike, or dual-axislike.
     fn input_control_kind(&self) -> InputControlKind;

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -122,7 +122,9 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
 
                 app.configure_sets(
                     PreUpdate,
-                    InputManagerSystem::Unify.after(InputManagerSystem::Filter),
+                    InputManagerSystem::Unify
+                        .after(InputManagerSystem::Filter)
+                        .after(InputSystem),
                 );
 
                 app.configure_sets(

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -318,6 +318,7 @@ impl Plugin for CentralInputStorePlugin {
         let mut central_input_store = CentralInputStore::default();
         central_input_store.register_standard_input_kinds(app);
 
-        app.insert_resource(central_input_store);
+        app.insert_resource(central_input_store)
+            .configure_sets(PreUpdate, InputManagerSystem::Unify.after(InputSystem));
     }
 }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -8,7 +8,6 @@ use bevy::app::{App, FixedPostUpdate, Plugin, RunFixedMainLoop};
 use bevy::input::InputSystem;
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
-use bevy::time::run_fixed_main_schedule;
 #[cfg(feature = "ui")]
 use bevy::ui::UiSystem;
 use updating::CentralInputStore;
@@ -178,7 +177,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
                         update_action_state::<A>,
                     )
                         .chain()
-                        .before(run_fixed_main_schedule),
+                        .in_set(RunFixedMainLoopSystem::BeforeFixedMainLoop),
                 );
 
                 app.add_systems(FixedPostUpdate, release_on_input_map_removed::<A>);
@@ -191,7 +190,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
                 );
                 app.add_systems(
                     RunFixedMainLoop,
-                    swap_to_update::<A>.after(run_fixed_main_schedule),
+                    swap_to_update::<A>.in_set(RunFixedMainLoopSystem::AfterFixedMainLoop),
                 );
             }
             Machine::Server => {
@@ -207,6 +206,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
         #[cfg(feature = "mouse")]
         app.register_type::<AccumulatedMouseMovement>()
             .register_type::<AccumulatedMouseScroll>()
+            .register_buttonlike_input::<MouseButton>()
             .register_buttonlike_input::<MouseMoveDirection>()
             .register_axislike_input::<MouseMoveAxis>()
             .register_dual_axislike_input::<MouseMove>()
@@ -222,7 +222,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
         app.register_buttonlike_input::<GamepadControlDirection>()
             .register_axislike_input::<GamepadControlAxis>()
             .register_dual_axislike_input::<GamepadStick>()
-            .register_buttonlike_input::<GamepadButtonType>();
+            .register_buttonlike_input::<GamepadButton>();
 
         // Virtual Axes
         app.register_axislike_input::<VirtualAxis>()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -113,8 +113,8 @@ pub fn filter_captured_input(
         bevy::input::ButtonInput<bevy::input::keyboard::KeyCode>,
     >,
     #[cfg(feature = "egui")] mut egui_query: Query<&'static mut bevy_egui::EguiContext>,
-    #[cfg(feature = "egui")] mut mouse_scroll: ResMut<AccumulatedMouseScroll>,
-    #[cfg(feature = "egui")] mut mouse_motion: ResMut<AccumulatedMouseMovement>,
+    #[cfg(feature = "egui")] mut mouse_scroll: ResMut<bevy::input::mouse::AccumulatedMouseScroll>,
+    #[cfg(feature = "egui")] mut mouse_motion: ResMut<bevy::input::mouse::AccumulatedMouseMotion>,
 ) {
     // If the user clicks on a button, do not apply it to the game state
     #[cfg(feature = "ui")]

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -113,8 +113,6 @@ pub fn filter_captured_input(
         bevy::input::ButtonInput<bevy::input::keyboard::KeyCode>,
     >,
     #[cfg(feature = "egui")] mut egui_query: Query<&'static mut bevy_egui::EguiContext>,
-    #[cfg(feature = "egui")] mut mouse_scroll: ResMut<bevy::input::mouse::AccumulatedMouseScroll>,
-    #[cfg(feature = "egui")] mut mouse_motion: ResMut<bevy::input::mouse::AccumulatedMouseMotion>,
 ) {
     // If the user clicks on a button, do not apply it to the game state
     #[cfg(feature = "ui")]
@@ -131,8 +129,6 @@ pub fn filter_captured_input(
         // Don't ask me why get doesn't exist :shrug:
         if egui_context.get_mut().wants_pointer_input() {
             mouse_buttons.reset_all();
-            mouse_motion.reset();
-            mouse_scroll.reset();
         }
 
         if egui_context.get_mut().wants_keyboard_input() {

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -13,7 +13,7 @@ use crate::{
 };
 
 use bevy::ecs::prelude::*;
-use bevy::prelude::Gamepads;
+use bevy::prelude::Gamepad;
 use bevy::{
     time::{Real, Time},
     utils::Instant,
@@ -116,7 +116,7 @@ pub fn accumulate_mouse_scroll(
 pub fn update_action_state<A: Actionlike>(
     input_store: Res<CentralInputStore>,
     clash_strategy: Res<ClashStrategy>,
-    gamepads: Res<Gamepads>,
+    mut gamepads: Query<Entity, With<Gamepad>>,
     action_state: Option<ResMut<ActionState<A>>>,
     input_map: Option<Res<InputMap<A>>>,
     mut query: Query<(&mut ActionState<A>, &InputMap<A>)>,
@@ -126,7 +126,11 @@ pub fn update_action_state<A: Actionlike>(
         .map(|(input_map, action_state)| (Mut::from(action_state), input_map.into_inner()));
 
     for (mut action_state, input_map) in query.iter_mut().chain(resources) {
-        action_state.update(input_map.process_actions(&gamepads, &input_store, *clash_strategy));
+        action_state.update(input_map.process_actions(
+            Some(gamepads.reborrow()),
+            &input_store,
+            *clash_strategy,
+        ));
     }
 }
 

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -1,11 +1,7 @@
 //! The systems that power each [`InputManagerPlugin`](crate::plugin::InputManagerPlugin).
 
 use crate::prelude::updating::CentralInputStore;
-#[cfg(feature = "mouse")]
-use crate::user_input::{AccumulatedMouseMovement, AccumulatedMouseScroll};
 use bevy::ecs::query::QueryFilter;
-#[cfg(feature = "mouse")]
-use bevy::input::mouse::{MouseMotion, MouseWheel};
 use bevy::log::debug;
 
 use crate::{
@@ -81,32 +77,6 @@ pub fn tick_action_state<A: Actionlike>(
 
     // Store the previous time in the system
     *stored_previous_instant = time.last_update();
-}
-
-/// Sums the[`MouseMotion`] events received since during this frame.
-#[cfg(feature = "mouse")]
-pub fn accumulate_mouse_movement(
-    mut mouse_motion: ResMut<AccumulatedMouseMovement>,
-    mut events: EventReader<MouseMotion>,
-) {
-    mouse_motion.reset();
-
-    for event in events.read() {
-        mouse_motion.accumulate(event);
-    }
-}
-
-/// Sums the [`MouseWheel`] events received since during this frame.
-#[cfg(feature = "mouse")]
-pub fn accumulate_mouse_scroll(
-    mut mouse_scroll: ResMut<AccumulatedMouseScroll>,
-    mut events: EventReader<MouseWheel>,
-) {
-    mouse_scroll.reset();
-
-    for event in events.read() {
-        mouse_scroll.accumulate(event);
-    }
 }
 
 /// Fetches the [`CentralInputStore`]

--- a/src/typetag.rs
+++ b/src/typetag.rs
@@ -1,6 +1,7 @@
 //! Type tag registration for trait objects
 
-use std::collections::BTreeMap;
+use std::{borrow::Cow, collections::BTreeMap};
+use std::fmt::Debug;
 
 pub use serde_flexitos::Registry;
 use serde_flexitos::{DeserializeFn, GetError};
@@ -13,7 +14,7 @@ pub trait RegisterTypeTag<'de, T: ?Sized> {
 
 /// An infallible version of [`MapRegistry`](serde_flexitos::MapRegistry)
 /// that allows multiple registrations of deserializers.
-pub struct InfallibleMapRegistry<O: ?Sized, I = &'static str> {
+pub struct InfallibleMapRegistry<O: ?Sized, I = Cow<'static, str>> {
     deserialize_fns: BTreeMap<I, Option<DeserializeFn<O>>>,
     trait_object_name: &'static str,
 }
@@ -29,7 +30,7 @@ impl<O: ?Sized, I> InfallibleMapRegistry<O, I> {
     }
 }
 
-impl<O: ?Sized, I: Ord> Registry for InfallibleMapRegistry<O, I> {
+impl<O: ?Sized, I: Ord + Debug> Registry for InfallibleMapRegistry<O, I> {
     type Identifier = I;
     type TraitObject = O;
 

--- a/src/typetag.rs
+++ b/src/typetag.rs
@@ -1,7 +1,7 @@
 //! Type tag registration for trait objects
 
-use std::{borrow::Cow, collections::BTreeMap};
 use std::fmt::Debug;
+use std::{borrow::Cow, collections::BTreeMap};
 
 pub use serde_flexitos::Registry;
 use serde_flexitos::{DeserializeFn, GetError};

--- a/src/user_input/chord.rs
+++ b/src/user_input/chord.rs
@@ -1,7 +1,7 @@
 //! This module contains [`ButtonlikeChord`] and its impls.
 
 use bevy::math::{Vec2, Vec3};
-use bevy::prelude::{Gamepad, Reflect, World};
+use bevy::prelude::{Entity, Reflect, World};
 use leafwing_input_manager_macros::serde_typetag;
 use serde::{Deserialize, Serialize};
 
@@ -130,7 +130,7 @@ impl Buttonlike for ButtonlikeChord {
     /// Checks if all the inner inputs within the chord are active simultaneously.
     #[must_use]
     #[inline]
-    fn pressed(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> bool {
+    fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         self.0
             .iter()
             .all(|input| input.pressed(input_store, gamepad))
@@ -148,13 +148,13 @@ impl Buttonlike for ButtonlikeChord {
         }
     }
 
-    fn press_as_gamepad(&self, world: &mut World, gamepad: Option<Gamepad>) {
+    fn press_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
         for input in &self.0 {
             input.press_as_gamepad(world, gamepad);
         }
     }
 
-    fn release_as_gamepad(&self, world: &mut World, gamepad: Option<Gamepad>) {
+    fn release_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
         for input in &self.0 {
             input.release_as_gamepad(world, gamepad);
         }
@@ -209,7 +209,7 @@ impl UserInput for AxislikeChord {
 
 #[serde_typetag]
 impl Axislike for AxislikeChord {
-    fn value(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> f32 {
+    fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         if self.button.pressed(input_store, gamepad) {
             self.axis.value(input_store, gamepad)
         } else {
@@ -221,7 +221,7 @@ impl Axislike for AxislikeChord {
         self.axis.set_value(world, value);
     }
 
-    fn set_value_as_gamepad(&self, world: &mut World, value: f32, gamepad: Option<Gamepad>) {
+    fn set_value_as_gamepad(&self, world: &mut World, value: f32, gamepad: Option<Entity>) {
         self.axis.set_value_as_gamepad(world, value, gamepad);
     }
 }
@@ -264,7 +264,7 @@ impl UserInput for DualAxislikeChord {
 
 #[serde_typetag]
 impl DualAxislike for DualAxislikeChord {
-    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec2 {
+    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         if self.button.pressed(input_store, gamepad) {
             self.dual_axis.axis_pair(input_store, gamepad)
         } else {
@@ -280,7 +280,7 @@ impl DualAxislike for DualAxislikeChord {
         &self,
         world: &mut World,
         axis_pair: Vec2,
-        gamepad: Option<Gamepad>,
+        gamepad: Option<Entity>,
     ) {
         self.dual_axis
             .set_axis_pair_as_gamepad(world, axis_pair, gamepad);
@@ -325,7 +325,7 @@ impl UserInput for TripleAxislikeChord {
 
 #[serde_typetag]
 impl TripleAxislike for TripleAxislikeChord {
-    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec3 {
+    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3 {
         if self.button.pressed(input_store, gamepad) {
             self.triple_axis.axis_triple(input_store, gamepad)
         } else {
@@ -341,7 +341,7 @@ impl TripleAxislike for TripleAxislikeChord {
         &self,
         world: &mut World,
         axis_triple: Vec3,
-        gamepad: Option<Gamepad>,
+        gamepad: Option<Entity>,
     ) {
         self.triple_axis
             .set_axis_triple_as_gamepad(world, axis_triple, gamepad);
@@ -369,12 +369,15 @@ mod tests {
 
         // WARNING: you MUST register your gamepad during tests,
         // or all gamepad input mocking actions will fail
+        let gamepad = app.world_mut().spawn(()).id();
         let mut gamepad_events = app.world_mut().resource_mut::<Events<GamepadEvent>>();
         gamepad_events.send(GamepadEvent::Connection(GamepadConnectionEvent {
             // This MUST be consistent with any other mocked events
-            gamepad: Gamepad { id: 1 },
+            gamepad,
             connection: GamepadConnection::Connected(GamepadInfo {
                 name: "TestController".into(),
+                vendor_id: None,
+                product_id: None,
             }),
         }));
 
@@ -408,8 +411,9 @@ mod tests {
         // No keys pressed, resulting in a released chord with a value of zero.
         let mut app = test_app();
         app.update();
+        let gamepad = app.world_mut().spawn(()).id();
         let inputs = app.world().resource::<CentralInputStore>();
-        assert!(!chord.pressed(inputs, Gamepad::new(0)));
+        assert!(!chord.pressed(inputs, gamepad));
 
         // All required keys pressed, resulting in a pressed chord with a value of one.
         let mut app = test_app();
@@ -418,7 +422,7 @@ mod tests {
         }
         app.update();
         let inputs = app.world().resource::<CentralInputStore>();
-        assert!(chord.pressed(inputs, Gamepad::new(0)));
+        assert!(chord.pressed(inputs, gamepad));
 
         // Some required keys pressed, but not all required keys for the chord,
         // resulting in a released chord with a value of zero.
@@ -429,7 +433,7 @@ mod tests {
             }
             app.update();
             let inputs = app.world().resource::<CentralInputStore>();
-            assert!(!chord.pressed(inputs, Gamepad::new(0)));
+            assert!(!chord.pressed(inputs, gamepad));
         }
 
         // Five keys pressed, but not all required keys for the chord,
@@ -441,6 +445,6 @@ mod tests {
         KeyCode::KeyB.press(app.world_mut());
         app.update();
         let inputs = app.world().resource::<CentralInputStore>();
-        assert!(!chord.pressed(inputs, Gamepad::new(0)));
+        assert!(!chord.pressed(inputs, gamepad));
     }
 }

--- a/src/user_input/chord.rs
+++ b/src/user_input/chord.rs
@@ -24,12 +24,12 @@ use super::{Axislike, DualAxislike};
 /// ```rust
 /// use bevy::prelude::*;
 /// use bevy::input::InputPlugin;
-/// use leafwing_input_manager::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+/// use leafwing_input_manager::plugin::CentralInputStorePlugin;
 /// use leafwing_input_manager::prelude::*;
 /// use leafwing_input_manager::user_input::testing_utils::FetchUserInput;
 ///
 /// let mut app = App::new();
-/// app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+/// app.add_plugins((InputPlugin, CentralInputStorePlugin));
 ///
 /// // Define a chord using A and B keys
 /// let input = ButtonlikeChord::new([KeyCode::KeyA, KeyCode::KeyB]);
@@ -352,7 +352,7 @@ impl TripleAxislike for TripleAxislikeChord {
 #[cfg(test)]
 mod tests {
     use super::ButtonlikeChord;
-    use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+    use crate::plugin::CentralInputStorePlugin;
     use crate::user_input::updating::CentralInputStore;
     use crate::user_input::Buttonlike;
     use bevy::input::gamepad::{
@@ -365,7 +365,7 @@ mod tests {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins)
             .add_plugins(InputPlugin)
-            .add_plugins((AccumulatorPlugin, CentralInputStorePlugin));
+            .add_plugins(CentralInputStorePlugin);
 
         // WARNING: you MUST register your gamepad during tests,
         // or all gamepad input mocking actions will fail

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -82,7 +82,7 @@ impl SpecificGamepadButton {
     }
 }
 
-/// Provides button-like behavior for a specific direction on a [`GamepadAxisType`].
+/// Provides button-like behavior for a specific direction on a [`GamepadAxis`].
 ///
 /// By default, it reads from **any connected gamepad**.
 /// Use the [`InputMap::set_gamepad`](crate::input_map::InputMap::set_gamepad) for specific ones.
@@ -209,7 +209,7 @@ impl Buttonlike for GamepadControlDirection {
         self.direction.is_active(value, self.threshold)
     }
 
-    /// Sends a [`RawGamepadEvent::Axis`] event with a magnitude of 1.0 for the specified direction on the provided [`Gamepad`].
+    /// Sends a [`RawGamepadEvent::Axis`] event with a magnitude of 1.0 for the specified direction on the provided gamepad [`Entity`].
     fn press_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
         let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(world);
         let query = query_state.get(world);
@@ -325,7 +325,7 @@ impl Axislike for SpecificGamepadAxis {
     }
 }
 
-/// A wrapper around a specific [`GamepadAxisType`] (e.g., left stick X-axis, right stick Y-axis).
+/// A wrapper around a specific [`GamepadAxis`] (e.g., left stick X-axis, right stick Y-axis).
 ///
 /// By default, it reads from **any connected gamepad**.
 /// Use the [`InputMap::set_gamepad`](crate::input_map::InputMap::set_gamepad) for specific ones.
@@ -557,7 +557,7 @@ impl DualAxislike for GamepadStick {
             .fold(Vec2::new(x, y), |value, processor| processor.process(value))
     }
 
-    /// Sends a [`RawGamepadEvent::Axis`] event with the specified values on the provided [`Gamepad`].
+    /// Sends a [`RawGamepadEvent::Axis`] event with the specified values on the provided gamepad [`Entity`].
     fn set_axis_pair_as_gamepad(&self, world: &mut World, value: Vec2, gamepad: Option<Entity>) {
         let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(world);
         let query = query_state.get(world);
@@ -742,17 +742,17 @@ impl Buttonlike for GamepadButton {
         button_value(input_store, gamepad, *self)
     }
 
-    /// Sends a [`GamepadEvent::Button`] event with a magnitude of 1.0 in the direction defined by `self` on the provided [`Gamepad`].
+    /// Sends a [`RawGamepadEvent::Button`] event with a magnitude of 1.0 in the direction defined by `self` on the provided gamepad [`Entity`].
     fn press_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
         self.set_value_as_gamepad(world, 1.0, gamepad);
     }
 
-    /// Sends a [`GamepadEvent::Button`] event with a magnitude of 0.0 in the direction defined by `self` on the provided [`Gamepad`].
+    /// Sends a [`RawGamepadEvent::Button`] event with a magnitude of 0.0 in the direction defined by `self` on the provided gamepad [`Entity`].
     fn release_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
         self.set_value_as_gamepad(world, 0.0, gamepad);
     }
 
-    /// Sends a [`GamepadEvent::Button`] event with the specified value in the direction defined by `self` on the provided [`Gamepad`].
+    /// Sends a [`RawGamepadEvent::Button`] event with the specified value in the direction defined by `self` on the provided gamepad [`Entity`].
     #[inline]
     fn set_value_as_gamepad(&self, world: &mut World, value: f32, gamepad: Option<Entity>) {
         let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(world);

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -727,7 +727,7 @@ impl Buttonlike for GamepadButton {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+    use crate::plugin::CentralInputStorePlugin;
     use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent, GamepadInfo};
     use bevy::input::InputPlugin;
     use bevy::prelude::*;
@@ -735,7 +735,7 @@ mod tests {
     fn test_app() -> App {
         let mut app = App::new();
         app.add_plugins(MinimalPlugins);
-        app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+        app.add_plugins((InputPlugin, CentralInputStorePlugin));
 
         // WARNING: you MUST register your gamepad during tests,
         // or all gamepad input mocking actions will fail

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -1,5 +1,7 @@
 //! Gamepad inputs
 
+use std::hash::{Hash, Hasher};
+
 use bevy::ecs::system::lifetimeless::{Read, SQuery};
 use bevy::ecs::system::{StaticSystemParam, SystemParam, SystemState};
 use bevy::input::gamepad::{
@@ -13,7 +15,6 @@ use bevy::prelude::{
 };
 use leafwing_input_manager_macros::serde_typetag;
 use serde::{Deserialize, Serialize};
-use std::hash::{Hash, Hasher};
 
 use crate as leafwing_input_manager;
 use crate::axislike::AxisDirection;
@@ -640,25 +641,23 @@ impl UpdatableInput for GamepadButton {
     ) {
         for (gamepad_entity, gamepad) in source_data.iter() {
             for key in gamepad.get_pressed() {
-                let value = key.value(&central_input_store, gamepad_entity);
-                central_input_store.update_buttonlike(
-                    SpecificGamepadButton {
-                        gamepad: gamepad_entity,
-                        button: *key,
-                    },
-                    ButtonValue::new(true, value),
-                );
+                let specific_button = SpecificGamepadButton {
+                    gamepad: gamepad_entity,
+                    button: *key,
+                };
+                let value = specific_button.value(&central_input_store, gamepad_entity);
+                central_input_store
+                    .update_buttonlike(specific_button, ButtonValue::new(true, value));
             }
 
             for key in gamepad.get_just_released() {
-                let value = key.value(&central_input_store, gamepad_entity);
-                central_input_store.update_buttonlike(
-                    SpecificGamepadButton {
-                        gamepad: gamepad_entity,
-                        button: *key,
-                    },
-                    ButtonValue::new(false, value),
-                );
+                let specific_button = SpecificGamepadButton {
+                    gamepad: gamepad_entity,
+                    button: *key,
+                };
+                let value = specific_button.value(&central_input_store, gamepad_entity);
+                central_input_store
+                    .update_buttonlike(specific_button, ButtonValue::new(false, value));
             }
         }
     }

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -657,38 +657,11 @@ impl UpdatableInput for GamepadButton {
                         gamepad: gamepad_entity,
                         button: *key,
                     },
-                    ButtonValue::new(true, value),
+                    ButtonValue::new(false, value),
                 );
             }
         }
     }
-
-    // fn compute(
-    //     mut central_input_store: ResMut<CentralInputStore>,
-    //     source_data: StaticSystemParam<Self::SourceData>,
-    // ) {
-    //     for (gamepad_entity, gamepad) in source_data.iter() {
-    //         for key in gamepad.get_pressed() {
-    //             central_input_store.update_buttonlike(
-    //                 SpecificGamepadButton {
-    //                     gamepad: gamepad_entity,
-    //                     button: *key,
-    //                 },
-    //                 true,
-    //             );
-    //             central_input_store.update_buttonlike(*key, ButtonValue::new(true, value));
-    //         }
-    //     }
-    //     for button in source_data.buttons.get_pressed() {
-    //         let value = source_data.axes.get(*button).unwrap_or(1.0);
-    //         central_input_store.update_buttonlike(*button, ButtonValue::new(true, value));
-    //     }
-
-    //     for button in source_data.buttons.get_just_released() {
-    //         let value = source_data.axes.get(*button).unwrap_or(0.0);
-    //         central_input_store.update_buttonlike(*button, ButtonValue::new(false, value));
-    //     }
-    // }
 }
 
 /// Unlike [`GamepadButton`], this struct represents a specific button on a specific gamepad.
@@ -758,26 +731,6 @@ impl Buttonlike for GamepadButton {
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         button_pressed(input_store, gamepad, *self)
     }
-
-    // /// Sends a [`RawGamepadEvent::Button`] event with a magnitude of 1.0 in the direction defined by `self` on the provided [`Gamepad`].
-    // fn press_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
-    //     let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(world);
-    //     let query = query_state.get(world);
-    //     let gamepad = gamepad.unwrap_or(find_gamepad(Some(query)));
-
-    //     let event = RawGamepadEvent::Button(RawGamepadButtonChangedEvent {
-    //         gamepad,
-    //         button: *self,
-    //         value: 1.0,
-    //     });
-    //     world.resource_mut::<Events<RawGamepadEvent>>().send(event);
-    // }
-
-    // /// Sends a [`RawGamepadEvent::Button`] event with a magnitude of 0.0 in the direction defined by `self` on the provided [`Gamepad`].
-    // fn release_as_gamepad(&self, world: &mut World, gamepad: Option<Entity>) {
-    //     let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(world);
-    //     let query = query_state.get(world);
-    //     let gamepad = gamepad.unwrap_or(find_gamepad(Some(query)));
 
     /// Retrieves the current value of the specified button.
     ///

--- a/src/user_input/keyboard.rs
+++ b/src/user_input/keyboard.rs
@@ -201,14 +201,14 @@ impl Buttonlike for ModifierKey {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+    use crate::plugin::CentralInputStorePlugin;
     use bevy::input::InputPlugin;
     use bevy::prelude::*;
 
     fn test_app() -> App {
         let mut app = App::new();
         app.add_plugins(InputPlugin)
-            .add_plugins((AccumulatorPlugin, CentralInputStorePlugin));
+            .add_plugins(CentralInputStorePlugin);
         app
     }
 

--- a/src/user_input/mod.rs
+++ b/src/user_input/mod.rs
@@ -38,7 +38,7 @@
 //!
 //! ### Gamepad Inputs
 //!
-//! - Check gamepad button presses using Bevy's [`GamepadButtonType`] directly.
+//! - Check gamepad button presses using Bevy's [`GamepadButton`] directly.
 //! - Access physical sticks using [`GamepadStick`], [`GamepadControlAxis`], and [`GamepadControlDirection`].
 //!
 //! ### Keyboard Inputs
@@ -74,8 +74,7 @@
 //! - [`TripleAxislikeChord`]: A combined input that groups a [`Buttonlike`] and a [`TripleAxislike`] together,
 //!   allowing you to only read the dual axis data when the button is pressed.
 //!
-//! [`GamepadAxisType`]: bevy::prelude::GamepadAxisType
-//! [`GamepadButtonType`]: bevy::prelude::GamepadButtonType
+//! [`GamepadButton`]: bevy::prelude::GamepadButton
 //! [`KeyCode`]: bevy::prelude::KeyCode
 //! [`MouseButton`]: bevy::prelude::MouseButton
 
@@ -161,7 +160,7 @@ pub trait Buttonlike:
         self.press_as_gamepad(world, None);
     }
 
-    /// Simulate a press of the buttonlike input, pretending to be the provided [`Gamepad`].
+    /// Simulate a press of the buttonlike input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`Buttonlike::press`] if not overridden,
     /// as is the case for things like mouse buttons and keyboard keys.
@@ -180,7 +179,7 @@ pub trait Buttonlike:
         self.release_as_gamepad(world, None);
     }
 
-    /// Simulate a release of the buttonlike input, pretending to be the provided [`Gamepad`].
+    /// Simulate a release of the buttonlike input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`Buttonlike::release`] if not overridden,
     /// as is the case for things like mouse buttons and keyboard keys.
@@ -203,7 +202,7 @@ pub trait Buttonlike:
         self.set_value_as_gamepad(world, value, None);
     }
 
-    /// Simulate a value change of the buttonlike input, pretending to be the provided [`Gamepad`].
+    /// Simulate a value change of the buttonlike input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`Buttonlike::set_value`] if not overridden,
     /// as is the case for things like a mouse wheel.
@@ -234,7 +233,7 @@ pub trait Axislike:
         self.set_value_as_gamepad(world, value, None);
     }
 
-    /// Simulate an axis-like input, pretending to be the provided [`Gamepad`].
+    /// Simulate an axis-like input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`Axislike::set_value`] if not overridden,
     /// as is the case for things like a mouse wheel.
@@ -261,7 +260,7 @@ pub trait DualAxislike:
         self.set_axis_pair_as_gamepad(world, value, None);
     }
 
-    /// Simulate a dual-axis-like input, pretending to be the provided [`Gamepad`].
+    /// Simulate a dual-axis-like input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`DualAxislike::set_axis_pair`] if not overridden,
     /// as is the case for things like a mouse wheel.
@@ -288,7 +287,7 @@ pub trait TripleAxislike:
         self.set_axis_triple_as_gamepad(world, value, None);
     }
 
-    /// Simulate a triple-axis-like input, pretending to be the provided [`Gamepad`].
+    /// Simulate a triple-axis-like input, pretending to be the provided gamepad [`Entity`].
     ///
     /// This method defaults to calling [`TripleAxislike::set_axis_triple`] if not overridden,
     /// as is the case for things like a space mouse.

--- a/src/user_input/mod.rs
+++ b/src/user_input/mod.rs
@@ -82,7 +82,7 @@
 use std::fmt::Debug;
 
 use bevy::math::{Vec2, Vec3};
-use bevy::prelude::{Gamepad, World};
+use bevy::prelude::{Entity, World};
 use bevy::reflect::{erased_serde, Reflect};
 use dyn_clone::DynClone;
 use dyn_eq::DynEq;
@@ -136,10 +136,10 @@ pub trait Buttonlike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Checks if the input is currently active.
-    fn pressed(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> bool;
+    fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool;
 
     /// Checks if the input is currently inactive.
-    fn released(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> bool {
+    fn released(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         !self.pressed(input_store, gamepad)
     }
 
@@ -158,7 +158,7 @@ pub trait Buttonlike:
     ///
     /// Use [`find_gamepad`] inside of this method to search for a gamepad to press the button on
     /// if the provided gamepad is `None`.
-    fn press_as_gamepad(&self, world: &mut World, _gamepad: Option<Gamepad>) {
+    fn press_as_gamepad(&self, world: &mut World, _gamepad: Option<Entity>) {
         self.press(world);
     }
 
@@ -177,7 +177,7 @@ pub trait Buttonlike:
     ///
     /// Use [`find_gamepad`] inside of this method to search for a gamepad to press the button on
     /// if the provided gamepad is `None`.
-    fn release_as_gamepad(&self, world: &mut World, _gamepad: Option<Gamepad>) {
+    fn release_as_gamepad(&self, world: &mut World, _gamepad: Option<Entity>) {
         self.release(world);
     }
 }
@@ -187,7 +187,7 @@ pub trait Axislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the current value of the input as an `f32`.
-    fn value(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> f32;
+    fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32;
 
     /// Simulate an axis-like input by sending the appropriate event.
     ///
@@ -204,7 +204,7 @@ pub trait Axislike:
     ///
     /// Use [`find_gamepad`] inside of this method to search for a gamepad to press the button on
     /// if the provided gamepad is `None`.
-    fn set_value_as_gamepad(&self, world: &mut World, value: f32, _gamepad: Option<Gamepad>) {
+    fn set_value_as_gamepad(&self, world: &mut World, value: f32, _gamepad: Option<Entity>) {
         self.set_value(world, value);
     }
 }
@@ -214,7 +214,7 @@ pub trait DualAxislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the values of this input along the X and Y axes (if applicable).
-    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec2;
+    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2;
 
     /// Simulate a dual-axis-like input by sending the appropriate event.
     ///
@@ -231,7 +231,7 @@ pub trait DualAxislike:
     ///
     /// Use [`find_gamepad`] inside of this method to search for a gamepad to press the button on
     /// if the provided gamepad is `None`.
-    fn set_axis_pair_as_gamepad(&self, world: &mut World, value: Vec2, _gamepad: Option<Gamepad>) {
+    fn set_axis_pair_as_gamepad(&self, world: &mut World, value: Vec2, _gamepad: Option<Entity>) {
         self.set_axis_pair(world, value);
     }
 }
@@ -241,7 +241,7 @@ pub trait TripleAxislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the values of this input along the X, Y, and Z axes (if applicable).
-    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec3;
+    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3;
 
     /// Simulate a triple-axis-like input by sending the appropriate event.
     ///
@@ -258,12 +258,7 @@ pub trait TripleAxislike:
     ///
     /// Use [`find_gamepad`] inside of this method to search for a gamepad to press the button on
     /// if the provided gamepad is `None`.
-    fn set_axis_triple_as_gamepad(
-        &self,
-        world: &mut World,
-        value: Vec3,
-        _gamepad: Option<Gamepad>,
-    ) {
+    fn set_axis_triple_as_gamepad(&self, world: &mut World, value: Vec3, _gamepad: Option<Entity>) {
         self.set_axis_triple(world, value);
     }
 }

--- a/src/user_input/testing_utils.rs
+++ b/src/user_input/testing_utils.rs
@@ -1,9 +1,7 @@
 //! Utilities for testing user input.
 
 use bevy::{
-    app::App,
-    math::Vec2,
-    prelude::{Gamepad, Gamepads, World},
+    app::App, ecs::system::SystemState, math::Vec2, prelude::{Entity, Gamepad, Query, With, World}
 };
 
 use super::{updating::CentralInputStore, Axislike, Buttonlike, DualAxislike};
@@ -12,8 +10,8 @@ use super::{updating::CentralInputStore, Axislike, Buttonlike, DualAxislike};
 use crate::user_input::gamepad::find_gamepad;
 
 #[cfg(not(feature = "gamepad"))]
-fn find_gamepad(_gamepads: &Gamepads) -> Gamepad {
-    Gamepad::new(0)
+fn find_gamepad(_: Option<Query<Entity, With<Gamepad>>>) -> Entity {
+    Entity::PLACEHOLDER
 }
 
 /// A trait used to quickly fetch the value of a given [`UserInput`](crate::user_input::UserInput).
@@ -32,31 +30,28 @@ pub trait FetchUserInput {
 
 impl FetchUserInput for World {
     fn read_pressed(&mut self, input: impl Buttonlike) -> bool {
+        let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(self);
+        let query = query_state.get(self);
+        let gamepad = find_gamepad(Some(query));
         let input_store = self.resource::<CentralInputStore>();
-        let gamepad = match self.get_resource::<Gamepads>() {
-            Some(gamepads) => find_gamepad(gamepads),
-            None => Gamepad::new(0),
-        };
 
         input.pressed(input_store, gamepad)
     }
 
     fn read_axis_value(&mut self, input: impl Axislike) -> f32 {
+        let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(self);
+        let query = query_state.get(self);
+        let gamepad = find_gamepad(Some(query));
         let input_store = self.resource::<CentralInputStore>();
-        let gamepad = match self.get_resource::<Gamepads>() {
-            Some(gamepads) => find_gamepad(gamepads),
-            None => Gamepad::new(0),
-        };
 
         input.value(input_store, gamepad)
     }
 
     fn read_dual_axis_values(&mut self, input: impl DualAxislike) -> Vec2 {
+        let mut query_state = SystemState::<Query<Entity, With<Gamepad>>>::new(self);
+        let query = query_state.get(self);
+        let gamepad = find_gamepad(Some(query));
         let input_store = self.resource::<CentralInputStore>();
-        let gamepad = match self.get_resource::<Gamepads>() {
-            Some(gamepads) => find_gamepad(gamepads),
-            None => Gamepad::new(0),
-        };
 
         input.axis_pair(input_store, gamepad)
     }

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -5,8 +5,9 @@ use std::hash::Hash;
 
 use bevy::{
     app::{App, PreUpdate},
+    ecs::system::{StaticSystemParam, SystemParam},
     math::{Vec2, Vec3},
-    prelude::{IntoSystemConfigs, Res, ResMut, Resource},
+    prelude::{IntoSystemConfigs, ResMut, Resource},
     reflect::Reflect,
     utils::{HashMap, HashSet},
 };
@@ -272,7 +273,7 @@ pub trait UpdatableInput: 'static {
     ///
     /// This type cannot be [`CentralInputStore`], as that would cause mutable aliasing and panic at runtime.
     // TODO: Ideally this should be a `SystemParam` for more flexibility.
-    type SourceData: Resource;
+    type SourceData: SystemParam;
 
     /// A system that updates the central store of user input based on the state of the world.
     ///
@@ -281,7 +282,10 @@ pub trait UpdatableInput: 'static {
     /// # Warning
     ///
     /// This system should not be added manually: instead, call [`CentralInputStore::register_input_kind`].
-    fn compute(central_input_store: ResMut<CentralInputStore>, source_data: Res<Self::SourceData>);
+    fn compute(
+        central_input_store: ResMut<CentralInputStore>,
+        source_data: StaticSystemParam<Self::SourceData>,
+    );
 }
 
 #[cfg(test)]
@@ -337,7 +341,7 @@ mod tests {
         dbg!(&mouse_button_input);
         world.insert_resource(mouse_button_input);
 
-        world.run_system_once(MouseButton::compute);
+        world.run_system_once(MouseButton::compute).unwrap();
         let central_input_store = world.resource::<CentralInputStore>();
         dbg!(central_input_store);
         assert!(central_input_store.pressed(&MouseButton::Left));

--- a/src/user_input/virtual_axial.rs
+++ b/src/user_input/virtual_axial.rs
@@ -38,10 +38,10 @@ use serde::{Deserialize, Serialize};
 /// use bevy::input::InputPlugin;
 /// use leafwing_input_manager::prelude::*;
 /// use leafwing_input_manager::user_input::testing_utils::FetchUserInput;
-/// use leafwing_input_manager::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+/// use leafwing_input_manager::plugin::CentralInputStorePlugin;
 ///
 /// let mut app = App::new();
-/// app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+/// app.add_plugins((InputPlugin, CentralInputStorePlugin));
 ///
 /// // Define a virtual Y-axis using arrow "up" and "down" keys
 /// let axis = VirtualAxis::vertical_arrow_keys();
@@ -273,10 +273,10 @@ impl WithAxisProcessingPipelineExt for VirtualAxis {
 /// use bevy::input::InputPlugin;
 /// use leafwing_input_manager::user_input::testing_utils::FetchUserInput;
 /// use leafwing_input_manager::prelude::*;
-/// use leafwing_input_manager::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+/// use leafwing_input_manager::plugin::CentralInputStorePlugin;
 ///
 /// let mut app = App::new();
-/// app.add_plugins((InputPlugin, AccumulatorPlugin, CentralInputStorePlugin));
+/// app.add_plugins((InputPlugin, CentralInputStorePlugin));
 ///
 /// // Define a virtual D-pad using the WASD keys
 /// let input = VirtualDPad::wasd();
@@ -601,14 +601,14 @@ mod tests {
     use bevy::input::InputPlugin;
     use bevy::prelude::*;
 
-    use crate::plugin::{AccumulatorPlugin, CentralInputStorePlugin};
+    use crate::plugin::CentralInputStorePlugin;
     use crate::prelude::updating::CentralInputStore;
     use crate::prelude::*;
 
     fn test_app() -> App {
         let mut app = App::new();
         app.add_plugins(InputPlugin)
-            .add_plugins((AccumulatorPlugin, CentralInputStorePlugin));
+            .add_plugins(CentralInputStorePlugin);
         app
     }
 

--- a/src/user_input/virtual_axial.rs
+++ b/src/user_input/virtual_axial.rs
@@ -12,10 +12,10 @@ use crate::user_input::Buttonlike;
 use crate::InputControlKind;
 use bevy::math::{Vec2, Vec3};
 #[cfg(feature = "gamepad")]
-use bevy::prelude::GamepadButtonType;
+use bevy::prelude::GamepadButton;
 #[cfg(feature = "keyboard")]
 use bevy::prelude::KeyCode;
-use bevy::prelude::{Gamepad, Reflect, World};
+use bevy::prelude::{Entity, Reflect, World};
 use leafwing_input_manager_macros::serde_typetag;
 use serde::{Deserialize, Serialize};
 
@@ -143,45 +143,45 @@ impl VirtualAxis {
     /// The [`VirtualAxis`] using the horizontal D-Pad button mappings.
     /// No processing is applied to raw data from the gamepad.
     ///
-    /// - [`GamepadButtonType::DPadLeft`] for negative direction.
-    /// - [`GamepadButtonType::DPadRight`] for positive direction.
+    /// - [`GamepadButton::DPadLeft`] for negative direction.
+    /// - [`GamepadButton::DPadRight`] for positive direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn dpad_x() -> Self {
-        Self::new(GamepadButtonType::DPadLeft, GamepadButtonType::DPadRight)
+        Self::new(GamepadButton::DPadLeft, GamepadButton::DPadRight)
     }
 
     /// The [`VirtualAxis`] using the vertical D-Pad button mappings.
     /// No processing is applied to raw data from the gamepad.
     ///
-    /// - [`GamepadButtonType::DPadDown`] for negative direction.
-    /// - [`GamepadButtonType::DPadUp`] for positive direction.
+    /// - [`GamepadButton::DPadDown`] for negative direction.
+    /// - [`GamepadButton::DPadUp`] for positive direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn dpad_y() -> Self {
-        Self::new(GamepadButtonType::DPadDown, GamepadButtonType::DPadUp)
+        Self::new(GamepadButton::DPadDown, GamepadButton::DPadUp)
     }
 
     /// The [`VirtualAxis`] using the horizontal action pad button mappings.
     /// No processing is applied to raw data from the gamepad.
     ///
-    /// - [`GamepadButtonType::West`] for negative direction.
-    /// - [`GamepadButtonType::East`] for positive direction.
+    /// - [`GamepadButton::West`] for negative direction.
+    /// - [`GamepadButton::East`] for positive direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn action_pad_x() -> Self {
-        Self::new(GamepadButtonType::West, GamepadButtonType::East)
+        Self::new(GamepadButton::West, GamepadButton::East)
     }
 
     /// The [`VirtualAxis`] using the vertical action pad button mappings.
     /// No processing is applied to raw data from the gamepad.
     ///
-    /// - [`GamepadButtonType::South`] for negative direction.
-    /// - [`GamepadButtonType::North`] for positive direction.
+    /// - [`GamepadButton::South`] for negative direction.
+    /// - [`GamepadButton::North`] for positive direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn action_pad_y() -> Self {
-        Self::new(GamepadButtonType::South, GamepadButtonType::North)
+        Self::new(GamepadButton::South, GamepadButton::North)
     }
 }
 
@@ -204,7 +204,7 @@ impl Axislike for VirtualAxis {
     /// Retrieves the current value of this axis after processing by the associated processors.
     #[must_use]
     #[inline]
-    fn value(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> f32 {
+    fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         let negative = f32::from(self.negative.pressed(input_store, gamepad));
         let positive = f32::from(self.positive.pressed(input_store, gamepad));
         let value = positive - negative;
@@ -218,7 +218,7 @@ impl Axislike for VirtualAxis {
     /// If the value is negative, the negative button is pressed.
     /// If the value is positive, the positive button is pressed.
     /// If the value is zero, neither button is pressed.
-    fn set_value_as_gamepad(&self, world: &mut World, value: f32, gamepad: Option<Gamepad>) {
+    fn set_value_as_gamepad(&self, world: &mut World, value: f32, gamepad: Option<Entity>) {
         if value < 0.0 {
             self.negative.press_as_gamepad(world, gamepad);
         } else if value > 0.0 {
@@ -376,35 +376,35 @@ impl VirtualDPad {
 
     /// Creates a new [`VirtualDPad`] using the common D-Pad button mappings.
     ///
-    /// - [`GamepadButtonType::DPadUp`] for upward direction.
-    /// - [`GamepadButtonType::DPadDown`] for downward direction.
-    /// - [`GamepadButtonType::DPadLeft`] for leftward direction.
-    /// - [`GamepadButtonType::DPadRight`] for rightward direction.
+    /// - [`GamepadButton::DPadUp`] for upward direction.
+    /// - [`GamepadButton::DPadDown`] for downward direction.
+    /// - [`GamepadButton::DPadLeft`] for leftward direction.
+    /// - [`GamepadButton::DPadRight`] for rightward direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn dpad() -> Self {
         Self::new(
-            GamepadButtonType::DPadUp,
-            GamepadButtonType::DPadDown,
-            GamepadButtonType::DPadLeft,
-            GamepadButtonType::DPadRight,
+            GamepadButton::DPadUp,
+            GamepadButton::DPadDown,
+            GamepadButton::DPadLeft,
+            GamepadButton::DPadRight,
         )
     }
 
     /// Creates a new [`VirtualDPad`] using the common action pad button mappings.
     ///
-    /// - [`GamepadButtonType::North`] for upward direction.
-    /// - [`GamepadButtonType::South`] for downward direction.
-    /// - [`GamepadButtonType::West`] for leftward direction.
-    /// - [`GamepadButtonType::East`] for rightward direction.
+    /// - [`GamepadButton::North`] for upward direction.
+    /// - [`GamepadButton::South`] for downward direction.
+    /// - [`GamepadButton::West`] for leftward direction.
+    /// - [`GamepadButton::East`] for rightward direction.
     #[cfg(feature = "gamepad")]
     #[inline]
     pub fn action_pad() -> Self {
         Self::new(
-            GamepadButtonType::North,
-            GamepadButtonType::South,
-            GamepadButtonType::West,
-            GamepadButtonType::East,
+            GamepadButton::North,
+            GamepadButton::South,
+            GamepadButton::West,
+            GamepadButton::East,
         )
     }
 }
@@ -416,7 +416,7 @@ impl UserInput for VirtualDPad {
         InputControlKind::DualAxis
     }
 
-    /// Returns the four [`GamepadButtonType`]s used by this D-pad.
+    /// Returns the four [`GamepadButton`]s used by this D-pad.
     #[inline]
     fn decompose(&self) -> BasicInputs {
         BasicInputs::Composite(vec![
@@ -433,7 +433,7 @@ impl DualAxislike for VirtualDPad {
     /// Retrieves the current X and Y values of this D-pad after processing by the associated processors.
     #[must_use]
     #[inline]
-    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec2 {
+    fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         let up = f32::from(self.up.pressed(input_store, gamepad));
         let down = f32::from(self.down.pressed(input_store, gamepad));
         let left = f32::from(self.left.pressed(input_store, gamepad));
@@ -445,7 +445,7 @@ impl DualAxislike for VirtualDPad {
     }
 
     /// Presses the corresponding buttons based on the quadrant of the given value.
-    fn set_axis_pair_as_gamepad(&self, world: &mut World, value: Vec2, gamepad: Option<Gamepad>) {
+    fn set_axis_pair_as_gamepad(&self, world: &mut World, value: Vec2, gamepad: Option<Entity>) {
         if value.x < 0.0 {
             self.left.press_as_gamepad(world, gamepad);
         } else if value.x > 0.0 {
@@ -563,7 +563,7 @@ impl TripleAxislike for VirtualDPad3D {
     /// Retrieves the current X, Y, and Z values of this D-pad.
     #[must_use]
     #[inline]
-    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Gamepad) -> Vec3 {
+    fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3 {
         let up = f32::from(self.up.pressed(input_store, gamepad));
         let down = f32::from(self.down.pressed(input_store, gamepad));
         let left = f32::from(self.left.pressed(input_store, gamepad));
@@ -574,7 +574,7 @@ impl TripleAxislike for VirtualDPad3D {
     }
 
     /// Presses the corresponding buttons based on the octant of the given value.
-    fn set_axis_triple_as_gamepad(&self, world: &mut World, value: Vec3, gamepad: Option<Gamepad>) {
+    fn set_axis_triple_as_gamepad(&self, world: &mut World, value: Vec3, gamepad: Option<Entity>) {
         if value.x < 0.0 {
             self.left.press_as_gamepad(world, gamepad);
         } else if value.x > 0.0 {
@@ -630,7 +630,7 @@ mod tests {
         app.update();
         let inputs = app.world().resource::<CentralInputStore>();
 
-        let gamepad = Gamepad::new(0);
+        let gamepad = Entity::PLACEHOLDER;
 
         assert_eq!(x.value(inputs, gamepad), 0.0);
         assert_eq!(xy.axis_pair(inputs, gamepad), Vec2::ZERO);

--- a/tests/action_diffs.rs
+++ b/tests/action_diffs.rs
@@ -64,7 +64,7 @@ fn send_action_diff(app: &mut App, action_diff: ActionDiffEvent<Action>) {
 #[track_caller]
 fn assert_has_no_action_diffs(app: &mut App) {
     let action_diff_events = get_events::<ActionDiffEvent<Action>>(app);
-    let action_diff_event_reader = &mut action_diff_events.get_reader();
+    let action_diff_event_reader = &mut action_diff_events.get_cursor();
     if let Some(action_diff) = action_diff_event_reader.read(action_diff_events).next() {
         panic!(
             "Expected no `ActionDiff` variants. Received: {:?}",
@@ -76,7 +76,7 @@ fn assert_has_no_action_diffs(app: &mut App) {
 #[track_caller]
 fn assert_action_diff_created(app: &mut App, predicate: impl Fn(&ActionDiffEvent<Action>)) {
     let mut action_diff_events = get_events_mut::<ActionDiffEvent<Action>>(app);
-    let action_diff_event_reader = &mut action_diff_events.get_reader();
+    let action_diff_event_reader = &mut action_diff_events.get_cursor();
     assert!(action_diff_event_reader.len(action_diff_events.as_ref()) < 2);
     match action_diff_event_reader
         .read(action_diff_events.as_ref())

--- a/tests/buttonlike.rs
+++ b/tests/buttonlike.rs
@@ -86,6 +86,8 @@ fn set_keyboard_updates_central_input_store() {
 }
 
 #[test]
+// FIXME: Should be fixed in a follow-up PR and the ignore should be removed
+#[ignore = "Ignoring as per https://github.com/Leafwing-Studios/leafwing-input-manager/pull/664#issuecomment-2529188830"]
 fn gamepad_button_value() {
     let mut app = test_app();
 
@@ -184,6 +186,8 @@ fn buttonlike_actions_can_be_pressed_and_released_when_pressed() {
 }
 
 #[test]
+// FIXME: Should be fixed in a follow-up PR and the ignore should be removed
+#[ignore = "Ignoring as per https://github.com/Leafwing-Studios/leafwing-input-manager/pull/664#issuecomment-2529188830"]
 fn buttonlike_actions_can_be_pressed_and_released_when_button_value_set() {
     let mut app = test_app();
 


### PR DESCRIPTION
Adopts #644

- Branched off [pcwalton:0.15-newer](https://github.com/pcwalton/leafwing-input-manager/tree/0.15-newer) and resolved conflicts with the `main` branch.
- Bumped `bevy_egui` version requirement to the latest compatible version.
- Set Bevy version requirement to 0.15.0.
- Replaced usage of the deprecated `SpriteBundle` with `Sprite` and `Transform` components.
- Applied system ordering suggestions from [this comment](https://github.com/Leafwing-Studios/leafwing-input-manager/pull/644#issuecomment-2527717209).