### PR TITLE
Introduce boxed methods for insertion.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "leafwing-input-manager"
 description = "A powerful, flexible and ergonomic way to manage action-input keybindings for the Bevy game engine."
-version = "0.16.0"
+version = "0.16.1"
 authors = ["Leafwing Studios"]
 homepage = "https://leafwing-studios.com/"
 repository = "https://github.com/leafwing-studios/leafwing-input-manager"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Version 0.16.1
+
+### Enhancements (0.16.1)
+
+- introduced `insert_*_boxed` methods for `Buttonlike`, `Axislike`, `DualAxislike`, and `TripleAxislike`
+  - now you can use dynamic dispatch inputs, allowing for easier seralisation into configs
+
 ## Version 0.16.0
 
 ## Depeendencies (0.16.0)

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -248,6 +248,17 @@ impl<A: Actionlike> InputMap<A> {
     #[inline(always)]
     #[track_caller]
     pub fn insert(&mut self, action: A, button: impl Buttonlike) -> &mut Self {
+        self.insert_boxed(action, Box::new(button));
+        self
+    }
+
+    /// See [`InputMap::insert`] for details.
+    ///
+    /// This method accepts a boxed [`Buttonlike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file)
+    #[inline(always)]
+    #[track_caller]
+    pub fn insert_boxed(&mut self, action: A, button: Box<dyn Buttonlike>) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::Button,
             "Cannot map a Buttonlike input for action {:?} of kind {:?}",
@@ -265,7 +276,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.buttonlike_map, &action, Box::new(button));
+        insert_unique(&mut self.buttonlike_map, &action, button);
         self
     }
 

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -255,7 +255,7 @@ impl<A: Actionlike> InputMap<A> {
     /// See [`InputMap::insert`] for details.
     ///
     /// This method accepts a boxed [`Buttonlike`] `input`, allowing for
-    /// generics to be used in place of specifics. (E.g. seralizing from a config file)
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
     #[inline(always)]
     #[track_caller]
     pub fn insert_boxed(&mut self, action: A, button: Box<dyn Buttonlike>) -> &mut Self {
@@ -288,6 +288,17 @@ impl<A: Actionlike> InputMap<A> {
     #[inline(always)]
     #[track_caller]
     pub fn insert_axis(&mut self, action: A, axis: impl Axislike) -> &mut Self {
+        self.insert_axis_boxed(action, Box::new(axis));
+        self
+    }
+
+    /// See [`InputMap::insert_axis`] for details.
+    ///
+    /// This method accepts a boxed [`Axislike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
+    #[inline(always)]
+    #[track_caller]
+    pub fn insert_axis_boxed(&mut self, action: A, axis: Box<dyn Axislike>) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::Axis,
             "Cannot map an Axislike input for action {:?} of kind {:?}",
@@ -305,7 +316,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.axislike_map, &action, Box::new(axis));
+        insert_unique(&mut self.axislike_map, &action, axis);
         self
     }
 
@@ -317,6 +328,17 @@ impl<A: Actionlike> InputMap<A> {
     #[inline(always)]
     #[track_caller]
     pub fn insert_dual_axis(&mut self, action: A, dual_axis: impl DualAxislike) -> &mut Self {
+        self.insert_dual_axis_boxed(action, Box::new(dual_axis));
+        self
+    }
+
+    /// See [`InputMap::insert_dual_axis`] for details.
+    ///
+    /// This method accepts a boxed [`DualAxislike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
+    #[inline(always)]
+    #[track_caller]
+    pub fn insert_dual_axis_boxed(&mut self, action: A, axis: Box<dyn DualAxislike>) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::DualAxis,
             "Cannot map a DualAxislike input for action {:?} of kind {:?}",
@@ -334,7 +356,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        insert_unique(&mut self.dual_axislike_map, &action, Box::new(dual_axis));
+        insert_unique(&mut self.dual_axislike_map, &action, axis);
         self
     }
 
@@ -346,6 +368,21 @@ impl<A: Actionlike> InputMap<A> {
     #[inline(always)]
     #[track_caller]
     pub fn insert_triple_axis(&mut self, action: A, triple_axis: impl TripleAxislike) -> &mut Self {
+        self.insert_triple_axis_boxed(action, Box::new(triple_axis));
+        self
+    }
+
+    /// See [`InputMap::insert_triple_axis`] for details.
+    ///
+    /// This method accepts a boxed [`TripleAxislike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
+    #[inline(always)]
+    #[track_caller]
+    pub fn insert_triple_axis_boxed(
+        &mut self,
+        action: A,
+        triple_axis: Box<dyn TripleAxislike>,
+    ) -> &mut Self {
         debug_assert!(
             action.input_control_kind() == InputControlKind::TripleAxis,
             "Cannot map a TripleAxislike input for action {:?} of kind {:?}",
@@ -363,8 +400,7 @@ impl<A: Actionlike> InputMap<A> {
             return self;
         }
 
-        let boxed = Box::new(triple_axis);
-        insert_unique(&mut self.triple_axislike_map, &action, boxed);
+        insert_unique(&mut self.triple_axislike_map, &action, triple_axis);
         self
     }
 
@@ -384,6 +420,21 @@ impl<A: Actionlike> InputMap<A> {
         let inputs = inputs
             .into_iter()
             .map(|input| Box::new(input) as Box<dyn Buttonlike>);
+        self.insert_one_to_many_boxed(action, inputs);
+        self
+    }
+
+    /// See [`InputMap::insert_one_to_many`] for details.
+    ///
+    /// This method accepts an iterator, over a boxed [`Buttonlike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
+    #[inline(always)]
+    pub fn insert_one_to_many_boxed(
+        &mut self,
+        action: A,
+        inputs: impl IntoIterator<Item = Box<dyn Buttonlike>>,
+    ) -> &mut Self {
+        let inputs = inputs.into_iter();
         if let Some(bindings) = self.buttonlike_map.get_mut(&action) {
             for input in inputs {
                 if !bindings.contains(&input) {
@@ -409,6 +460,21 @@ impl<A: Actionlike> InputMap<A> {
     ) -> &mut Self {
         for (action, input) in bindings.into_iter() {
             self.insert(action, input);
+        }
+        self
+    }
+
+    /// See [`InputMap::insert_multiple`] for details.
+    ///
+    /// This method accepts an iterator, over a boxed [`Buttonlike`] `input`, allowing for
+    /// generics to be used in place of specifics. (E.g. seralizing from a config file).
+    #[inline(always)]
+    pub fn insert_multiple_boxed(
+        &mut self,
+        bindings: impl IntoIterator<Item = (A, Box<dyn Buttonlike>)>,
+    ) -> &mut Self {
+        for (action, input) in bindings.into_iter() {
+            self.insert_boxed(action, input);
         }
         self
     }


### PR DESCRIPTION
PR introduces additional methods that allow using boxed versions of the traits directly.
Previous methods have been adapted to use the boxed versions underlying, and the boxed methods run all the (previous) logic to them.

Relevant issue: #620