### PR TITLE
use required components for `InputMap` (requires `ActionState`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,7 @@ struct Player;
 fn spawn_player(mut commands: Commands) {
     // Describes how to convert from player inputs into those actions
     let input_map = InputMap::new([(Action::Jump, KeyCode::Space)]);
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 // Query for the `ActionState` component in your game logic systems!

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -26,6 +26,7 @@
 - added ability to filter entities to generate action diffs for:
   - added new `generate_action_diffs_filtered<A, F>` system, which accepts a `QueryFilter`, so that only entities matching QueryFilter `F` (and with `ActionState<A>`) generate action diffs
   - added new `summarize_filtered<F>` function for `SummarizedActionState<A>` (alongside the original `summarize`).
+- `InputMap` now requires `ActionState`, `InputManagerBundle` is deprecated.
 
 ## Version 0.15.1
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,11 @@
 # Release Notes
 
+## Version 0.17.0
+
+### Usability (0.17.0)
+
+- `InputMap` now requires `ActionState`, `InputManagerBundle` is deprecated.
+
 ## Version 0.16.0
 
 ## Depeendencies (0.16.0)
@@ -26,7 +32,6 @@
 - added ability to filter entities to generate action diffs for:
   - added new `generate_action_diffs_filtered<A, F>` system, which accepts a `QueryFilter`, so that only entities matching QueryFilter `F` (and with `ActionState<A>`) generate action diffs
   - added new `summarize_filtered<F>` function for `SummarizedActionState<A>` (alongside the original `summarize`).
-- `InputMap` now requires `ActionState`, `InputManagerBundle` is deprecated.
 
 ## Version 0.15.1
 

--- a/examples/axis_inputs.rs
+++ b/examples/axis_inputs.rs
@@ -40,9 +40,7 @@ fn spawn_player(mut commands: Commands) {
             Action::Rudder,
             GamepadControlAxis::RIGHT_X.with_deadzone_symmetric(0.1),
         );
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 // Query for the `ActionState` component in your game logic systems!

--- a/examples/clash_handling.rs
+++ b/examples/clash_handling.rs
@@ -44,7 +44,7 @@ fn spawn_input_map(mut commands: Commands) {
         ButtonlikeChord::new([Digit1, Digit2, Digit3]),
     );
 
-    commands.spawn(InputManagerBundle::with_map(input_map));
+    commands.spawn(input_map);
 }
 
 fn report_pressed_actions(

--- a/examples/default_controls.rs
+++ b/examples/default_controls.rs
@@ -45,9 +45,7 @@ struct Player;
 fn spawn_player(mut commands: Commands) {
     // Spawn the player with the default input_map
     commands
-        .spawn(InputManagerBundle::with_map(
-            PlayerAction::default_input_map(),
-        ))
+        .spawn(PlayerAction::default_input_map())
         .insert(Player);
 }
 

--- a/examples/input_processing.rs
+++ b/examples/input_processing.rs
@@ -47,9 +47,7 @@ fn spawn_player(mut commands: Commands) {
                 DualAxisSensitivity::all(2.0).into(),
             ]),
         );
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 fn check_data(query: Query<&ActionState<Action>, With<Player>>) {

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -27,9 +27,7 @@ struct Player;
 fn spawn_player(mut commands: Commands) {
     // Describes how to convert from player inputs into those actions
     let input_map = InputMap::new([(Action::Jump, KeyCode::Space)]);
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 // Query for the `ActionState` component in your game logic systems!

--- a/examples/mouse_motion.rs
+++ b/examples/mouse_motion.rs
@@ -21,9 +21,7 @@ fn setup(mut commands: Commands) {
     // Note that you can also use discrete gesture-like motion,
     // via the `MouseMoveDirection` enum.
     let input_map = InputMap::default().with_dual_axis(CameraMovement::Pan, MouseMove::default());
-    commands
-        .spawn(Camera2d)
-        .insert(InputManagerBundle::with_map(input_map));
+    commands.spawn(Camera2d).insert(input_map);
 
     commands.spawn((
         Sprite::default(),

--- a/examples/mouse_wheel.rs
+++ b/examples/mouse_wheel.rs
@@ -32,9 +32,7 @@ fn setup(mut commands: Commands) {
         .with_dual_axis(CameraMovement::Pan, MouseScroll::default())
         // Or even a digital dual-axis input!
         .with_dual_axis(CameraMovement::Pan, MouseScroll::default().digital());
-    commands
-        .spawn(Camera2d)
-        .insert(InputManagerBundle::with_map(input_map));
+    commands.spawn(Camera2d).insert(input_map);
 
     commands.spawn((
         Sprite::default(),

--- a/examples/multiplayer.rs
+++ b/examples/multiplayer.rs
@@ -23,13 +23,7 @@ enum Player {
     Two,
 }
 
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    input_manager: InputManagerBundle<Action>,
-}
-
-impl PlayerBundle {
+impl Player {
     fn input_map(player: Player, gamepad_0: Entity, gamepad_1: Entity) -> InputMap<Action> {
         let mut input_map = match player {
             Player::One => InputMap::new([
@@ -67,23 +61,15 @@ fn spawn_players(mut commands: Commands) {
     let gamepad_0 = commands.spawn(()).id();
     let gamepad_1 = commands.spawn(()).id();
 
-    commands.spawn(PlayerBundle {
-        player: Player::One,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(
-            Player::One,
-            gamepad_0,
-            gamepad_1,
-        )),
-    });
+    commands.spawn((
+        Player::One,
+        Player::input_map(Player::One, gamepad_0, gamepad_1),
+    ));
 
-    commands.spawn(PlayerBundle {
-        player: Player::Two,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::input_map(
-            Player::Two,
-            gamepad_0,
-            gamepad_1,
-        )),
-    });
+    commands.spawn((
+        Player::Two,
+        Player::input_map(Player::Two, gamepad_0, gamepad_1),
+    ));
 }
 
 fn move_players(player_query: Query<(&Player, &ActionState<Action>)>) {

--- a/examples/register_gamepads.rs
+++ b/examples/register_gamepads.rs
@@ -52,7 +52,7 @@ fn join(
                 // Make sure to set the gamepad or all gamepads will be used!
                 .with_gamepad(gamepad_entity);
                 let player = commands
-                    .spawn(InputManagerBundle::with_map(input_map))
+                    .spawn(input_map)
                     .insert(Player {
                         gamepad: gamepad_entity,
                     })

--- a/examples/send_actions_over_network.rs
+++ b/examples/send_actions_over_network.rs
@@ -122,9 +122,7 @@ fn spawn_player(mut commands: Commands) {
 
     let input_map = InputMap::new([(MoveLeft, KeyW), (MoveRight, KeyD), (Jump, Space)])
         .with(Shoot, MouseButton::Left);
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 /// A simple mock network interface that copies a set of events from the client to the server

--- a/examples/single_player.rs
+++ b/examples/single_player.rs
@@ -57,15 +57,7 @@ impl ArpgAction {
 #[derive(Component)]
 pub struct Player;
 
-#[derive(Bundle)]
-struct PlayerBundle {
-    player: Player,
-    // This bundle must be added to your player entity
-    // (or whatever else you wish to control)
-    input_manager: InputManagerBundle<ArpgAction>,
-}
-
-impl PlayerBundle {
+impl Player {
     fn default_input_map() -> InputMap<ArpgAction> {
         // This allows us to replace `ArpgAction::Up` with `Up`,
         // significantly reducing boilerplate
@@ -108,10 +100,7 @@ impl PlayerBundle {
 }
 
 fn spawn_player(mut commands: Commands) {
-    commands.spawn(PlayerBundle {
-        player: Player,
-        input_manager: InputManagerBundle::with_map(PlayerBundle::default_input_map()),
-    });
+    commands.spawn((Player, Player::default_input_map()));
 }
 
 fn cast_fireball(query: Query<&ActionState<ArpgAction>, With<Player>>) {

--- a/examples/virtual_dpad.rs
+++ b/examples/virtual_dpad.rs
@@ -35,9 +35,7 @@ fn spawn_player(mut commands: Commands) {
             GamepadButton::DPadRight,
         ),
     );
-    commands
-        .spawn(InputManagerBundle::with_map(input_map))
-        .insert(Player);
+    commands.spawn(input_map).insert(Player);
 }
 
 // Query for the `ActionState` component in your game logic systems!

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -17,7 +17,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::clashing_inputs::ClashStrategy;
 use crate::prelude::updating::CentralInputStore;
-use crate::prelude::UserInputWrapper;
+use crate::prelude::{ActionState, UserInputWrapper};
 use crate::user_input::{Axislike, Buttonlike, DualAxislike, TripleAxislike};
 use crate::{Actionlike, InputControlKind};
 
@@ -102,6 +102,7 @@ fn find_gamepad(_: Option<Query<Entity, With<Gamepad>>>) -> Entity {
 /// input_map.clear();
 /// ```
 #[derive(Resource, Component, Debug, Clone, PartialEq, Eq, Reflect, Serialize, Deserialize)]
+#[require(ActionState::<A>)]
 #[cfg_attr(feature = "asset", derive(Asset))]
 #[reflect(Resource, Component)]
 pub struct InputMap<A: Actionlike> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,6 +113,7 @@ pub trait Actionlike:
 ///
 /// Use with [`InputManagerPlugin`](crate::plugin::InputManagerPlugin), providing the same enum type to both.
 #[derive(Bundle)]
+#[deprecated(note = "Insert `InputMap` directly (and optionally `ActionState`) instead.")]
 pub struct InputManagerBundle<A: Actionlike> {
     /// An [`ActionState`] component
     pub action_state: ActionState<A>,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -44,10 +44,7 @@ struct Player;
 
 fn spawn_player(mut commands: Commands) {
     commands
-        .spawn(InputManagerBundle::with_map(InputMap::new([(
-            Action::PayRespects,
-            KeyCode::KeyF,
-        )])))
+        .spawn(InputMap::new([(Action::PayRespects, KeyCode::KeyF)]))
         .insert(Player);
 }
 


### PR DESCRIPTION
- `InputMap` now requires `ActionState`.
- deprecated `InputManagerBundle` in favor of required components.
- I did not touch the `press_duration` example because I couldn't get it to work (on this or main)

before:

```rust
commands.spawn((Player, InputManagerBundle::with_map(input_map)));
```

after:

```rust
commands.spawn((Player, input_map));
```