### PR TITLE
Fix warnings

### DIFF
--- a/examples/arpg_indirection.rs
+++ b/examples/arpg_indirection.rs
@@ -5,7 +5,7 @@
 //! This example demonstrates how to model that pattern by copying [`ActionData`]
 //! between two distinct [`ActionState`] components.
 
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::*;
 use leafwing_input_manager::plugin::InputManagerSystem;
 use leafwing_input_manager::prelude::*;

--- a/examples/register_gamepads.rs
+++ b/examples/register_gamepads.rs
@@ -1,6 +1,6 @@
 //! Demonstrates how to register gamepads in local multiplayer fashion
 
-use bevy::{platform_support::collections::HashMap, prelude::*};
+use bevy::{platform::collections::HashMap, prelude::*};
 use leafwing_input_manager::prelude::*;
 
 fn main() {

--- a/src/action_diff.rs
+++ b/src/action_diff.rs
@@ -12,7 +12,7 @@ use bevy::{
         query::QueryFilter,
     },
     math::{Vec2, Vec3},
-    platform_support::collections::{HashMap, HashSet},
+    platform::collections::{HashMap, HashSet},
     prelude::{EntityMapper, EventWriter, Query, Res},
 };
 use serde::{Deserialize, Serialize};

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -2,7 +2,7 @@
 
 use bevy::{
     math::{Vec2, Vec3},
-    platform_support::time::Instant,
+    platform::time::Instant,
     reflect::Reflect,
 };
 use serde::{Deserialize, Serialize};

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -4,7 +4,7 @@ use crate::input_map::UpdatedValue;
 use crate::{action_diff::ActionDiff, input_map::UpdatedActions};
 use crate::{Actionlike, InputControlKind};
 
-use bevy::platform_support::{collections::HashMap, time::Instant};
+use bevy::platform::{collections::HashMap, time::Instant};
 use bevy::prelude::Resource;
 use bevy::reflect::Reflect;
 use bevy::{ecs::component::Component, prelude::ReflectComponent};

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -45,7 +45,7 @@ pub use action_data::*;
 /// ```rust
 /// use bevy::reflect::Reflect;
 /// use leafwing_input_manager::prelude::*;
-/// use bevy::platform_support::time::Instant;
+/// use bevy::platform::time::Instant;
 ///
 /// #[derive(Actionlike, PartialEq, Eq, Hash, Clone, Copy, Debug, Reflect)]
 /// enum Action {
@@ -171,7 +171,7 @@ impl<A: Actionlike> ActionState<A> {
     /// use bevy::prelude::Reflect;
     /// use leafwing_input_manager::prelude::*;
     /// use leafwing_input_manager::buttonlike::ButtonState;
-    /// use bevy::platform_support::time::Instant;
+    /// use bevy::platform::time::Instant;
     ///
     /// #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
     /// enum Action {

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -5,7 +5,7 @@ use std::hash::Hash;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
-use bevy::platform_support::collections::HashMap;
+use bevy::platform::collections::HashMap;
 use bevy::prelude::{Component, Deref, DerefMut, Entity, Gamepad, Query, Reflect, Resource, With};
 use bevy::{log::error, prelude::ReflectComponent};
 use bevy::{

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -908,7 +908,7 @@ impl<A: Actionlike, U: Buttonlike> From<HashMap<A, Vec<U>>> for InputMap<A> {
     ///
     /// ```rust
     /// use bevy::prelude::*;
-    /// use bevy::platform_support::collections::HashMap;
+    /// use bevy::platform::collections::HashMap;
     /// use leafwing_input_manager::prelude::*;
     ///
     /// #[derive(Actionlike, Debug, Clone, Copy, PartialEq, Eq, Hash, Reflect)]

--- a/src/input_processing/mod.rs
+++ b/src/input_processing/mod.rs
@@ -48,11 +48,11 @@
 //! to avoid unexpected behavior caused by extreme inputs.
 //!
 //! - [`AxisBounds`]: A min-max range for valid single-axis inputs,
-//!     implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
+//!   implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
 //! - [`DualAxisBounds`]: A square-shaped region for valid dual-axis inputs,
-//!     with independent min-max ranges for each axis, implemented [`Into<DualAxisProcessor>`].
+//!   with independent min-max ranges for each axis, implemented [`Into<DualAxisProcessor>`].
 //! - [`CircleBounds`]: A circular region for valid dual-axis inputs,
-//!     with a radius defining the maximum magnitude, implemented [`Into<DualAxisProcessor>`].
+//!   with a radius defining the maximum magnitude, implemented [`Into<DualAxisProcessor>`].
 //!
 //! ## Dead Zones
 //!
@@ -63,11 +63,11 @@
 //! helping filter out minor fluctuations and unintended movements.
 //!
 //! - [`AxisExclusion`]: A min-max range for excluding single-axis input values,
-//!     implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
+//!   implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
 //! - [`DualAxisExclusion`]: A cross-shaped region for excluding dual-axis inputs,
-//!     with independent min-max ranges for each axis, implemented [`Into<DualAxisProcessor>`].
+//!   with independent min-max ranges for each axis, implemented [`Into<DualAxisProcessor>`].
 //! - [`CircleExclusion`]: A circular region for excluding dual-axis inputs,
-//!     with a radius defining the maximum excluded magnitude, implemented [`Into<DualAxisProcessor>`].
+//!   with a radius defining the maximum excluded magnitude, implemented [`Into<DualAxisProcessor>`].
 //!
 //! ### Scaled Versions
 //!
@@ -76,12 +76,12 @@
 //! the remaining region within the bounds after dead zone exclusion.
 //!
 //! - [`AxisDeadZone`]: A scaled version of [`AxisExclusion`] with the bounds
-//!     set to [`AxisBounds::symmetric(1.0)`](AxisBounds::default),
-//!     implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
+//!   set to [`AxisBounds::symmetric(1.0)`](AxisBounds::default),
+//!   implemented [`Into<AxisProcessor>`] and [`Into<DualAxisProcessor>`].
 //! - [`DualAxisDeadZone`]: A scaled version of [`DualAxisExclusion`] with the bounds
-//!     set to [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default), implemented [`Into<DualAxisProcessor>`].
+//!   set to [`DualAxisBounds::symmetric_all(1.0)`](DualAxisBounds::default), implemented [`Into<DualAxisProcessor>`].
 //! - [`CircleDeadZone`]: A scaled version of [`CircleExclusion`] with the bounds
-//!     set to [`CircleBounds::new(1.0)`](CircleBounds::default), implemented [`Into<DualAxisProcessor>`].
+//!   set to [`CircleBounds::new(1.0)`](CircleBounds::default), implemented [`Into<DualAxisProcessor>`].
 
 pub use self::dual_axis::*;
 pub use self::single_axis::*;

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -11,7 +11,7 @@ use crate::{
 use bevy::ecs::prelude::*;
 use bevy::prelude::Gamepad;
 use bevy::{
-    platform_support::time::Instant,
+    platform::time::Instant,
     time::{Real, Time},
 };
 

--- a/src/timing.rs
+++ b/src/timing.rs
@@ -1,6 +1,6 @@
 //! Information about when an action was pressed or released.
 
-use bevy::{platform_support::time::Instant, reflect::Reflect};
+use bevy::{platform::time::Instant, reflect::Reflect};
 use core::time::Duration;
 use serde::{Deserialize, Serialize};
 
@@ -78,7 +78,7 @@ mod tests {
     #[test]
     fn time_tick_ticks_away() {
         use crate::action_state::ActionState;
-        use bevy::platform_support::time::Instant;
+        use bevy::platform::time::Instant;
         use core::time::Duration;
 
         let mut action_state = ActionState::<Action>::default();
@@ -103,7 +103,7 @@ mod tests {
     #[test]
     fn durations() {
         use crate::action_state::ActionState;
-        use bevy::platform_support::time::Instant;
+        use bevy::platform::time::Instant;
         use core::time::Duration;
 
         let mut action_state = ActionState::<Action>::default();

--- a/src/user_input/chord.rs
+++ b/src/user_input/chord.rs
@@ -128,7 +128,6 @@ impl UserInput for ButtonlikeChord {
 #[serde_typetag]
 impl Buttonlike for ButtonlikeChord {
     /// Checks if all the inner inputs within the chord are active simultaneously.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         self.0

--- a/src/user_input/chord.rs
+++ b/src/user_input/chord.rs
@@ -128,6 +128,7 @@ impl UserInput for ButtonlikeChord {
 #[serde_typetag]
 impl Buttonlike for ButtonlikeChord {
     /// Checks if all the inner inputs within the chord are active simultaneously.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         self.0

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -202,7 +202,6 @@ impl UserInput for GamepadControlDirection {
 #[serde_typetag]
 impl Buttonlike for GamepadControlDirection {
     /// Checks if there is any recent stick movement along the specified direction.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         let value = read_axis_value(input_store, gamepad, self.axis);
@@ -419,7 +418,6 @@ impl UserInput for GamepadControlAxis {
 #[serde_typetag]
 impl Axislike for GamepadControlAxis {
     /// Retrieves the current value of this axis after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         let value = read_axis_value(input_store, gamepad, self.axis);
@@ -547,7 +545,6 @@ impl UserInput for GamepadStick {
 #[serde_typetag]
 impl DualAxislike for GamepadStick {
     /// Retrieves the current X and Y values of this stick after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         let x = read_axis_value(input_store, gamepad, self.x);
@@ -725,7 +722,6 @@ impl UserInput for GamepadButton {
 #[serde_typetag]
 impl Buttonlike for GamepadButton {
     /// Checks if the specified button is currently pressed down.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         button_pressed(input_store, gamepad, *self)
@@ -736,7 +732,6 @@ impl Buttonlike for GamepadButton {
     /// This will be 0.0 if the button is released, and 1.0 if it is pressed.
     /// Physically triggerlike buttons will return a value between 0.0 and 1.0,
     /// depending on how far the button is pressed.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         button_value(input_store, gamepad, *self)

--- a/src/user_input/gamepad.rs
+++ b/src/user_input/gamepad.rs
@@ -202,6 +202,7 @@ impl UserInput for GamepadControlDirection {
 #[serde_typetag]
 impl Buttonlike for GamepadControlDirection {
     /// Checks if there is any recent stick movement along the specified direction.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         let value = read_axis_value(input_store, gamepad, self.axis);
@@ -418,6 +419,7 @@ impl UserInput for GamepadControlAxis {
 #[serde_typetag]
 impl Axislike for GamepadControlAxis {
     /// Retrieves the current value of this axis after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         let value = read_axis_value(input_store, gamepad, self.axis);
@@ -545,6 +547,7 @@ impl UserInput for GamepadStick {
 #[serde_typetag]
 impl DualAxislike for GamepadStick {
     /// Retrieves the current X and Y values of this stick after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         let x = read_axis_value(input_store, gamepad, self.x);
@@ -722,6 +725,7 @@ impl UserInput for GamepadButton {
 #[serde_typetag]
 impl Buttonlike for GamepadButton {
     /// Checks if the specified button is currently pressed down.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool {
         button_pressed(input_store, gamepad, *self)
@@ -732,6 +736,7 @@ impl Buttonlike for GamepadButton {
     /// This will be 0.0 if the button is released, and 1.0 if it is pressed.
     /// Physically triggerlike buttons will return a value between 0.0 and 1.0,
     /// depending on how far the button is pressed.
+    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         button_value(input_store, gamepad, *self)

--- a/src/user_input/keyboard.rs
+++ b/src/user_input/keyboard.rs
@@ -53,7 +53,6 @@ impl UpdatableInput for KeyCode {
 #[serde_typetag]
 impl Buttonlike for KeyCode {
     /// Checks if the specified key is currently pressed down.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         input_store.pressed(self)
@@ -179,7 +178,6 @@ impl UserInput for ModifierKey {
 #[serde_typetag]
 impl Buttonlike for ModifierKey {
     /// Checks if the specified modifier key is currently pressed down.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         input_store.pressed(&self.left()) || input_store.pressed(&self.right())

--- a/src/user_input/keyboard.rs
+++ b/src/user_input/keyboard.rs
@@ -53,6 +53,7 @@ impl UpdatableInput for KeyCode {
 #[serde_typetag]
 impl Buttonlike for KeyCode {
     /// Checks if the specified key is currently pressed down.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         input_store.pressed(self)
@@ -178,6 +179,7 @@ impl UserInput for ModifierKey {
 #[serde_typetag]
 impl Buttonlike for ModifierKey {
     /// Checks if the specified modifier key is currently pressed down.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         input_store.pressed(&self.left()) || input_store.pressed(&self.right())

--- a/src/user_input/mod.rs
+++ b/src/user_input/mod.rs
@@ -136,6 +136,7 @@ pub trait Buttonlike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Checks if the input is currently active.
+    #[must_use]
     fn pressed(&self, input_store: &CentralInputStore, gamepad: Entity) -> bool;
 
     /// Checks if the input is currently inactive.
@@ -148,6 +149,7 @@ pub trait Buttonlike:
     /// The returned value should be between `0.0` and `1.0`,
     /// with `0.0` representing the input being fully released
     /// and `1.0` representing the input being fully pressed.
+    #[must_use]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         f32::from(self.pressed(input_store, gamepad))
     }
@@ -223,6 +225,7 @@ pub trait Axislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the current value of the input as an `f32`.
+    #[must_use]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32;
 
     /// Simulate an axis-like input by sending the appropriate event.
@@ -250,6 +253,7 @@ pub trait DualAxislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the values of this input along the X and Y axes (if applicable).
+    #[must_use]
     fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2;
 
     /// Simulate a dual-axis-like input by sending the appropriate event.
@@ -277,6 +281,7 @@ pub trait TripleAxislike:
     UserInput + DynClone + DynEq + DynHash + Reflect + erased_serde::Serialize
 {
     /// Gets the values of this input along the X, Y, and Z axes (if applicable).
+    #[must_use]
     fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3;
 
     /// Simulate a triple-axis-like input by sending the appropriate event.

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -196,7 +196,6 @@ impl UserInput for MouseMoveDirection {
 #[serde_typetag]
 impl Buttonlike for MouseMoveDirection {
     /// Checks if there is any recent mouse movement along the specified direction.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let mouse_movement = input_store.pair(&MouseMove::default());
@@ -308,7 +307,6 @@ impl UserInput for MouseMoveAxis {
 impl Axislike for MouseMoveAxis {
     /// Retrieves the amount of the mouse movement along the specified axis
     /// after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseMove::default());
@@ -421,7 +419,6 @@ impl UserInput for MouseMove {
 #[serde_typetag]
 impl DualAxislike for MouseMove {
     /// Retrieves the mouse displacement after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseMove::default());
@@ -556,7 +553,6 @@ impl UserInput for MouseScrollDirection {
 #[serde_typetag]
 impl Buttonlike for MouseScrollDirection {
     /// Checks if there is any recent mouse wheel movement along the specified direction.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let movement = input_store.pair(&MouseScroll::default());
@@ -675,7 +671,6 @@ impl UserInput for MouseScrollAxis {
 impl Axislike for MouseScrollAxis {
     /// Retrieves the amount of the mouse wheel movement along the specified axis
     /// after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseScroll::default());
@@ -800,7 +795,6 @@ impl UserInput for MouseScroll {
 #[serde_typetag]
 impl DualAxislike for MouseScroll {
     /// Retrieves the mouse scroll movement on both axes after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseScroll::default());

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -196,8 +196,6 @@ impl UserInput for MouseMoveDirection {
 #[serde_typetag]
 impl Buttonlike for MouseMoveDirection {
     /// Checks if there is any recent mouse movement along the specified direction.
-    #[must_use]
-    #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let mouse_movement = input_store.pair(&MouseMove::default());
         self.direction.is_active(mouse_movement, self.threshold)
@@ -308,7 +306,6 @@ impl UserInput for MouseMoveAxis {
 impl Axislike for MouseMoveAxis {
     /// Retrieves the amount of the mouse movement along the specified axis
     /// after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseMove::default());
@@ -421,7 +418,6 @@ impl UserInput for MouseMove {
 #[serde_typetag]
 impl DualAxislike for MouseMove {
     /// Retrieves the mouse displacement after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseMove::default());
@@ -556,7 +552,6 @@ impl UserInput for MouseScrollDirection {
 #[serde_typetag]
 impl Buttonlike for MouseScrollDirection {
     /// Checks if there is any recent mouse wheel movement along the specified direction.
-    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let movement = input_store.pair(&MouseScroll::default());
@@ -675,7 +670,6 @@ impl UserInput for MouseScrollAxis {
 impl Axislike for MouseScrollAxis {
     /// Retrieves the amount of the mouse wheel movement along the specified axis
     /// after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseScroll::default());
@@ -800,7 +794,6 @@ impl UserInput for MouseScroll {
 #[serde_typetag]
 impl DualAxislike for MouseScroll {
     /// Retrieves the mouse scroll movement on both axes after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseScroll::default());

--- a/src/user_input/mouse.rs
+++ b/src/user_input/mouse.rs
@@ -196,6 +196,8 @@ impl UserInput for MouseMoveDirection {
 #[serde_typetag]
 impl Buttonlike for MouseMoveDirection {
     /// Checks if there is any recent mouse movement along the specified direction.
+    #[must_use]
+    #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let mouse_movement = input_store.pair(&MouseMove::default());
         self.direction.is_active(mouse_movement, self.threshold)
@@ -306,6 +308,7 @@ impl UserInput for MouseMoveAxis {
 impl Axislike for MouseMoveAxis {
     /// Retrieves the amount of the mouse movement along the specified axis
     /// after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseMove::default());
@@ -418,6 +421,7 @@ impl UserInput for MouseMove {
 #[serde_typetag]
 impl DualAxislike for MouseMove {
     /// Retrieves the mouse displacement after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseMove::default());
@@ -552,6 +556,7 @@ impl UserInput for MouseScrollDirection {
 #[serde_typetag]
 impl Buttonlike for MouseScrollDirection {
     /// Checks if there is any recent mouse wheel movement along the specified direction.
+    #[must_use]
     #[inline]
     fn pressed(&self, input_store: &CentralInputStore, _gamepad: Entity) -> bool {
         let movement = input_store.pair(&MouseScroll::default());
@@ -670,6 +675,7 @@ impl UserInput for MouseScrollAxis {
 impl Axislike for MouseScrollAxis {
     /// Retrieves the amount of the mouse wheel movement along the specified axis
     /// after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, _gamepad: Entity) -> f32 {
         let movement = input_store.pair(&MouseScroll::default());
@@ -794,6 +800,7 @@ impl UserInput for MouseScroll {
 #[serde_typetag]
 impl DualAxislike for MouseScroll {
     /// Retrieves the mouse scroll movement on both axes after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, _gamepad: Entity) -> Vec2 {
         let movement = input_store.pair(&MouseScroll::default());

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -10,7 +10,7 @@ use bevy::{
         system::{StaticSystemParam, SystemParam},
     },
     math::{Vec2, Vec3},
-    platform_support::collections::{HashMap, HashSet},
+    platform::collections::{HashMap, HashSet},
     prelude::{ResMut, Resource},
     reflect::Reflect,
 };

--- a/src/user_input/virtual_axial.rs
+++ b/src/user_input/virtual_axial.rs
@@ -202,7 +202,6 @@ impl UserInput for VirtualAxis {
 #[serde_typetag]
 impl Axislike for VirtualAxis {
     /// Retrieves the current value of this axis after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         let negative = self.negative.value(input_store, gamepad);
@@ -432,7 +431,6 @@ impl UserInput for VirtualDPad {
 #[serde_typetag]
 impl DualAxislike for VirtualDPad {
     /// Retrieves the current X and Y values of this D-pad after processing by the associated processors.
-    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         let up = self.up.value(input_store, gamepad);
@@ -568,7 +566,6 @@ impl UserInput for VirtualDPad3D {
 #[serde_typetag]
 impl TripleAxislike for VirtualDPad3D {
     /// Retrieves the current X, Y, and Z values of this D-pad.
-    #[must_use]
     #[inline]
     fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3 {
         let up = self.up.value(input_store, gamepad);

--- a/src/user_input/virtual_axial.rs
+++ b/src/user_input/virtual_axial.rs
@@ -202,6 +202,7 @@ impl UserInput for VirtualAxis {
 #[serde_typetag]
 impl Axislike for VirtualAxis {
     /// Retrieves the current value of this axis after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn value(&self, input_store: &CentralInputStore, gamepad: Entity) -> f32 {
         let negative = self.negative.value(input_store, gamepad);
@@ -431,6 +432,7 @@ impl UserInput for VirtualDPad {
 #[serde_typetag]
 impl DualAxislike for VirtualDPad {
     /// Retrieves the current X and Y values of this D-pad after processing by the associated processors.
+    #[must_use]
     #[inline]
     fn axis_pair(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec2 {
         let up = self.up.value(input_store, gamepad);
@@ -566,6 +568,7 @@ impl UserInput for VirtualDPad3D {
 #[serde_typetag]
 impl TripleAxislike for VirtualDPad3D {
     /// Retrieves the current X, Y, and Z values of this D-pad.
+    #[must_use]
     #[inline]
     fn axis_triple(&self, input_store: &CentralInputStore, gamepad: Entity) -> Vec3 {
         let up = self.up.value(input_store, gamepad);

--- a/tests/clashes.rs
+++ b/tests/clashes.rs
@@ -2,7 +2,7 @@
 
 use bevy::ecs::system::SystemState;
 use bevy::input::InputPlugin;
-use bevy::platform_support::collections::HashSet;
+use bevy::platform::collections::HashSet;
 use bevy::prelude::*;
 use leafwing_input_manager::prelude::*;
 use updating::CentralInputStore;


### PR DESCRIPTION
Based on #686 

Fixes the docs indentation error from clippy, and moves the `#[must_use]` attributes on the `{Button,Axis,DualAxis,TripleAxis}Like` implementations to the trait definition itself to fix a warning on nightly versions.