### PR TITLE
Add a small deadzone for analog inputs

### DIFF
--- a/RELEASES.md
+++ b/RELEASES.md
@@ -14,7 +14,8 @@
 
 ### Usability (0.18.1)
 
-- analog gamepad buttons (triggers) will now report their values between `0.0` and `1.0` and will be considered pressed when above `0.0`
+- analog gamepad buttons (triggers) will now report their values between `0.0` and `1.0` and will be considered pressed when above `0.02` 
+  - this prevents issues where triggers would report very small non-zero values as "pressed" when not physically pressed due to sensor imprecision
 
 - run conditions provided by `common_conditions` can now find `ActionState`s from either resources or queries
 

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -576,9 +576,10 @@ impl<A: Actionlike> ActionState<A> {
     }
 
     /// Sets the value of the buttonlike `action` to the provided `value`.
-    /// The threshold of `0.02` is to account for a semi-frequent issue
-    /// with analog inputs (e.g., gamepad triggers) reporting very small
-    /// non-zero values when not pressed.
+    /// A threshold of `0.02` must be overcome for the button to count as "pressed"
+    /// This is used to account for a semi-frequent issue with analog inputs
+    /// (e.g., gamepad triggers) reporting very small non-zero values when
+    /// not physically pressed, due to sensor imprecision.
     ///
     /// Also updates the state of the button based on the `value`:
     /// - If `value > 0.02`, the button will be pressed.
@@ -586,11 +587,12 @@ impl<A: Actionlike> ActionState<A> {
     #[track_caller]
     pub fn set_button_value(&mut self, action: &A, value: f32) {
         debug_assert_eq!(action.input_control_kind(), InputControlKind::Button);
+        const BUTTON_PRESS_THRESHOLD: f32 = 0.02;
 
         let button_data = self.button_data_mut_or_default(action);
         button_data.value = value;
 
-        if value > 0.02 {
+        if value > BUTTON_PRESS_THRESHOLD {
             #[cfg(feature = "timing")]
             if button_data.state.released() {
                 button_data.timing.flip();


### PR DESCRIPTION
## What was the problem?

Occasionally analog inputs would read as low non-zero values when they were not being pressed.

Closes #722

## How did you fix it?

Implement a very small deadzone to account for this issue.

## \[Optional\] What needs special attention?

As discussed in #722, this will be a simple hardcoded deadzone for now. Future work may include making this configurable.
