### PR TITLE
Replace Egui with disableable inputs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,6 @@ ui = ['bevy/bevy_ui']
 # - Order systems to allow picking observers to modify action state.
 picking = ['bevy/bevy_picking']
 
-# Add support for 'egui' integration:
-# - Allow 'egui' to take priority over actions when processing inputs.
-egui = ['dep:bevy_egui']
-
 [dependencies]
 leafwing_input_manager_macros = { path = "macros", version = "0.16" }
 bevy = { version = "0.16.0-rc", default-features = false, features = [
@@ -55,9 +51,6 @@ bevy = { version = "0.16.0-rc", default-features = false, features = [
   "bevy_log"
 ] }
 
-# TODO: Update before release
-bevy_egui = { git = "http://github.com/slyedoc/bevy_egui", branch = "bevy_0.16", optional = true, default-features = false }
-#bevy_egui = { version = "0.32", optional = true, default-features = false }
 itertools = "0.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_flexitos = "0.2"

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -2,12 +2,21 @@
 
 ## Version 0.17.0 (unreleased)
 
+### Breaking Changes
+
+- removed the `egui` feature together with the `bevy_egui` dependency, absorbing inputs is now supported by `bevy_egui` itself
+
+### Enhancements
+
+- added `EnabledInput` resources to allow disabling input handling by input type
+
 ### Bugs (0.17.0)
+
 - fixed the bug making it impossible to register custom input types via `register_input_kind`
 
 ### Dependencies (0.17.0)
 
-- now supports bevy_egui 0.32
+- now supports Bevy 0.16
 
 ## Version 0.16.0
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -137,16 +137,13 @@ impl<A: Actionlike + TypePath + bevy::reflect::GetTypeRegistration> Plugin
                         .after(InputManagerSystem::Unify),
                 );
 
-                #[cfg(any(feature = "egui", feature = "ui"))]
+                #[cfg(feature = "ui")]
                 app.add_systems(
                     PreUpdate,
                     filter_captured_input
                         .before(update_action_state::<A>)
                         .in_set(InputManagerSystem::Filter),
                 );
-
-                #[cfg(feature = "egui")]
-                app.configure_sets(PreUpdate, InputManagerSystem::Filter);
 
                 #[cfg(feature = "ui")]
                 app.configure_sets(PreUpdate, InputManagerSystem::Filter.after(UiSystem::Focus));

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -104,15 +104,11 @@ pub fn update_action_state<A: Actionlike>(
     }
 }
 
-#[cfg(any(feature = "egui", feature = "ui"))]
+#[cfg(feature = "ui")]
 /// Filters out all inputs that are captured by the UI.
 pub fn filter_captured_input(
     mut mouse_buttons: ResMut<bevy::input::ButtonInput<bevy::input::mouse::MouseButton>>,
     #[cfg(feature = "ui")] interactions: Query<&bevy::ui::Interaction>,
-    #[cfg(feature = "egui")] mut keycodes: ResMut<
-        bevy::input::ButtonInput<bevy::input::keyboard::KeyCode>,
-    >,
-    #[cfg(feature = "egui")] mut egui_query: Query<&'static mut bevy_egui::EguiContext>,
 ) {
     // If the user clicks on a button, do not apply it to the game state
     #[cfg(feature = "ui")]
@@ -121,19 +117,6 @@ pub fn filter_captured_input(
         .any(|&interaction| interaction != bevy::ui::Interaction::None)
     {
         mouse_buttons.clear();
-    }
-
-    // If egui wants to own inputs, don't also apply them to the game state
-    #[cfg(feature = "egui")]
-    for mut egui_context in egui_query.iter_mut() {
-        // Don't ask me why get doesn't exist :shrug:
-        if egui_context.get_mut().wants_pointer_input() {
-            mouse_buttons.reset_all();
-        }
-
-        if egui_context.get_mut().wants_keyboard_input() {
-            keycodes.reset_all();
-        }
     }
 }
 

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -215,6 +215,8 @@ pub struct EnabledInput<T> {
     _p: PhantomData<T>,
 }
 
+// SAFETY: The `Resource` derive requires `T` to implement `Send + Sync` as well, but since it's
+// used only as `PhantomData`, it's safe to say that `EnabledInput` is `Send + Sync` regardless of `T`.
 unsafe impl<T> Send for EnabledInput<T> {}
 unsafe impl<T> Sync for EnabledInput<T> {}
 

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -222,7 +222,7 @@ impl<T: UpdatableInput> Default for EnabledInput<T> {
     fn default() -> Self {
         Self {
             is_enabled: true,
-            _p: PhantomData::default(),
+            _p: PhantomData,
         }
     }
 }

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -207,7 +207,8 @@ impl CentralInputStore {
 }
 
 #[derive(Resource)]
-/// This resource exists for each input event type that implements [`UpdatableInput`]. Set [`EnabledInput::is_enabled`] to `false` to disable corresponding input handling.
+/// This resource exists for each input type that implements [`UpdatableInput`] (e.g. [`bevy::input::mouse::MouseButton`], [`bevy::input::keyboard::KeyCode`]).
+/// Set [`EnabledInput::is_enabled`] to `false` to disable corresponding input handling.
 pub struct EnabledInput<T> {
     /// Set this flag to `false` to disable input handling of corresponding events.
     pub is_enabled: bool,

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -78,19 +78,12 @@ fn main() {
     }
 
     // The features the lib offers
-    let lib_features = ["asset", "timing", "ui", "egui"];
+    let lib_features = ["asset", "timing", "ui"];
 
     // Generate all possible combinations of lib features
     // and convert them into '--features=<FEATURE_A,FEATURE_B,...>'
     let lib_features_options = (1..lib_features.len())
         .flat_map(|combination_length| lib_features.iter().combinations(combination_length))
-        .map(|mut combination| {
-            // bevy_egui 0.29 uses the bevy winit feature, which requires a renderer.
-            if combination.contains(&&"egui") {
-                combination.push(&"bevy/wayland");
-            }
-            combination
-        })
         .map(|combination| String::from("--features=") + &combination.iter().join(","));
 
     let default_feature_options = ["--no-default-features", "--all-features"];


### PR DESCRIPTION
Based on #686.

Since `bevy_egui` now implements absorbing inputs (https://github.com/vladbat00/bevy_egui/pull/369, https://github.com/vladbat00/bevy_egui/pull/373), we shouldn't have both libraries possibly fighting over inputs. This PR removes the Egui feature completely.

Also, this PR adds an `EnabledInput` resource to make it possible to disable certain inputs without absorbing `ButtonInput<T>` for every possible system existing in an app, providing a more granular approach.

I haven't removed the `ui` feature as I thought some users might still benefit from it if they don't use `bevy_egui`.