### PR TITLE
Remove unused derive_more dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,11 +53,6 @@ bevy = { version = "0.15.0", default-features = false, features = [
   "serialize",
 ] }
 bevy_egui = { version = "0.31", optional = true }
-
-derive_more = { version = "0.99", default-features = false, features = [
-  "display",
-  "error",
-] }
 itertools = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_flexitos = "0.2"


### PR DESCRIPTION
Pruning some duplicate versions from cargo tree in my project and found derive_more to be unused in lwim