### PR TITLE
Fixes #612 and `previous_duration`

### DIFF
--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -793,7 +793,7 @@ impl<A: Actionlike> ActionState<A> {
         let action_data = self.button_data_mut_or_default(action);
 
         #[cfg(feature = "timing")]
-        if action_data.state.released() {
+        if action_data.update_state.released() {
             action_data.timing.flip();
         }
 
@@ -812,7 +812,7 @@ impl<A: Actionlike> ActionState<A> {
         let action_data = self.button_data_mut_or_default(action);
 
         #[cfg(feature = "timing")]
-        if action_data.state.pressed() {
+        if action_data.update_state.pressed() {
             action_data.timing.flip();
         }
 


### PR DESCRIPTION
Fixes #612 and `previous_duration` not working

`flip()` was called two times, both by update and fixed update, erasing the `previous_duration` value in `ButtonData`'s `Timing`. I switched `flip()` check to only use update data to fix it