### PR TITLE
add test coverage for `action_state`

### DIFF
--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -290,3 +290,263 @@ pub struct TripleAxisData {
     /// The `triple` of the action in the `FixedMain` schedule
     pub fixed_update_triple: Vec3,
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::buttonlike::ButtonState;
+
+    #[test]
+    fn test_tick_triple_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::TripleAxisData;
+        use bevy::platform::time::Instant;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::TripleAxis(TripleAxisData {
+                triple: bevy::math::Vec3::new(1.0, 2.0, 3.0),
+                update_triple: bevy::math::Vec3::new(4.0, 5.0, 6.0),
+                fixed_update_triple: bevy::math::Vec3::new(7.0, 8.0, 9.0),
+            }),
+        };
+
+        let previous_instant = Instant::now();
+        let current_instant = previous_instant + std::time::Duration::from_secs(1);
+
+        action_data.tick(current_instant, previous_instant);
+
+        if let ActionKindData::TripleAxis(data) = &action_data.kind_data {
+            assert_eq!(data.triple, bevy::math::Vec3::new(1.0, 2.0, 3.0));
+        } else {
+            panic!("Expected TripleAxisData");
+        }
+    }
+
+    #[test]
+    fn test_swap_update_to_update_state_triple_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::TripleAxisData;
+        use bevy::math::Vec3;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::TripleAxis(TripleAxisData {
+                triple: Vec3::new(1.0, 2.0, 3.0),
+                update_triple: Vec3::new(4.0, 5.0, 6.0),
+                fixed_update_triple: Vec3::new(7.0, 8.0, 9.0),
+            }),
+        };
+
+        action_data.kind_data.swap_to_update_state();
+
+        if let ActionKindData::TripleAxis(data) = &action_data.kind_data {
+            assert_eq!(data.triple, Vec3::new(4.0, 5.0, 6.0));
+        } else {
+            panic!("Expected TripleAxisData");
+        }
+    }
+
+    #[test]
+    fn test_swap_to_fixed_update_state_triple_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::TripleAxisData;
+        use bevy::math::Vec3;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::TripleAxis(TripleAxisData {
+                triple: Vec3::new(1.0, 2.0, 3.0),
+                update_triple: Vec3::new(4.0, 5.0, 6.0),
+                fixed_update_triple: Vec3::new(7.0, 8.0, 9.0),
+            }),
+        };
+
+        action_data.kind_data.swap_to_fixed_update_state();
+
+        if let ActionKindData::TripleAxis(data) = &action_data.kind_data {
+            assert_eq!(data.triple, Vec3::new(7.0, 8.0, 9.0));
+        } else {
+            panic!("Expected TripleAxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_update_state_from_state_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::AxisData;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::Axis(AxisData {
+                value: 1.0,
+                update_value: 2.0,
+                fixed_update_value: 3.0,
+            }),
+        };
+
+        action_data.kind_data.set_update_state_from_state();
+
+        if let ActionKindData::Axis(data) = &action_data.kind_data {
+            assert_eq!(data.update_value, 1.0);
+        } else {
+            panic!("Expected AxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_update_state_from_state_dual_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::DualAxisData;
+        use bevy::math::Vec2;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::DualAxis(DualAxisData {
+                pair: Vec2::new(1.0, 2.0),
+                update_pair: Vec2::new(3.0, 4.0),
+                fixed_update_pair: Vec2::new(5.0, 6.0),
+            }),
+        };
+
+        action_data.kind_data.set_update_state_from_state();
+
+        if let ActionKindData::DualAxis(data) = &action_data.kind_data {
+            assert_eq!(data.update_pair, Vec2::new(1.0, 2.0));
+        } else {
+            panic!("Expected DualAxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_update_state_from_state_triple_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::TripleAxisData;
+        use bevy::math::Vec3;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::TripleAxis(TripleAxisData {
+                triple: Vec3::new(1.0, 2.0, 3.0),
+                update_triple: Vec3::new(4.0, 5.0, 6.0),
+                fixed_update_triple: Vec3::new(7.0, 8.0, 9.0),
+            }),
+        };
+
+        action_data.kind_data.set_update_state_from_state();
+
+        if let ActionKindData::TripleAxis(data) = &action_data.kind_data {
+            assert_eq!(data.update_triple, Vec3::new(1.0, 2.0, 3.0));
+        } else {
+            panic!("Expected TripleAxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_fixed_update_state_from_state_button() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::ButtonData;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::Button(ButtonData {
+                state: ButtonState::Pressed,
+                update_state: ButtonState::JustPressed,
+                fixed_update_state: ButtonState::Released,
+                value: 1.0,
+                update_value: 0.5,
+                fixed_update_value: 0.0,
+                #[cfg(feature = "timing")]
+                timing: Default::default(),
+            }),
+        };
+
+        action_data.kind_data.set_fixed_update_state_from_state();
+        if let ActionKindData::Button(data) = &action_data.kind_data {
+            assert_eq!(data.fixed_update_state, ButtonState::Pressed);
+            assert_eq!(data.fixed_update_value, 1.0);
+        } else {
+            panic!("Expected ButtonData");
+        }
+    }
+
+    #[test]
+    fn test_set_fixed_update_state_from_state_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::AxisData;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::Axis(AxisData {
+                value: 1.0,
+                update_value: 2.0,
+                fixed_update_value: 3.0,
+            }),
+        };
+
+        action_data.kind_data.set_fixed_update_state_from_state();
+
+        if let ActionKindData::Axis(data) = &action_data.kind_data {
+            assert_eq!(data.fixed_update_value, 1.0);
+        } else {
+            panic!("Expected AxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_fixed_update_state_from_state_dual_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::DualAxisData;
+        use bevy::math::Vec2;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::DualAxis(DualAxisData {
+                pair: Vec2::new(1.0, 2.0),
+                update_pair: Vec2::new(3.0, 4.0),
+                fixed_update_pair: Vec2::new(5.0, 6.0),
+            }),
+        };
+
+        action_data.kind_data.set_fixed_update_state_from_state();
+
+        if let ActionKindData::DualAxis(data) = &action_data.kind_data {
+            assert_eq!(data.fixed_update_pair, Vec2::new(1.0, 2.0));
+        } else {
+            panic!("Expected DualAxisData");
+        }
+    }
+
+    #[test]
+    fn test_set_fixed_update_state_from_state_triple_axis() {
+        use super::ActionData;
+        use super::ActionKindData;
+        use super::TripleAxisData;
+        use bevy::math::Vec3;
+
+        let mut action_data = ActionData {
+            disabled: false,
+            kind_data: ActionKindData::TripleAxis(TripleAxisData {
+                triple: Vec3::new(1.0, 2.0, 3.0),
+                update_triple: Vec3::new(4.0, 5.0, 6.0),
+                fixed_update_triple: Vec3::new(7.0, 8.0, 9.0),
+            }),
+        };
+
+        action_data.kind_data.set_fixed_update_state_from_state();
+
+        if let ActionKindData::TripleAxis(data) = &action_data.kind_data {
+            assert_eq!(data.fixed_update_triple, Vec3::new(1.0, 2.0, 3.0));
+        } else {
+            panic!("Expected TripleAxisData");
+        }
+    }
+}

--- a/src/action_state/mod.rs
+++ b/src/action_state/mod.rs
@@ -1166,11 +1166,20 @@ impl<A: Actionlike> ActionState<A> {
 #[cfg(test)]
 mod tests {
     use crate as leafwing_input_manager;
-    use crate::action_state::ActionState;
+    use crate::action_diff::ActionDiff;
+    use crate::action_state::{
+        ActionData, ActionKindData, ActionState, AxisData, ButtonData, DualAxisData,
+    };
+    use crate::buttonlike::{ButtonState, ButtonValue};
+    use crate::input_map::UpdatedActions;
+    #[cfg(any(feature = "gamepad", feature = "keyboard"))]
     use crate::prelude::{ButtonlikeChord, InputMap};
-    use bevy::prelude::KeyCode::*;
+    #[cfg(feature = "gamepad")]
+    use bevy::input::gamepad::GamepadButton;
+    #[cfg(feature = "keyboard")]
+    use bevy::input::keyboard::KeyCode;
+    use bevy::platform::collections::HashMap;
     use bevy::prelude::*;
-
     use leafwing_input_manager_macros::Actionlike;
 
     #[derive(Actionlike, Clone, Copy, PartialEq, Eq, Hash, Debug, Reflect)]
@@ -1182,13 +1191,21 @@ mod tests {
         One,
         Two,
         OneAndTwo,
+        #[actionlike(Axis)]
+        Axis,
+        #[actionlike(DualAxis)]
+        DualAxis,
+        #[actionlike(TripleAxis)]
+        TripleAxis,
     }
 
+    #[cfg(any(feature = "keyboard", feature = "gamepad"))]
     struct TestContext {
         pub app: App,
         pub input_map: InputMap<TestAction>,
     }
 
+    #[cfg(any(feature = "keyboard", feature = "gamepad"))]
     impl TestContext {
         pub fn new() -> Self {
             use bevy::input::InputPlugin;
@@ -1203,15 +1220,19 @@ mod tests {
             ));
 
             let mut input_map = InputMap::default();
+            #[cfg(feature = "gamepad")]
             input_map.insert(TestAction::Trigger, GamepadButton::RightTrigger);
-            input_map.insert(TestAction::One, Digit1);
-            input_map.insert(TestAction::Two, Digit2);
-            input_map.insert(
-                TestAction::OneAndTwo,
-                ButtonlikeChord::new([Digit1, Digit2]),
-            );
 
-            input_map.insert(TestAction::Run, KeyCode::KeyR);
+            #[cfg(feature = "keyboard")]
+            {
+                input_map.insert(TestAction::One, KeyCode::Digit1);
+                input_map.insert(TestAction::Two, KeyCode::Digit2);
+                input_map.insert(
+                    TestAction::OneAndTwo,
+                    ButtonlikeChord::new([KeyCode::Digit1, KeyCode::Digit2]),
+                );
+                input_map.insert(TestAction::Run, KeyCode::KeyR);
+            }
 
             app.insert_resource(input_map.clone())
                 .init_resource::<ActionState<TestAction>>();
@@ -1221,6 +1242,7 @@ mod tests {
             Self { app, input_map }
         }
 
+        #[cfg(feature = "gamepad")]
         pub fn send_gamepad_connection_event(&mut self, gamepad: Option<Entity>) -> Entity {
             use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent};
 
@@ -1242,6 +1264,105 @@ mod tests {
         pub fn update(&mut self) {
             self.app.update();
         }
+    }
+
+    #[test]
+    fn action_state_default_state() {
+        let action_state = ActionState::<TestAction>::default();
+
+        assert!(!action_state.disabled);
+        assert_eq!(action_state.action_data, HashMap::default());
+    }
+
+    #[test]
+    fn action_state_all_action_data() {
+        let action_state = ActionState::<TestAction>::default();
+
+        assert_eq!(action_state.all_action_data(), &action_state.action_data);
+    }
+
+    #[test]
+    fn action_state_button() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        assert!(!action_state.pressed(&TestAction::Jump));
+        assert_eq!(action_state.button_value(&TestAction::Jump), 0.0);
+
+        let mut updated_actions = UpdatedActions::<TestAction>::default();
+        updated_actions.0.insert(
+            TestAction::Jump,
+            crate::input_map::UpdatedValue::Button(ButtonValue {
+                pressed: true,
+                value: 0.5,
+            }),
+        );
+
+        action_state.update(updated_actions);
+
+        assert!(action_state.pressed(&TestAction::Jump));
+        assert_eq!(action_state.button_value(&TestAction::Jump), 0.5);
+    }
+
+    #[test]
+    fn action_state_axis() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        assert_eq!(action_state.value(&TestAction::Axis), 0.0);
+
+        let mut updated_actions = UpdatedActions::<TestAction>::default();
+        updated_actions
+            .0
+            .insert(TestAction::Axis, crate::input_map::UpdatedValue::Axis(0.5));
+
+        action_state.update(updated_actions);
+
+        assert_eq!(action_state.value(&TestAction::Axis), 0.5);
+    }
+
+    #[test]
+    fn action_state_dual_axis() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        assert_eq!(
+            action_state.axis_pair(&TestAction::DualAxis),
+            Vec2::new(0.0, 0.0)
+        );
+
+        let mut updated_actions = UpdatedActions::<TestAction>::default();
+        updated_actions.0.insert(
+            TestAction::DualAxis,
+            crate::input_map::UpdatedValue::DualAxis(Vec2::new(0.5, 0.5)),
+        );
+
+        action_state.update(updated_actions);
+
+        assert_eq!(
+            action_state.axis_pair(&TestAction::DualAxis),
+            Vec2::new(0.5, 0.5)
+        );
+    }
+
+    #[test]
+    fn action_state_triple_axis() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        assert_eq!(
+            action_state.axis_triple(&TestAction::TripleAxis),
+            Vec3::new(0.0, 0.0, 0.0)
+        );
+
+        let mut updated_actions = UpdatedActions::<TestAction>::default();
+        updated_actions.0.insert(
+            TestAction::TripleAxis,
+            crate::input_map::UpdatedValue::TripleAxis(Vec3::new(0.5, 0.5, 0.5)),
+        );
+
+        action_state.update(updated_actions);
+
+        assert_eq!(
+            action_state.axis_triple(&TestAction::TripleAxis),
+            Vec3::new(0.5, 0.5, 0.5)
+        );
     }
 
     #[cfg(feature = "keyboard")]
@@ -1425,9 +1546,616 @@ mod tests {
         assert!(action_state.pressed(&TestAction::OneAndTwo));
     }
 
+    #[test]
+    fn test_set_update_state_from_state() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        // Initial state
+        assert!(action_state.released(&TestAction::Run));
+        assert!(!action_state.just_released(&TestAction::Run));
+        assert!(!action_state.pressed(&TestAction::Run));
+        assert!(!action_state.just_pressed(&TestAction::Run));
+
+        // Update the state manually
+        action_state.action_data.insert(
+            TestAction::Run,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Button(ButtonData {
+                    state: ButtonState::Pressed,
+                    update_state: ButtonState::Pressed,
+                    fixed_update_state: ButtonState::Pressed,
+                    value: 1.0,
+                    update_value: 1.0,
+                    fixed_update_value: 1.0,
+                    #[cfg(feature = "timing")]
+                    timing: Default::default(),
+                }),
+            },
+        );
+        action_state.set_update_state_from_state();
+
+        // Check the state
+        assert!(action_state.pressed(&TestAction::Run));
+        assert!(!action_state.just_pressed(&TestAction::Run));
+        assert!(!action_state.released(&TestAction::Run));
+        assert!(!action_state.just_released(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_set_fixed_update_state_from_state() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        // Initial state
+        assert!(action_state.released(&TestAction::Run));
+        assert!(!action_state.just_released(&TestAction::Run));
+        assert!(!action_state.pressed(&TestAction::Run));
+        assert!(!action_state.just_pressed(&TestAction::Run));
+
+        // Update the state manually
+        action_state.action_data.insert(
+            TestAction::Run,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Button(ButtonData {
+                    state: ButtonState::Pressed,
+                    update_state: ButtonState::Pressed,
+                    fixed_update_state: ButtonState::Pressed,
+                    value: 1.0,
+                    update_value: 1.0,
+                    fixed_update_value: 1.0,
+                    #[cfg(feature = "timing")]
+                    timing: Default::default(),
+                }),
+            },
+        );
+        action_state.set_fixed_update_state_from_state();
+
+        assert!(action_state.pressed(&TestAction::Run));
+        assert!(!action_state.just_pressed(&TestAction::Run));
+        assert!(!action_state.released(&TestAction::Run));
+        assert!(!action_state.just_released(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_button_data_for_button_action_without_data() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.remove(&TestAction::Run);
+        assert!(action_state.button_data(&TestAction::Run).is_none());
+    }
+
+    #[test]
+    fn test_button_data_for_non_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Axis,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Axis(AxisData {
+                    value: 0.5,
+                    update_value: 0.5,
+                    fixed_update_value: 0.5,
+                }),
+            },
+        );
+        assert!(action_state.button_data(&TestAction::Axis).is_none());
+    }
+
+    #[test]
+    fn test_button_data_mut_for_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Run,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Button(ButtonData {
+                    state: ButtonState::Released,
+                    update_state: ButtonState::Released,
+                    fixed_update_state: ButtonState::Released,
+                    value: 0.0,
+                    update_value: 0.0,
+                    fixed_update_value: 0.0,
+                    #[cfg(feature = "timing")]
+                    timing: Default::default(),
+                }),
+            },
+        );
+
+        assert!(action_state.button_data_mut(&TestAction::Run).is_some());
+    }
+
+    #[test]
+    fn test_button_data_mut_for_button_action_without_data() {
+        let mut action_state = ActionState::<TestAction>::default();
+
+        assert!(action_state.button_data_mut(&TestAction::Run).is_none());
+    }
+
+    #[test]
+    fn test_button_data_mut_for_non_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Axis,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Axis(AxisData {
+                    value: 0.5,
+                    update_value: 0.5,
+                    fixed_update_value: 0.5,
+                }),
+            },
+        );
+        assert!(action_state.button_data_mut(&TestAction::Axis).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed\n  left: Axis\n right: Button")]
+    fn test_button_data_mut_or_default_for_non_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        let _ = action_state.button_data_mut_or_default(&TestAction::Axis);
+    }
+
+    #[test]
+    fn test_axis_data_for_axis_action_without_data() {
+        let action_state = ActionState::<TestAction>::default();
+        assert!(action_state.axis_data(&TestAction::Axis).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed\n  left: Button\n right: Axis")]
+    fn test_axis_data_for_non_axis_action() {
+        let action_state = ActionState::<TestAction>::default();
+        assert!(action_state.axis_data(&TestAction::Run).is_none());
+    }
+
+    #[test]
+    fn test_axis_data_mut_for_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Axis,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Axis(AxisData {
+                    value: 0.5,
+                    update_value: 0.5,
+                    fixed_update_value: 0.5,
+                }),
+            },
+        );
+        assert!(action_state.axis_data_mut(&TestAction::Axis).is_some());
+    }
+
+    #[test]
+    fn test_axis_data_mut_for_axis_action_without_data() {
+        let mut action_state = ActionState::<TestAction>::default();
+        assert!(action_state.axis_data_mut(&TestAction::Axis).is_none());
+    }
+
+    #[test]
+    fn test_axis_data_mut_for_non_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Run,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::Button(ButtonData {
+                    state: ButtonState::Released,
+                    update_state: ButtonState::Released,
+                    fixed_update_state: ButtonState::Released,
+                    value: 0.0,
+                    update_value: 0.0,
+                    fixed_update_value: 0.0,
+                    #[cfg(feature = "timing")]
+                    timing: Default::default(),
+                }),
+            },
+        );
+        assert!(action_state.axis_data_mut(&TestAction::Run).is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed\n  left: Button\n right: Axis")]
+    fn test_axis_data_mut_or_default_for_non_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        let _ = action_state.axis_data_mut_or_default(&TestAction::Run);
+    }
+
+    #[test]
+    fn test_dual_axis_data_for_dual_axis_action_without_data() {
+        let action_state = ActionState::<TestAction>::default();
+        assert!(action_state.dual_axis_data(&TestAction::DualAxis).is_none());
+    }
+
+    #[test]
+    fn test_dual_axis_data_mut_for_dual_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::DualAxis,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::DualAxis(DualAxisData {
+                    pair: Vec2::new(0.5, 0.5),
+                    update_pair: Vec2::new(0.5, 0.5),
+                    fixed_update_pair: Vec2::new(0.5, 0.5),
+                }),
+            },
+        );
+        assert!(action_state
+            .dual_axis_data_mut(&TestAction::DualAxis)
+            .is_some());
+    }
+
+    #[test]
+    fn test_dual_axis_data_mut_for_dual_axis_action_without_data() {
+        let mut action_state = ActionState::<TestAction>::default();
+        assert!(action_state
+            .dual_axis_data_mut(&TestAction::DualAxis)
+            .is_none());
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed\n  left: Button\n right: DualAxis")]
+    fn test_dual_axis_data_mut_for_non_dual_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        assert!(action_state.dual_axis_data_mut(&TestAction::Run).is_none());
+    }
+
+    #[test]
+    fn test_triple_axis_data_for_triple_axis_action_without_data() {
+        let action_state = ActionState::<TestAction>::default();
+        assert!(action_state
+            .triple_axis_data(&TestAction::TripleAxis)
+            .is_none());
+    }
+
+    #[test]
+    fn test_triple_axis_data_mut_for_triple_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::TripleAxis,
+            ActionData {
+                disabled: false,
+                kind_data: ActionKindData::TripleAxis(crate::action_state::TripleAxisData {
+                    triple: Vec3::new(0.5, 0.5, 0.5),
+                    update_triple: Vec3::new(0.5, 0.5, 0.5),
+                    fixed_update_triple: Vec3::new(0.5, 0.5, 0.5),
+                }),
+            },
+        );
+        assert!(action_state
+            .triple_axis_data_mut(&TestAction::TripleAxis)
+            .is_some());
+    }
+
+    #[test]
+    fn test_button_value_for_disabled_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Run,
+            ActionData {
+                disabled: true,
+                kind_data: ActionKindData::Button(ButtonData {
+                    state: ButtonState::Pressed,
+                    update_state: ButtonState::Pressed,
+                    fixed_update_state: ButtonState::Pressed,
+                    value: 1.0,
+                    update_value: 1.0,
+                    fixed_update_value: 1.0,
+                    #[cfg(feature = "timing")]
+                    timing: Default::default(),
+                }),
+            },
+        );
+        action_state.disable_action(&TestAction::Run);
+        assert_eq!(action_state.button_value(&TestAction::Run), 0.0);
+    }
+
+    #[test]
+    fn test_clamped_button_value_less_than_zero() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, -0.5);
+        assert_eq!(action_state.clamped_button_value(&TestAction::Run), 0.0);
+    }
+
+    #[test]
+    fn test_clamped_button_value_greater_than_zero() {
+        let mut action_state: ActionState<TestAction> = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 1.5);
+        assert_eq!(action_state.clamped_button_value(&TestAction::Run), 1.0);
+    }
+
+    #[test]
+    fn test_value_for_disabled_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.action_data.insert(
+            TestAction::Axis,
+            ActionData {
+                disabled: true,
+                kind_data: ActionKindData::Axis(AxisData {
+                    value: 1.0,
+                    update_value: 1.0,
+                    fixed_update_value: 1.0,
+                }),
+            },
+        );
+        action_state.disable_action(&TestAction::Axis);
+        assert_eq!(action_state.value(&TestAction::Axis), 0.0);
+    }
+
+    #[test]
+    fn test_clamped_value_less_than_negative_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_value(&TestAction::Axis, -2.0);
+        assert_eq!(action_state.clamped_value(&TestAction::Axis), -1.0);
+    }
+
+    #[test]
+    fn test_clamped_value_greater_than_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_value(&TestAction::Axis, 2.0);
+        assert_eq!(action_state.clamped_value(&TestAction::Axis), 1.0);
+    }
+
+    #[test]
+    fn test_axis_pair_for_disabled_dual_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable_action(&TestAction::DualAxis);
+        assert_eq!(action_state.axis_pair(&TestAction::DualAxis), Vec2::ZERO);
+    }
+
+    #[test]
+    fn test_clamped_axis_pair_greater_than_vec2_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_pair(&TestAction::DualAxis, Vec2::new(2.0, 2.0));
+        assert_eq!(
+            action_state.clamped_axis_pair(&TestAction::DualAxis),
+            Vec2::ONE
+        );
+    }
+
+    #[test]
+    fn test_clamped_axis_pair_less_than_vec2_negative_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_pair(&TestAction::DualAxis, Vec2::new(-2.0, -2.0));
+        assert_eq!(
+            action_state.clamped_axis_pair(&TestAction::DualAxis),
+            Vec2::NEG_ONE
+        );
+    }
+
+    #[test]
+    fn test_axis_triple_for_disabled_triple_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable_action(&TestAction::TripleAxis);
+        assert_eq!(
+            action_state.axis_triple(&TestAction::TripleAxis),
+            Vec3::ZERO
+        );
+    }
+
+    #[test]
+    fn test_clamped_axis_triple_greater_than_vec3_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_triple(&TestAction::TripleAxis, Vec3::new(2.0, 2.0, 2.0));
+        assert_eq!(
+            action_state.clamped_axis_triple(&TestAction::TripleAxis),
+            Vec3::ONE
+        );
+    }
+
+    #[test]
+    fn test_clamped_axis_triple_less_than_vec3_negative_one() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_triple(&TestAction::TripleAxis, Vec3::new(-2.0, -2.0, -2.0));
+        assert_eq!(
+            action_state.clamped_axis_triple(&TestAction::TripleAxis),
+            Vec3::NEG_ONE
+        );
+    }
+
+    #[test]
+    fn test_set_button_data_for_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        let button_data = ButtonData {
+            state: ButtonState::Pressed,
+            update_state: ButtonState::Pressed,
+            fixed_update_state: ButtonState::Pressed,
+            value: 1.0,
+            update_value: 1.0,
+            fixed_update_value: 1.0,
+            #[cfg(feature = "timing")]
+            timing: Default::default(),
+        };
+        action_state.set_button_data(TestAction::Run, button_data);
+
+        let returned_data = action_state.button_data(&TestAction::Run).unwrap();
+        assert_eq!(returned_data.state, ButtonState::Pressed);
+        assert_eq!(returned_data.value, 1.0);
+    }
+
+    #[test]
+    #[should_panic(expected = "assertion `left == right` failed\n  left: Axis\n right: Button")]
+    fn test_set_button_data_for_non_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        let button_data = ButtonData {
+            state: ButtonState::Pressed,
+            update_state: ButtonState::Pressed,
+            fixed_update_state: ButtonState::Pressed,
+            value: 1.0,
+            update_value: 1.0,
+            fixed_update_value: 1.0,
+            #[cfg(feature = "timing")]
+            timing: Default::default(),
+        };
+        action_state.set_button_data(TestAction::Axis, button_data);
+    }
+
+    #[test]
+    fn test_reset_button_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 1.0);
+        action_state.reset(&TestAction::Run);
+
+        assert!(!action_state.pressed(&TestAction::Run));
+        assert_eq!(action_state.button_value(&TestAction::Run), 0.0);
+    }
+
+    #[test]
+    fn test_reset_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_value(&TestAction::Axis, 1.0);
+        action_state.reset(&TestAction::Axis);
+
+        assert_eq!(action_state.value(&TestAction::Axis), 0.0);
+    }
+
+    #[test]
+    fn test_reset_dual_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_pair(&TestAction::DualAxis, Vec2::ONE);
+        action_state.reset(&TestAction::DualAxis);
+
+        assert_eq!(action_state.axis_pair(&TestAction::DualAxis), Vec2::ZERO);
+    }
+
+    #[test]
+    fn test_reset_triple_axis_action() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_triple(&TestAction::TripleAxis, Vec3::ONE);
+        action_state.reset(&TestAction::TripleAxis);
+
+        assert_eq!(
+            action_state.axis_triple(&TestAction::TripleAxis),
+            Vec3::ZERO
+        );
+    }
+
+    #[test]
+    fn test_action_disabled_when_action_state_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable();
+
+        assert!(action_state.action_disabled(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_action_disabled_when_action_state_not_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        assert!(!action_state.action_disabled(&TestAction::Run));
+
+        action_state.disable_action(&TestAction::Run);
+        assert!(action_state.action_disabled(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_disable() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable();
+
+        assert!(action_state.disabled);
+    }
+
+    #[test]
+    fn test_enable() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable();
+        action_state.enable();
+        assert!(!action_state.disabled);
+    }
+
+    #[test]
+    fn test_just_pressed_when_action_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable_action(&TestAction::Run);
+
+        assert!(!action_state.just_pressed(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_released_when_action_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable_action(&TestAction::Run);
+
+        assert!(action_state.released(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_just_released_when_action_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable_action(&TestAction::Run);
+
+        assert!(!action_state.just_released(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_pressed_when_action_disabled() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.disable();
+
+        assert!(!action_state.pressed(&TestAction::Run));
+    }
+
+    #[test]
+    fn apply_diff_triple_axis() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_axis_triple(&TestAction::TripleAxis, Vec3::new(1.0, 1.0, 1.0));
+
+        let diff = ActionDiff::TripleAxisChanged {
+            action: TestAction::TripleAxis,
+            axis_triple: Vec3::new(0.5, 1.0, 1.5),
+        };
+        action_state.apply_diff(&diff);
+
+        assert_eq!(
+            action_state.axis_triple(&TestAction::TripleAxis),
+            Vec3::new(0.5, 1.0, 1.5)
+        );
+    }
+
+    #[test]
+    fn test_get_pressed() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 1.0);
+
+        let pressed_actions: Vec<TestAction> = action_state.get_pressed();
+        assert_eq!(pressed_actions.len(), 1);
+        assert!(pressed_actions.contains(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_get_just_pressed() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 1.0);
+
+        let just_pressed_actions: Vec<TestAction> = action_state.get_just_pressed();
+        assert_eq!(just_pressed_actions.len(), 1);
+        assert!(just_pressed_actions.contains(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_get_released() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 0.0);
+
+        let released_actions: Vec<TestAction> = action_state.get_released();
+        assert_eq!(released_actions.len(), 1);
+        assert!(released_actions.contains(&TestAction::Run));
+    }
+
+    #[test]
+    fn test_get_just_released() {
+        let mut action_state = ActionState::<TestAction>::default();
+        action_state.set_button_value(&TestAction::Run, 1.0);
+        action_state.set_button_value(&TestAction::Run, 0.0);
+
+        let just_released_actions: Vec<TestAction> = action_state.get_just_released();
+        assert_eq!(just_released_actions.len(), 1);
+        assert!(just_released_actions.contains(&TestAction::Run));
+    }
+
     #[cfg(feature = "gamepad")]
     #[test]
-    fn test_analog_buttons() {
+    fn test_triggerlikes() {
         use crate::prelude::Buttonlike;
 
         let mut ctx = TestContext::new();


### PR DESCRIPTION
## What was the problem?

In going through and fixing bugs over time I noticed there was very little coverage for this crate as a whole and I think that at least the core user-facing pieces should have some coverage. So here ya go

## How did you fix it?

I added some tests to this thing that took coverage for the `action_state` directory from 58.72% to 90.26%

Coverage report is generated with [tarpaulin](https://github.com/xd009642/tarpaulin)

```bash
cargo tarpaulin --out html --engine llvm
```