### PR TITLE
Explicitly order LWIM and bevy_picking system sets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ opt-level = 3
 members = ["./", "tools/ci", "macros"]
 
 [features]
-default = ["asset", "ui", "mouse", "keyboard", "gamepad"]
+default = ["asset", "ui", "mouse", "keyboard", "gamepad", "picking"]
 
 # Allow support for tracking timing information about actions (how long a button was pressed, etc.)
 timing = []
@@ -38,6 +38,10 @@ asset = ['bevy/bevy_asset']
 # Add support for 'bevy::ui' integration:
 # - Allow 'bevy::ui' to take priority over actions when processing inputs.
 ui = ['bevy/bevy_ui']
+
+# Add support for 'bevy::picking' integration:
+# - Order systems to allow picking observers to modify action state.
+picking = ['bevy/bevy_picking']
 
 # Add support for 'egui' integration:
 # - Allow 'egui' to take priority over actions when processing inputs.

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -6,6 +6,8 @@ use std::fmt::Debug;
 
 use bevy::app::{App, FixedPostUpdate, Plugin, RunFixedMainLoop};
 use bevy::input::InputSystem;
+#[cfg(feature = "picking")]
+use bevy::picking::PickSet;
 use bevy::prelude::*;
 use bevy::reflect::TypePath;
 #[cfg(feature = "ui")]
@@ -162,6 +164,9 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
                         .after(UiSystem::Focus)
                         .after(InputSystem),
                 );
+
+                #[cfg(feature = "picking")]
+                app.configure_sets(PreUpdate, InputManagerSystem::Update.before(PickSet::Focus));
 
                 // FixedMain schedule
                 app.add_systems(


### PR DESCRIPTION
This makes sure that action state updates from e.g pointer click observers happens after the state reset of LWIM.