### PR TITLE
Fix stale input edges when an `InputMap` is replaced while a physical input is still held

### DIFF
--- a/examples/input_map_isolation.rs
+++ b/examples/input_map_isolation.rs
@@ -1,0 +1,140 @@
+//! Demonstrates input isolation across [`InputMap`] replacements.
+//!
+//! Run with:
+//!
+//! `cargo run --example input_map_isolation`
+//!
+//! Steps:
+//!
+//! 1. Press and hold `Space` while `InputMap A` is active.
+//! 2. Press `Tab` to switch to `InputMap B` while still holding `Space`.
+//! 3. Release `Space`.
+//! 4. Press `Space` again.
+//!
+//! Expected behavior:
+//!
+//! - the first `Space` press triggers `Jump`;
+//! - switching maps while holding `Space` does not trigger `Confirm`;
+//! - releasing that held `Space` does not trigger `Confirm.just_released`;
+//! - only the second press after the release triggers `Confirm`.
+
+use bevy::prelude::*;
+use leafwing_input_manager::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins(DefaultPlugins.set(WindowPlugin {
+            primary_window: Some(Window {
+                title: "InputMap Isolation Example".to_owned(),
+                ..default()
+            }),
+            ..default()
+        }))
+        .add_plugins(InputManagerPlugin::<Action>::default())
+        .add_systems(Startup, (print_instructions, spawn_player))
+        .add_systems(
+            Update,
+            (
+                report_physical_space_events,
+                swap_input_map_on_tab,
+                report_action_events,
+            ),
+        )
+        .run();
+}
+
+#[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
+enum Action {
+    Jump,
+    Confirm,
+}
+
+#[derive(Component, Clone, Copy, Debug, PartialEq, Eq)]
+enum ActiveMap {
+    A,
+    B,
+}
+
+#[derive(Component)]
+struct Player;
+
+fn print_instructions() {
+    println!("InputMap isolation demo");
+    println!("-----------------------");
+    println!("Space is bound to Jump in InputMap A.");
+    println!("Press Tab to replace the map so Space is bound to Confirm in InputMap B.");
+    println!("Hold Space, press Tab, then release Space.");
+    println!("You should NOT see `Confirm just released` from that release.");
+    println!("Press Space again after releasing it to trigger Confirm normally.");
+    println!();
+}
+
+fn spawn_player(mut commands: Commands) {
+    commands.spawn((Player, ActiveMap::A, input_map_a()));
+    println!("Spawned player with InputMap A: Space -> Jump");
+}
+
+fn input_map_a() -> InputMap<Action> {
+    InputMap::new([(Action::Jump, KeyCode::Space)])
+}
+
+fn input_map_b() -> InputMap<Action> {
+    InputMap::new([(Action::Confirm, KeyCode::Space)])
+}
+
+fn report_physical_space_events(
+    keys: Res<ButtonInput<KeyCode>>,
+    map: Single<&ActiveMap, With<Player>>,
+) {
+    let active_map = *map;
+
+    if keys.just_pressed(KeyCode::Space) {
+        println!("Physical Space pressed while InputMap {active_map:?} is active");
+    }
+
+    if keys.just_released(KeyCode::Space) {
+        println!("Physical Space released while InputMap {active_map:?} is active");
+    }
+}
+
+fn swap_input_map_on_tab(
+    keys: Res<ButtonInput<KeyCode>>,
+    player: Single<(&mut InputMap<Action>, &mut ActiveMap), With<Player>>,
+) {
+    if !keys.just_pressed(KeyCode::Tab) {
+        return;
+    }
+
+    let (mut input_map, mut active_map) = player.into_inner();
+
+    match *active_map {
+        ActiveMap::A => {
+            *input_map = input_map_b();
+            *active_map = ActiveMap::B;
+            println!("Switched to InputMap B: Space -> Confirm");
+        }
+        ActiveMap::B => {
+            *input_map = input_map_a();
+            *active_map = ActiveMap::A;
+            println!("Switched to InputMap A: Space -> Jump");
+        }
+    }
+}
+
+fn report_action_events(action_state: Single<&ActionState<Action>, With<Player>>) {
+    if action_state.just_pressed(&Action::Jump) {
+        println!("Action event: Jump just pressed");
+    }
+
+    if action_state.just_released(&Action::Jump) {
+        println!("Action event: Jump just released");
+    }
+
+    if action_state.just_pressed(&Action::Confirm) {
+        println!("Action event: Confirm just pressed");
+    }
+
+    if action_state.just_released(&Action::Confirm) {
+        println!("Action event: Confirm just released");
+    }
+}

--- a/src/action_state/action_data.rs
+++ b/src/action_state/action_data.rs
@@ -56,6 +56,16 @@ impl ActionData {
             ActionKindData::TripleAxis(ref mut _data) => {}
         }
     }
+
+    /// Resets the action back to its neutral value without generating transition events.
+    pub fn reset_silently(&mut self) {
+        match &mut self.kind_data {
+            ActionKindData::Button(data) => *data = ButtonData::RELEASED,
+            ActionKindData::Axis(data) => *data = AxisData::default(),
+            ActionKindData::DualAxis(data) => *data = DualAxisData::default(),
+            ActionKindData::TripleAxis(data) => *data = TripleAxisData::default(),
+        }
+    }
 }
 
 /// A wrapper over the various forms of data that an action can take.

--- a/src/clashing_inputs.rs
+++ b/src/clashing_inputs.rs
@@ -9,7 +9,7 @@ use std::cmp::Ordering;
 use bevy::prelude::{Entity, Resource};
 use serde::{Deserialize, Serialize};
 
-use crate::input_map::{InputMap, UpdatedActions};
+use crate::input_map::{InputMap, InputMapState, UpdatedActions};
 use crate::prelude::updating::CentralInputStore;
 use crate::user_input::Buttonlike;
 use crate::{Actionlike, InputControlKind};
@@ -177,10 +177,26 @@ impl<A: Actionlike> InputMap<A> {
         clash_strategy: ClashStrategy,
         gamepad: Entity,
     ) {
-        for clash in self.get_clashes(updated_actions, input_store, gamepad) {
+        self.handle_clashes_with_state(updated_actions, input_store, clash_strategy, gamepad, None);
+    }
+
+    pub(crate) fn handle_clashes_with_state(
+        &self,
+        updated_actions: &mut UpdatedActions<A>,
+        input_store: &CentralInputStore,
+        clash_strategy: ClashStrategy,
+        gamepad: Entity,
+        input_map_state: Option<&InputMapState<A>>,
+    ) {
+        for clash in self.get_clashes(updated_actions, input_store, gamepad, input_map_state) {
             // Remove the action in the pair that was overruled, if any
-            if let Some(culled_action) = resolve_clash(&clash, clash_strategy, input_store, gamepad)
-            {
+            if let Some(culled_action) = resolve_clash_with_state(
+                &clash,
+                clash_strategy,
+                input_store,
+                gamepad,
+                input_map_state,
+            ) {
                 updated_actions.remove(&culled_action);
             }
         }
@@ -210,6 +226,7 @@ impl<A: Actionlike> InputMap<A> {
         updated_actions: &UpdatedActions<A>,
         input_store: &CentralInputStore,
         gamepad: Entity,
+        input_map_state: Option<&InputMapState<A>>,
     ) -> Vec<Clash<A>> {
         let mut clashes = Vec::default();
 
@@ -222,7 +239,9 @@ impl<A: Actionlike> InputMap<A> {
             // This is not strictly necessary, but saves work
             if pressed_a && pressed_b {
                 // Check if the potential clash occurred based on the pressed inputs
-                if let Some(clash) = check_clash(&clash, input_store, gamepad) {
+                if let Some(clash) =
+                    check_clash_with_state(&clash, input_store, gamepad, input_map_state)
+                {
                     clashes.push(clash)
                 }
             }
@@ -323,20 +342,28 @@ fn check_clash<A: Actionlike>(
     input_store: &CentralInputStore,
     gamepad: Entity,
 ) -> Option<Clash<A>> {
+    check_clash_with_state(clash, input_store, gamepad, None)
+}
+
+#[must_use]
+fn check_clash_with_state<A: Actionlike>(
+    clash: &Clash<A>,
+    input_store: &CentralInputStore,
+    gamepad: Entity,
+    input_map_state: Option<&InputMapState<A>>,
+) -> Option<Clash<A>> {
     let mut actual_clash: Clash<A> = clash.clone();
 
     // For all inputs actually pressed that match action A
     for input_a in clash
         .inputs_a
         .iter()
-        .filter(|&input| input.pressed(input_store, gamepad))
+        .filter(|input| buttonlike_is_active(input.as_ref(), input_store, gamepad, input_map_state))
     {
         // For all inputs actually pressed that match action B
-        for input_b in clash
-            .inputs_b
-            .iter()
-            .filter(|&input| input.pressed(input_store, gamepad))
-        {
+        for input_b in clash.inputs_b.iter().filter(|input| {
+            buttonlike_is_active(input.as_ref(), input_store, gamepad, input_map_state)
+        }) {
             // If a clash was detected
             if input_a.decompose().clashes_with(&input_b.decompose()) {
                 actual_clash.inputs_a.push(input_a.clone());
@@ -357,18 +384,29 @@ fn resolve_clash<A: Actionlike>(
     input_store: &CentralInputStore,
     gamepad: Entity,
 ) -> Option<A> {
+    resolve_clash_with_state(clash, clash_strategy, input_store, gamepad, None)
+}
+
+#[must_use]
+fn resolve_clash_with_state<A: Actionlike>(
+    clash: &Clash<A>,
+    clash_strategy: ClashStrategy,
+    input_store: &CentralInputStore,
+    gamepad: Entity,
+    input_map_state: Option<&InputMapState<A>>,
+) -> Option<A> {
     // Figure out why the actions are pressed
     let reasons_a_is_pressed: Vec<&dyn Buttonlike> = clash
         .inputs_a
         .iter()
-        .filter(|input| input.pressed(input_store, gamepad))
+        .filter(|input| buttonlike_is_active(input.as_ref(), input_store, gamepad, input_map_state))
         .map(|input| input.as_ref())
         .collect();
 
     let reasons_b_is_pressed: Vec<&dyn Buttonlike> = clash
         .inputs_b
         .iter()
-        .filter(|input| input.pressed(input_store, gamepad))
+        .filter(|input| buttonlike_is_active(input.as_ref(), input_store, gamepad, input_map_state))
         .map(|input| input.as_ref())
         .collect();
 
@@ -408,6 +446,16 @@ fn resolve_clash<A: Actionlike>(
             }
         }
     }
+}
+
+fn buttonlike_is_active<A: Actionlike>(
+    input: &dyn Buttonlike,
+    input_store: &CentralInputStore,
+    gamepad: Entity,
+    input_map_state: Option<&InputMapState<A>>,
+) -> bool {
+    input.pressed(input_store, gamepad)
+        && !input_map_state.is_some_and(|state| state.suppresses(input))
 }
 
 #[cfg(feature = "keyboard")]

--- a/src/input_map.rs
+++ b/src/input_map.rs
@@ -2,12 +2,13 @@
 
 use std::fmt::Debug;
 use std::hash::Hash;
+use std::marker::PhantomData;
 
 #[cfg(feature = "asset")]
 use bevy::asset::Asset;
 use bevy::input::gamepad::Gamepad;
 use bevy::math::{Vec2, Vec3};
-use bevy::platform::collections::HashMap;
+use bevy::platform::collections::{HashMap, HashSet};
 use bevy::prelude::{Component, Deref, DerefMut, Entity, Query, Reflect, With};
 use bevy::{log::error, prelude::ReflectComponent};
 use itertools::Itertools;
@@ -17,7 +18,7 @@ use crate::buttonlike::ButtonValue;
 use crate::clashing_inputs::ClashStrategy;
 use crate::prelude::updating::CentralInputStore;
 use crate::prelude::{ActionState, UserInputWrapper};
-use crate::user_input::{Axislike, Buttonlike, DualAxislike, TripleAxislike};
+use crate::user_input::{Axislike, Buttonlike, DualAxislike, TripleAxislike, UserInput};
 use crate::{Actionlike, InputControlKind};
 
 #[cfg(feature = "gamepad")]
@@ -26,6 +27,49 @@ use crate::user_input::gamepad::find_gamepad;
 #[cfg(not(feature = "gamepad"))]
 fn find_gamepad(_: Option<Query<Entity, With<Gamepad>>>) -> Entity {
     Entity::PLACEHOLDER
+}
+
+/// Runtime state used to isolate held inputs across [`InputMap`] changes.
+#[derive(Component, Debug)]
+pub(crate) struct InputMapState<A: Actionlike> {
+    suppressed_inputs: HashSet<Box<dyn Buttonlike>>,
+    suppressed_gamepad: Entity,
+    _marker: PhantomData<A>,
+}
+
+impl<A: Actionlike> Default for InputMapState<A> {
+    fn default() -> Self {
+        Self {
+            suppressed_inputs: HashSet::default(),
+            suppressed_gamepad: Entity::PLACEHOLDER,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<A: Actionlike> InputMapState<A> {
+    pub(crate) fn suppress(&mut self, inputs: HashSet<Box<dyn Buttonlike>>, gamepad: Entity) {
+        self.suppressed_inputs = inputs;
+        self.suppressed_gamepad = gamepad;
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.suppressed_inputs.clear();
+        self.suppressed_gamepad = Entity::PLACEHOLDER;
+    }
+
+    pub(crate) fn clear_released(&mut self, input_store: &CentralInputStore) {
+        self.suppressed_inputs
+            .retain(|input| input.pressed(input_store, self.suppressed_gamepad));
+    }
+
+    pub(crate) fn suppresses(&self, input: &dyn UserInput) -> bool {
+        input
+            .decompose()
+            .inputs()
+            .into_iter()
+            .any(|basic_input| self.suppressed_inputs.contains(&basic_input))
+    }
 }
 
 /// A Multi-Map that allows you to map actions to multiple [`UserInputs`](crate::user_input::UserInput)s,
@@ -101,7 +145,7 @@ fn find_gamepad(_: Option<Query<Entity, With<Gamepad>>>) -> Entity {
 /// input_map.clear();
 /// ```
 #[derive(Component, Debug, Clone, PartialEq, Eq, Reflect, Serialize, Deserialize)]
-#[require(ActionState::<A>)]
+#[require(ActionState::<A>, InputMapState::<A>)]
 #[cfg_attr(feature = "asset", derive(Asset))]
 #[reflect(Component)]
 pub struct InputMap<A: Actionlike> {
@@ -571,6 +615,10 @@ impl<A: Actionlike> InputMap<A> {
 
 // Check whether actions are pressed
 impl<A: Actionlike> InputMap<A> {
+    pub(crate) fn resolve_gamepad(&self, gamepads: Option<Query<Entity, With<Gamepad>>>) -> Entity {
+        self.associated_gamepad.unwrap_or(find_gamepad(gamepads))
+    }
+
     /// Checks if the `action` are currently pressed by any of the associated [`Buttonlike`]s.
     ///
     /// Accounts for clashing inputs according to the [`ClashStrategy`] and remove conflicting actions.
@@ -610,13 +658,27 @@ impl<A: Actionlike> InputMap<A> {
         input_store: &CentralInputStore,
         clash_strategy: ClashStrategy,
     ) -> UpdatedActions<A> {
+        self.process_actions_with_state(gamepads, input_store, clash_strategy, None)
+    }
+
+    pub(crate) fn process_actions_with_state(
+        &self,
+        gamepads: Option<Query<Entity, With<Gamepad>>>,
+        input_store: &CentralInputStore,
+        clash_strategy: ClashStrategy,
+        input_map_state: Option<&InputMapState<A>>,
+    ) -> UpdatedActions<A> {
         let mut updated_actions = UpdatedActions::default();
-        let gamepad = self.associated_gamepad.unwrap_or(find_gamepad(gamepads));
+        let gamepad = self.resolve_gamepad(gamepads);
 
         // Generate the base action data for each action
         for (action, input_bindings) in self.iter_buttonlike() {
             let mut final_state: Option<(bool, f32)> = None;
             for binding in input_bindings {
+                if input_map_state.is_some_and(|state| state.suppresses(binding.as_ref())) {
+                    continue;
+                }
+
                 let pressed = binding.pressed(input_store, gamepad);
                 let value = binding.value(input_store, gamepad);
                 if let Some((existing_state, existing_value)) = final_state {
@@ -637,6 +699,10 @@ impl<A: Actionlike> InputMap<A> {
         for (action, input_bindings) in self.iter_axislike() {
             let mut final_value = None;
             for binding in input_bindings {
+                if input_map_state.is_some_and(|state| state.suppresses(binding.as_ref())) {
+                    continue;
+                }
+
                 if let Some(value) = binding.get_value(input_store, gamepad) {
                     final_value = Some(final_value.unwrap_or(0.0) + value);
                 }
@@ -650,6 +716,10 @@ impl<A: Actionlike> InputMap<A> {
         for (action, _input_bindings) in self.iter_dual_axislike() {
             let mut final_value = None;
             for binding in _input_bindings {
+                if input_map_state.is_some_and(|state| state.suppresses(binding.as_ref())) {
+                    continue;
+                }
+
                 if let Some(axis_pair) = binding.get_axis_pair(input_store, gamepad) {
                     final_value = Some(final_value.unwrap_or(Vec2::ZERO) + axis_pair);
                 }
@@ -663,6 +733,10 @@ impl<A: Actionlike> InputMap<A> {
         for (action, _input_bindings) in self.iter_triple_axislike() {
             let mut final_value = Vec3::ZERO;
             for binding in _input_bindings {
+                if input_map_state.is_some_and(|state| state.suppresses(binding.as_ref())) {
+                    continue;
+                }
+
                 final_value += binding.axis_triple(input_store, gamepad);
             }
 
@@ -670,7 +744,13 @@ impl<A: Actionlike> InputMap<A> {
         }
 
         // Handle clashing inputs, possibly removing some pressed actions from the list
-        self.handle_clashes(&mut updated_actions, input_store, clash_strategy, gamepad);
+        self.handle_clashes_with_state(
+            &mut updated_actions,
+            input_store,
+            clash_strategy,
+            gamepad,
+            input_map_state,
+        );
 
         updated_actions
     }
@@ -714,6 +794,64 @@ impl<A: Actionlike> Default for UpdatedActions<A> {
 
 // Utilities
 impl<A: Actionlike> InputMap<A> {
+    pub(crate) fn currently_pressed_inputs(
+        &self,
+        input_store: &CentralInputStore,
+        gamepad: Entity,
+    ) -> HashSet<Box<dyn Buttonlike>> {
+        let mut pressed_inputs = HashSet::default();
+
+        for (_action, input_bindings) in self.iter_buttonlike() {
+            for binding in input_bindings {
+                pressed_inputs.extend(
+                    binding
+                        .decompose()
+                        .inputs()
+                        .into_iter()
+                        .filter(|input| input.pressed(input_store, gamepad)),
+                );
+            }
+        }
+
+        for (_action, input_bindings) in self.iter_axislike() {
+            for binding in input_bindings {
+                pressed_inputs.extend(
+                    binding
+                        .decompose()
+                        .inputs()
+                        .into_iter()
+                        .filter(|input| input.pressed(input_store, gamepad)),
+                );
+            }
+        }
+
+        for (_action, input_bindings) in self.iter_dual_axislike() {
+            for binding in input_bindings {
+                pressed_inputs.extend(
+                    binding
+                        .decompose()
+                        .inputs()
+                        .into_iter()
+                        .filter(|input| input.pressed(input_store, gamepad)),
+                );
+            }
+        }
+
+        for (_action, input_bindings) in self.iter_triple_axislike() {
+            for binding in input_bindings {
+                pressed_inputs.extend(
+                    binding
+                        .decompose()
+                        .inputs()
+                        .into_iter()
+                        .filter(|input| input.pressed(input_store, gamepad)),
+                );
+            }
+        }
+
+        pressed_inputs
+    }
+
     /// Returns an iterator over all registered [`Buttonlike`] actions with their input bindings.
     pub fn iter_buttonlike(&self) -> impl Iterator<Item = (&A, &Vec<Box<dyn Buttonlike>>)> {
         self.buttonlike_map.iter()

--- a/src/systems.rs
+++ b/src/systems.rs
@@ -5,7 +5,10 @@ use bevy::ecs::query::QueryFilter;
 use bevy::log::debug;
 
 use crate::{
-    Actionlike, action_state::ActionState, clashing_inputs::ClashStrategy, input_map::InputMap,
+    Actionlike,
+    action_state::ActionState,
+    clashing_inputs::ClashStrategy,
+    input_map::{InputMap, InputMapState},
 };
 
 use bevy::ecs::prelude::*;
@@ -63,18 +66,32 @@ pub fn tick_action_state<A: Actionlike>(
 /// to update [`ActionState`] according to the [`InputMap`].
 ///
 /// Clashes will be resolved according to the [`ClashStrategy`] resource.
-pub fn update_action_state<A: Actionlike>(
+pub(crate) fn update_action_state<A: Actionlike>(
     input_store: Res<CentralInputStore>,
     clash_strategy: Res<ClashStrategy>,
     mut gamepads: Query<Entity, With<Gamepad>>,
-    mut query: Query<(&mut ActionState<A>, &InputMap<A>)>,
+    mut query: Query<(&mut ActionState<A>, Ref<InputMap<A>>, &mut InputMapState<A>)>,
 ) {
-    for (mut action_state, input_map) in query.iter_mut() {
-        action_state.update(input_map.process_actions(
+    for (mut action_state, input_map, mut input_map_state) in query.iter_mut() {
+        let gamepad = input_map.resolve_gamepad(Some(gamepads.reborrow()));
+
+        if input_map.is_added() {
+            input_map_state.clear();
+        } else if input_map.is_changed() {
+            input_map_state.suppress(
+                input_map.currently_pressed_inputs(&input_store, gamepad),
+                gamepad,
+            );
+        }
+
+        action_state.update(input_map.process_actions_with_state(
             Some(gamepads.reborrow()),
             &input_store,
             *clash_strategy,
+            Some(&input_map_state),
         ));
+
+        input_map_state.clear_released(&input_store);
     }
 }
 

--- a/src/user_input/updating.rs
+++ b/src/user_input/updating.rs
@@ -12,13 +12,27 @@ use bevy::{
     },
     math::{Vec2, Vec3},
     platform::collections::{HashMap, HashSet},
-    prelude::{Res, ResMut, Resource},
+    prelude::{Entity, Res, ResMut, Resource},
     reflect::Reflect,
 };
 
 use super::{Axislike, Buttonlike, DualAxislike, TripleAxislike};
+use crate::axislike::AxisDirection;
 use crate::buttonlike::ButtonValue;
 use crate::{InputControlKind, plugin::InputManagerSystem};
+
+#[cfg(feature = "gamepad")]
+use crate::user_input::gamepad::{
+    GamepadControlDirection, SpecificGamepadAxis, SpecificGamepadButton,
+};
+#[cfg(feature = "mouse")]
+use crate::user_input::mouse::{MouseMove, MouseMoveDirection, MouseScroll, MouseScrollDirection};
+#[cfg(feature = "gamepad")]
+use bevy::input::gamepad::GamepadButton;
+#[cfg(feature = "mouse")]
+use bevy::input::mouse::MouseButton;
+#[cfg(feature = "keyboard")]
+use bevy::prelude::KeyCode;
 
 /// An overarching store for all user inputs.
 ///
@@ -26,7 +40,7 @@ use crate::{InputControlKind, plugin::InputManagerSystem};
 /// and ensures that their values are only recomputed once per frame.
 ///
 /// To add a new kind of input, call [`InputRegistration::register_input_kind`] during [`App`] setup.
-#[derive(Resource, Default, Debug, Reflect)]
+#[derive(Resource, Default, Debug, Reflect, Clone)]
 pub struct CentralInputStore {
     /// Stores the updated values of each kind of input.
     updated_values: HashMap<TypeId, UpdatedValues>,
@@ -194,6 +208,149 @@ impl CentralInputStore {
             .copied()
             .unwrap_or(Vec3::ZERO)
     }
+
+    /// Returns a copy of this store where the suppressed primitive inputs behave as released.
+    pub fn with_suppressed(
+        &self,
+        suppressed_inputs: &HashSet<Box<dyn Buttonlike>>,
+        gamepad: Entity,
+    ) -> Self {
+        let mut filtered = self.clone();
+
+        for input in suppressed_inputs {
+            filtered.suppress_buttonlike_input(input.as_ref(), gamepad);
+        }
+
+        filtered
+    }
+
+    fn suppress_buttonlike<B: Buttonlike + Hash + Eq + Clone>(&mut self, buttonlike: B) {
+        let Some(UpdatedValues::Buttonlike(buttonlikes)) =
+            self.updated_values.get_mut(&TypeId::of::<B>())
+        else {
+            return;
+        };
+
+        let key: Box<dyn Buttonlike> = Box::new(buttonlike);
+        if let Some(value) = buttonlikes.get_mut(&key) {
+            *value = ButtonValue::from_pressed(false);
+        }
+    }
+
+    fn clip_axislike<A: Axislike + Hash + Eq + Clone>(
+        &mut self,
+        axislike: A,
+        clip: impl FnOnce(f32) -> f32,
+    ) {
+        let Some(UpdatedValues::Axislike(axislikes)) =
+            self.updated_values.get_mut(&TypeId::of::<A>())
+        else {
+            return;
+        };
+
+        let key: Box<dyn Axislike> = Box::new(axislike);
+        if let Some(value) = axislikes.get_mut(&key) {
+            *value = clip(*value);
+        }
+    }
+
+    fn clip_dual_axislike<D: DualAxislike + Hash + Eq + Clone>(
+        &mut self,
+        dual_axislike: D,
+        clip: impl FnOnce(Vec2) -> Vec2,
+    ) {
+        let Some(UpdatedValues::Dualaxislike(dual_axislikes)) =
+            self.updated_values.get_mut(&TypeId::of::<D>())
+        else {
+            return;
+        };
+
+        let key: Box<dyn DualAxislike> = Box::new(dual_axislike);
+        if let Some(value) = dual_axislikes.get_mut(&key) {
+            *value = clip(*value);
+        }
+    }
+
+    fn suppress_buttonlike_input(&mut self, input: &dyn Buttonlike, gamepad: Entity) {
+        #[cfg(feature = "keyboard")]
+        if let Some(keycode) = Reflect::as_any(input).downcast_ref::<KeyCode>() {
+            self.suppress_buttonlike(*keycode);
+            return;
+        }
+
+        #[cfg(feature = "mouse")]
+        if let Some(button) = Reflect::as_any(input).downcast_ref::<MouseButton>() {
+            self.suppress_buttonlike(*button);
+            return;
+        }
+
+        #[cfg(feature = "gamepad")]
+        if let Some(button) = Reflect::as_any(input).downcast_ref::<GamepadButton>() {
+            self.suppress_buttonlike(*button);
+            self.suppress_buttonlike(SpecificGamepadButton::new(gamepad, *button));
+            return;
+        }
+
+        #[cfg(feature = "gamepad")]
+        if let Some(button) = Reflect::as_any(input).downcast_ref::<SpecificGamepadButton>() {
+            self.suppress_buttonlike(*button);
+            self.suppress_buttonlike(button.button);
+            return;
+        }
+
+        #[cfg(feature = "gamepad")]
+        if let Some(direction) = Reflect::as_any(input).downcast_ref::<GamepadControlDirection>() {
+            self.suppress_gamepad_direction(*direction, gamepad);
+            return;
+        }
+
+        #[cfg(feature = "mouse")]
+        if let Some(direction) = Reflect::as_any(input).downcast_ref::<MouseMoveDirection>() {
+            self.suppress_mouse_move_direction(*direction);
+            return;
+        }
+
+        #[cfg(feature = "mouse")]
+        if let Some(direction) = Reflect::as_any(input).downcast_ref::<MouseScrollDirection>() {
+            self.suppress_mouse_scroll_direction(*direction);
+        }
+    }
+
+    #[cfg(feature = "gamepad")]
+    fn suppress_gamepad_direction(&mut self, direction: GamepadControlDirection, gamepad: Entity) {
+        let clip = |value| suppress_axis_direction(value, direction.direction);
+        self.clip_axislike(direction.axis, clip);
+        self.clip_axislike(SpecificGamepadAxis::new(gamepad, direction.axis), clip);
+    }
+
+    #[cfg(feature = "mouse")]
+    fn suppress_mouse_move_direction(&mut self, direction: MouseMoveDirection) {
+        self.clip_dual_axislike(MouseMove::default(), |value| {
+            suppress_dual_axis_direction(value, direction.direction.axis_direction())
+        });
+    }
+
+    #[cfg(feature = "mouse")]
+    fn suppress_mouse_scroll_direction(&mut self, direction: MouseScrollDirection) {
+        self.clip_dual_axislike(MouseScroll::default(), |value| {
+            suppress_dual_axis_direction(value, direction.direction.axis_direction())
+        });
+    }
+}
+
+fn suppress_axis_direction(value: f32, direction: AxisDirection) -> f32 {
+    match direction {
+        AxisDirection::Negative if value < 0.0 => 0.0,
+        AxisDirection::Positive if value > 0.0 => 0.0,
+        _ => value,
+    }
+}
+
+fn suppress_dual_axis_direction(value: Vec2, direction: AxisDirection) -> Vec2 {
+    match direction {
+        AxisDirection::Negative => Vec2::new(suppress_axis_direction(value.x, direction), value.y),
+        AxisDirection::Positive => Vec2::new(suppress_axis_direction(value.x, direction), value.y),
+    }
 }
 
 #[derive(Resource)]
@@ -295,7 +452,7 @@ pub(crate) fn register_standard_input_kinds(app: &mut App) {
 ///
 /// The key should be the default form of the input if there is no need to differentiate between possible inputs of the same type,
 /// and the value should be the updated value fetched from [`UpdatableInput::SourceData`].
-#[derive(Debug, Reflect)]
+#[derive(Debug, Reflect, Clone)]
 enum UpdatedValues {
     Buttonlike(HashMap<Box<dyn Buttonlike>, ButtonValue>),
     Axislike(HashMap<Box<dyn Axislike>, f32>),

--- a/tests/input_map_isolation.rs
+++ b/tests/input_map_isolation.rs
@@ -1,0 +1,193 @@
+#[cfg(feature = "gamepad")]
+use bevy::input::gamepad::{GamepadConnection, GamepadConnectionEvent};
+use bevy::{input::InputPlugin, prelude::*};
+use leafwing_input_manager::prelude::*;
+
+#[derive(Actionlike, Clone, Copy, Debug, Reflect, PartialEq, Eq, Hash)]
+enum Action {
+    Jump,
+    Confirm,
+    Dash,
+    Pause,
+}
+
+#[derive(Component)]
+struct TestPlayer;
+
+fn test_app() -> App {
+    let mut app = App::new();
+    app.add_plugins((
+        MinimalPlugins,
+        InputPlugin,
+        InputManagerPlugin::<Action>::default(),
+    ));
+    app
+}
+
+fn spawn_player(app: &mut App, input_map: InputMap<Action>) -> Entity {
+    app.world_mut().spawn((TestPlayer, input_map)).id()
+}
+
+fn player_action_state<'w>(app: &'w mut App) -> &'w ActionState<Action> {
+    app.world_mut()
+        .query_filtered::<&ActionState<Action>, With<TestPlayer>>()
+        .single(app.world())
+        .expect("ActionState not found")
+}
+
+#[cfg(feature = "gamepad")]
+fn connect_gamepad(app: &mut App) -> Entity {
+    let gamepad = app.world_mut().spawn_empty().id();
+    app.world_mut()
+        .resource_mut::<Messages<GamepadConnectionEvent>>()
+        .write(GamepadConnectionEvent::new(
+            gamepad,
+            GamepadConnection::Connected {
+                name: "TestController".to_owned(),
+                vendor_id: None,
+                product_id: None,
+            },
+        ));
+    app.update();
+    gamepad
+}
+
+#[cfg(feature = "keyboard")]
+#[test]
+fn keyboard_hold_across_input_map_replacement() {
+    let mut app = test_app();
+    let player = spawn_player(&mut app, InputMap::new([(Action::Jump, KeyCode::Space)]));
+    app.update();
+
+    KeyCode::Space.press(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(action_state.just_pressed(&Action::Jump));
+
+    app.world_mut()
+        .entity_mut(player)
+        .insert(InputMap::new([(Action::Confirm, KeyCode::Space)]));
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(!action_state.just_pressed(&Action::Confirm));
+
+    KeyCode::Space.release(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(!action_state.just_pressed(&Action::Confirm));
+    assert!(!action_state.just_released(&Action::Confirm));
+}
+
+#[cfg(feature = "gamepad")]
+#[test]
+fn gamepad_hold_across_input_map_replacement() {
+    let mut app = test_app();
+    let gamepad = connect_gamepad(&mut app);
+
+    let mut jump_map = InputMap::new([(Action::Jump, GamepadButton::South)]);
+    jump_map.set_gamepad(gamepad);
+    let player = spawn_player(&mut app, jump_map);
+    app.update();
+
+    GamepadButton::South.press_as_gamepad(app.world_mut(), Some(gamepad));
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(action_state.just_pressed(&Action::Jump));
+
+    let mut confirm_map = InputMap::new([(Action::Confirm, GamepadButton::South)]);
+    confirm_map.set_gamepad(gamepad);
+    app.world_mut().entity_mut(player).insert(confirm_map);
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(!action_state.just_pressed(&Action::Confirm));
+
+    GamepadButton::South.release_as_gamepad(app.world_mut(), Some(gamepad));
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(!action_state.just_pressed(&Action::Confirm));
+    assert!(!action_state.just_released(&Action::Confirm));
+}
+
+#[cfg(feature = "keyboard")]
+#[test]
+fn multiple_held_inputs_stay_suppressed_after_input_map_replacement() {
+    let mut app = test_app();
+    let player = spawn_player(
+        &mut app,
+        InputMap::new([
+            (Action::Jump, KeyCode::Space),
+            (Action::Dash, KeyCode::KeyF),
+        ]),
+    );
+    app.update();
+
+    KeyCode::Space.press(app.world_mut());
+    KeyCode::KeyF.press(app.world_mut());
+    app.update();
+
+    app.world_mut().entity_mut(player).insert(InputMap::new([
+        (Action::Confirm, KeyCode::Space),
+        (Action::Pause, KeyCode::KeyF),
+    ]));
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(!action_state.just_pressed(&Action::Confirm));
+    assert!(!action_state.pressed(&Action::Pause));
+    assert!(!action_state.just_pressed(&Action::Pause));
+
+    KeyCode::Space.release(app.world_mut());
+    KeyCode::KeyF.release(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.just_released(&Action::Confirm));
+    assert!(!action_state.just_released(&Action::Pause));
+}
+
+#[cfg(feature = "keyboard")]
+#[test]
+fn input_becomes_active_again_after_release_and_repress() {
+    let mut app = test_app();
+    let player = spawn_player(&mut app, InputMap::new([(Action::Jump, KeyCode::Space)]));
+    app.update();
+
+    KeyCode::Space.press(app.world_mut());
+    app.update();
+
+    app.world_mut()
+        .entity_mut(player)
+        .insert(InputMap::new([(Action::Confirm, KeyCode::Space)]));
+    app.update();
+
+    KeyCode::Space.release(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.just_released(&Action::Confirm));
+
+    KeyCode::Space.press(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(action_state.pressed(&Action::Confirm));
+    assert!(action_state.just_pressed(&Action::Confirm));
+
+    KeyCode::Space.release(app.world_mut());
+    app.update();
+
+    let action_state = player_action_state(&mut app);
+    assert!(!action_state.pressed(&Action::Confirm));
+    assert!(action_state.just_released(&Action::Confirm));
+}


### PR DESCRIPTION
## Summary

Fix stale input edges when an `InputMap` is replaced while a physical input is still held.

Before this change, if an input started its press cycle under one `InputMap`, then the map was replaced before release, the release could be observed by an action in the new map. In practice, this meant the new action could receive `just_released` even though it never saw the corresponding press.

This PR isolates held inputs across `InputMap` replacements so that a newly assigned map only observes fresh press/release cycles.

## Example

Before:

- `InputMap A`: `Space -> Jump`
- hold `Space`
- switch to `InputMap B`: `Space -> Confirm`
- release `Space`
- `Confirm.just_released == true`

After:

- the held `Space` input is suppressed for `InputMap B`
- releasing that held `Space` does not trigger `Confirm.just_released`
- `Confirm` only becomes active again after releasing and pressing `Space` again

## Implementation

This PR takes an `InputMap`-local approach.

When an `InputMap` is replaced while inputs are held:

- the currently held primitive inputs are snapshotted
- those inputs are suppressed for the new map
- their release is ignored by the new map
- suppression is cleared once the physical input is released
- future press/release cycles behave normally

This keeps the fix scoped to `InputMap` replacement behavior rather than changing general `ActionState` semantics.

## Alternative

I also explored an `ActionState`-level solution based on a public `InputContextPolicy` API.

That approach was simpler internally in some ways, because it filtered stale transitions at the action-state layer after a context was marked fresh. However, it also introduced a broader public concept and made this issue feel like a new action-state policy feature rather than a targeted fix for `InputMap` replacement.

---

I really don't know what is the better approach:
- https://github.com/ettoreleandrotognoli/leafwing-input-manager/tree/issues/742 ( this PR )
- https://github.com/ettoreleandrotognoli/leafwing-input-manager/tree/issues/742-add-input-context-policy

Resolves #742 
