### PR TITLE
Resolves build warnings

### DIFF
--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -1025,6 +1025,7 @@ impl<A: Actionlike, U: Buttonlike> FromIterator<(A, U)> for InputMap<A> {
     }
 }
 
+#[cfg(test)]
 #[cfg(feature = "keyboard")]
 mod tests {
     use bevy::prelude::Reflect;

--- a/src/input_processing/dual_axis/custom.rs
+++ b/src/input_processing/dual_axis/custom.rs
@@ -115,11 +115,11 @@ impl PartialReflect for Box<dyn CustomDualAxisProcessor> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 

--- a/src/input_processing/single_axis/custom.rs
+++ b/src/input_processing/single_axis/custom.rs
@@ -114,11 +114,11 @@ impl PartialReflect for Box<dyn CustomAxisProcessor> {
         ReflectKind::Opaque
     }
 
-    fn reflect_ref(&self) -> ReflectRef {
+    fn reflect_ref(&self) -> ReflectRef<'_> {
         ReflectRef::Opaque(self)
     }
 
-    fn reflect_mut(&mut self) -> ReflectMut {
+    fn reflect_mut(&mut self) -> ReflectMut<'_> {
         ReflectMut::Opaque(self)
     }
 

--- a/src/user_input/trait_reflection.rs
+++ b/src/user_input/trait_reflection.rs
@@ -33,11 +33,11 @@ mod buttonlike {
             ReflectKind::Opaque
         }
 
-        fn reflect_ref(&self) -> ReflectRef {
+        fn reflect_ref(&self) -> ReflectRef<'_> {
             ReflectRef::Opaque(self)
         }
 
-        fn reflect_mut(&mut self) -> ReflectMut {
+        fn reflect_mut(&mut self) -> ReflectMut<'_> {
             ReflectMut::Opaque(self)
         }
 
@@ -200,11 +200,11 @@ mod axislike {
             ReflectKind::Opaque
         }
 
-        fn reflect_ref(&self) -> ReflectRef {
+        fn reflect_ref(&self) -> ReflectRef<'_> {
             ReflectRef::Opaque(self)
         }
 
-        fn reflect_mut(&mut self) -> ReflectMut {
+        fn reflect_mut(&mut self) -> ReflectMut<'_> {
             ReflectMut::Opaque(self)
         }
 
@@ -390,11 +390,11 @@ mod dualaxislike {
             ReflectKind::Opaque
         }
 
-        fn reflect_ref(&self) -> ReflectRef {
+        fn reflect_ref(&self) -> ReflectRef<'_> {
             ReflectRef::Opaque(self)
         }
 
-        fn reflect_mut(&mut self) -> ReflectMut {
+        fn reflect_mut(&mut self) -> ReflectMut<'_> {
             ReflectMut::Opaque(self)
         }
 
@@ -557,11 +557,11 @@ mod tripleaxislike {
             ReflectKind::Opaque
         }
 
-        fn reflect_ref(&self) -> ReflectRef {
+        fn reflect_ref(&self) -> ReflectRef<'_> {
             ReflectRef::Opaque(self)
         }
 
-        fn reflect_mut(&mut self) -> ReflectMut {
+        fn reflect_mut(&mut self) -> ReflectMut<'_> {
             ReflectMut::Opaque(self)
         }
 


### PR DESCRIPTION
Most of the warnings are regarding the lifetime not being specified.
Some are from the test mod being built which we can avoid with `#[cfg(test)]`

closes #708