### PR TITLE
Fix Getting Started Sample after Bevy 0.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ fn spawn_player(mut commands: Commands) {
 // Query for the `ActionState` component in your game logic systems!
 fn jump(query: Query<&ActionState<Action>, With<Player>>) {
     let action_state = query.single();
-    // Each action has a button-like state of its own that you can check
-    if action_state.just_pressed(&Action::Jump) {
-        println!("I'm jumping!");
+    if let Ok(action_state) = action_state {
+        // Each action has a button-like state of its own that you can check
+        if action_state.just_pressed(&Action::Jump) {
+            println!("I'm jumping!");
+        }
     }
 }
 ```


### PR DESCRIPTION
## What was the problem?

Bevy changed the way you can get a `.single` to be a `Result` and it needed to be handled.
Closes #719

## How did you fix it?

I checked the `Result` and handled it accordingly.

