### PR TITLE
Update bevy_egui to 0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ leafwing_input_manager_macros = { path = "macros", version = "0.16" }
 bevy = { version = "0.15.0", default-features = false, features = [
   "serialize",
 ] }
-bevy_egui = { version = "0.31", optional = true }
+bevy_egui = { version = "0.32", optional = true, default-features = false }
 itertools = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_flexitos = "0.2"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,8 +1,14 @@
 # Release Notes
 
+## Version 0.17.0 (unreleased)
+
+### Dependencies (0.17.0)
+
+- now supports bevy_egui 0.32
+
 ## Version 0.16.0
 
-## Depeendencies (0.16.0)
+### Dependencies (0.16.0)
 
 - now supports Bevy 0.15 and bevy_egui 0.31
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -145,10 +145,7 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
                 );
 
                 #[cfg(feature = "egui")]
-                app.configure_sets(
-                    PreUpdate,
-                    InputManagerSystem::Filter.after(bevy_egui::EguiSet::ProcessInput),
-                );
+                app.configure_sets(PreUpdate, InputManagerSystem::Filter);
 
                 #[cfg(feature = "ui")]
                 app.configure_sets(PreUpdate, InputManagerSystem::Filter.after(UiSystem::Focus));


### PR DESCRIPTION
I've disabled default-features (which might save some compilation time for someone), and removed `after(bevy_egui::EguiSet::ProcessInput)` from the system ordering.

Egui writes it to memory whether it wants mouse/keyboard input only during its `end_pass`, which happens in the `PostUpdate` schedule, and since we want to run filtering during `PreUpdate`, the system ordering is redundant (`wants_pointer_input` and others always have a 1-frame delay anyway).