### PR TITLE
Add public methods to override the fixed_update_state from state

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## Unreleased
+
+### Usability
+
+- added two public methods `ActionState::set_fixed_update_state_from_state` and `ActionState::set_update_state_from_state` for advanced users. This is mostly used for networking.
+
+
 ## Version 0.17.0
 
 ### Breaking Changes (0.17.0)

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -121,6 +121,44 @@ impl ActionKindData {
             }
         }
     }
+
+    // set the `update_state` to the current `state`
+    pub(super) fn set_update_state_from_state(&mut self) {
+        match self {
+            Self::Button(data) => {
+                data.update_state = data.state;
+                data.update_value = data.value;
+            }
+            Self::Axis(data) => {
+                data.update_value = data.value;
+            }
+            Self::DualAxis(data) => {
+                data.update_pair = data.pair;
+            }
+            Self::TripleAxis(data) => {
+                data.update_triple = data.triple;
+            }
+        }
+    }
+
+    // set the `fixed_update_state` to the current `state`
+    pub(super) fn set_fixed_update_state_from_state(&mut self) {
+        match self {
+            Self::Button(data) => {
+                data.fixed_update_state = data.state;
+                data.fixed_update_value = data.value;
+            }
+            Self::Axis(data) => {
+                data.fixed_update_value = data.value;
+            }
+            Self::DualAxis(data) => {
+                data.fixed_update_pair = data.pair;
+            }
+            Self::TripleAxis(data) => {
+                data.fixed_update_triple = data.triple;
+            }
+        }
+    }
 }
 
 /// Metadata about an [`Buttonlike`](crate::user_input::Buttonlike) action

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -128,6 +128,20 @@ impl<A: Actionlike> ActionState<A> {
         }
     }
 
+    /// Function for advanced users to override the `state` from the `update_state`
+    pub fn set_update_state_from_state(&mut self) {
+        for action_datum in self.action_data.values_mut() {
+            action_datum.kind_data.set_update_state_from_state();
+        }
+    }
+
+    /// Function for advanced users to override the `state` from the `fixed_update_state`
+    pub fn set_fixed_update_state_from_state(&mut self) {
+        for action_datum in self.action_data.values_mut() {
+            action_datum.kind_data.set_fixed_update_state_from_state();
+        }
+    }
+
     /// Updates the [`ActionState`] based on the provided [`UpdatedActions`].
     ///
     /// The `action_data` is typically constructed from [`InputMap::process_actions`](crate::input_map::InputMap::process_actions),


### PR DESCRIPTION
This is useful for networking purposes as what i'm receiving from the remote is a set of Diffs.
Applying the diffs means updating the `state` field, which is usually not enough because the `state` is swapped out for `fixed_update_state` in the FixedUpdateSchedule.

A solution for this would be to apply the diffs AFTER the state has been swapped for fixed_update, but this would mean doing it in RunFixedMainLoop, which is not always feasible for ordering reasons.

Therefore we need a public method to be able to modify directly `fixed_update_state` and not just `state`