### PR TITLE
Fix ignored tests from update to bevy 0.15

### DIFF
--- a/tests/buttonlike.rs
+++ b/tests/buttonlike.rs
@@ -34,7 +34,7 @@ fn test_app() -> App {
     app.insert_resource(input_map)
         .init_resource::<ActionState<TestAction>>();
 
-    let gamepad = app.world_mut().spawn_empty().id();
+    let gamepad = app.world_mut().spawn(Gamepad::default()).id();
     let mut gamepad_events: Mut<'_, Events<GamepadEvent>> =
         app.world_mut().resource_mut::<Events<GamepadEvent>>();
     gamepad_events.send(GamepadEvent::Connection(GamepadConnectionEvent {
@@ -86,8 +86,6 @@ fn set_keyboard_updates_central_input_store() {
 }
 
 #[test]
-// FIXME: Should be fixed in a follow-up PR and the ignore should be removed
-#[ignore = "Ignoring as per https://github.com/Leafwing-Studios/leafwing-input-manager/pull/664#issuecomment-2529188830"]
 fn gamepad_button_value() {
     let mut app = test_app();
 
@@ -186,8 +184,6 @@ fn buttonlike_actions_can_be_pressed_and_released_when_pressed() {
 }
 
 #[test]
-// FIXME: Should be fixed in a follow-up PR and the ignore should be removed
-#[ignore = "Ignoring as per https://github.com/Leafwing-Studios/leafwing-input-manager/pull/664#issuecomment-2529188830"]
 fn buttonlike_actions_can_be_pressed_and_released_when_button_value_set() {
     let mut app = test_app();
 


### PR DESCRIPTION
Fixes the ignored tests introduced in #664 .

The reason these tests were failing was because the [`find_gamepad`](https://github.com/Leafwing-Studios/leafwing-input-manager/blob/d40715f2cf13aa3d3bcaa8fc5c33ed65c7abb8fd/src/user_input/gamepad.rs#L37) function was changed to rely on the existence of a `Gamepad` component to find a gamepad entity if no entity reference was directly provided, however this was not being added.